### PR TITLE
[bug][#11020] List admins changes not synchronized with admin_table

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -390,7 +390,7 @@ sub new {
         || $list->{'admin'}{'ttl'};
     if ($status
         && ((     !$options->{'skip_sync_admin'}
-                && $list->{'last_sync'} < time - $pertinent_ttl
+                && $list->{'last_sync_admin_user'} < time - $pertinent_ttl
             )
             || $options->{'force_sync_admin'}
         )


### PR DESCRIPTION
Bug description: For some lists we have noticed a synchronization issue with the admin_table: an owner gets added to the list config file (through list family instanciation) but never appears in the admin_table. As a consequence this new list owner is not listed in the list panel on the web interface and does not have the expected privileges.

After a bit of code analysis and debugging I found out that revision 9948 is the cause of the problem: https://sourcesup.renater.fr/scm/viewvc.php/branches/sympa-6.1-branch/src/lib/List.pm?root=sympa&r1=9947&r2=9948

It turns out that List::sync_include_admin() subroutine mights never been run for a list if that list includes members from an external datasource but owner/editors get defined "statically" in the config list. To be more precise:
* List::add_list_admin is called from List::sync_include_admin only
* List::sync_include_admin is called
* from List::new, unless a sync_include() has been ran recently
* from task_manager::sync_include, but only if the list defined editor_include or owner_include parameters

This bug has on impact on any list that includes members from an external datasource but has owner/editor defined inline in the list config file. In our situation most lists based on list families are impacted. For these lists, list owners/editors never get updated in the admin_table.

Revision 9948 should be fixed to check $list->{'last_sync_admin_user'} instead of $list->{'last_sync'}; attached is a patch proposal.