### PR TITLE
Be able to remove some list parameters by emptying them

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -11797,8 +11797,11 @@ sub do_edit_list {
                     }
                     ## Else if the parameter has only a scalar value
                 } else {
-                    ## Remove if empty
-                    if ($new_admin->{$pname}[$i] =~ /^\s*$/) {
+                    ## Remove if empty, but not if it's a param we should be
+                    ## able to remove
+                    if (   $new_admin->{$pname}[$i] =~ /^\s*$/
+                        && $pname !~
+                           /^(anonymous_sender|delivery_time|other_email)$/) {
                         splice(@{$new_admin->{$pname}}, $i, 1);
                         next;
                     }


### PR DESCRIPTION
If you set an anonymous_sender, you can't remove it using the web
interface (not the only list parameter with this problem).
This allows to remove these parameters.