### PR TITLE
[6.2] New code for list config semantics

### DIFF
--- a/default/web_tt2/error.tt2
+++ b/default/web_tt2/error.tt2
@@ -92,7 +92,6 @@
   [% ELSIF u_err.msg == 'didnt_change_anything' %][%|loc%]You did not select an action to perform[%END%]
   [% ELSIF u_err.msg == 'no_bounce_user' %][%|loc(u_err.email)%]No bounce for user  %1[%END%]
   [% ELSIF u_err.msg == 'no_bounce_subscriber' %][%|loc%]List has no bouncing subscribers[%END%]
-  [% ELSIF u_err.msg == 'no_parameter_edited' %][%|loc%]No parameter was edited[%END%]
   [% ELSIF u_err.msg == 'config_changed' %][%|loc(u_err.email)%]Config file has been modified by %1. Cannot apply your changes[%END%]
   [% ELSIF u_err.msg == 'topic_other' %][%|loc%]Topic "other" is a reserved word[%END%]
   [% ELSIF u_err.msg == 'mandatory_parameter' %][%|loc(u_err.p_name)%]Parameter '%1' is mandatory. Ignoring deletion.[%END%]

--- a/default/web_tt2/error.tt2
+++ b/default/web_tt2/error.tt2
@@ -47,7 +47,7 @@
   [%|loc(u_err.action)%]ERROR (%1) [%END-%] -    
   [% IF u_err.msg == 'wrong_param' %][%|loc()%]Wrong parameters[%END%]
   [% ELSIF u_err.msg == 'unknown_action' %][%|loc()%]Unknown action[%END%]
-  [% ELSIF u_err.msg == 'syntax_errors' %][%|loc(u_err.params)%]Syntax errors with the following parameters: %1[%END%]
+  [% ELSIF u_err.msg == 'syntax_errors' %][%|loc(u_err.params || u_err.p_name)%]Syntax errors with the following parameters: %1[%END%]
   [% ELSIF u_err.msg == 'authorization_reject' %][%|loc()%]Authorization rejected. Maybe you forgot to log in?[%END%]
   [% ELSIF u_err.msg == 'unknown_list' %][%|loc(u_err.list)%]%1: unknown list[%END%]
   [% ELSIF u_err.msg == 'unknown_robot' %][%|loc(u_err.new_robot)%]%1: unknown robot[%END%]

--- a/default/web_tt2/error.tt2
+++ b/default/web_tt2/error.tt2
@@ -61,7 +61,7 @@
   [% ELSIF u_err.msg == 'unable_to_parse' %][%|loc()%]You specified both an URL and a file to upload. Sympa can't choose which one to send. Please fill the form with one of them only. A web page OR a file to upload.[%END%]
   [% ELSIF u_err.msg == 'wrong_value' %][%|loc(u_err.argument)%]Wrong value for parameter %1[%END%]
   [% ELSIF u_err.msg == 'no_user' %][%|loc%]You need to login[%END%]
-  [% ELSIF u_err.msg == 'incorrect_email' %][%|loc(u_err.email)%]Address "%1" is incorrect[%END%]
+  [% ELSIF u_err.msg == 'incorrect_email' %][%|loc(u_err.email || u_err.value)%]Address "%1" is incorrect[%END%]
   [% ELSIF u_err.msg == 'incorrect_passwd' %][%|loc%]Provided password is incorrect[%END%]
   [% ELSIF u_err.msg == 'init_passwd' %][%|loc%]You did not choose a password, request a reminder of the initial password[%END%]
   [% ELSIF u_err.msg == 'ldap_user' %][%|loc%]Your password is stored in an LDAP directory, therefore Sympa cannot post you a reminder[%END%]

--- a/default/web_tt2/notice.tt2
+++ b/default/web_tt2/notice.tt2
@@ -44,6 +44,11 @@
 <i class="fi-check"></i> 
 [%|loc%]Configuration file has been updated[%END%]
 
+[% ELSIF notice.msg == 'no_parameter_edited' %]
+    <div  data-alert class="alert-box info radius">
+<i class="fi-eye"></i>
+[%|loc%]No parameter was edited[%END%]
+
 [% ELSIF notice.msg == 'list_purged' %]
     <div  data-alert class="alert-box success radius">
 <i class="fi-check"></i> 

--- a/default/web_tt2/notice.tt2
+++ b/default/web_tt2/notice.tt2
@@ -4,6 +4,8 @@
     <div  data-alert class="alert-box info radius">
 <i class="fi-eye"></i> 
 [%|loc(last_login_host,last_login_date)%]last login from %1 (%2)[%END%]<br/>
+
+    </div>
 [%END%]
 
 [% FOREACH notice = notices %]
@@ -143,11 +145,12 @@
 [%|loc(notice.notified_user)%]User %1 has been notified[%END%]
 
 [% ELSE %]
+    <div  data-alert class="alert-box info radius">
+<i class="fi-eye"></i>
 [% notice.msg.replace('\n','<br/>') %]
 
 [% END %]
-
-[% END %]
     </div>
+[% END %]
 </div>
 <!-- end notice.tt2 -->

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -12045,66 +12045,11 @@ sub do_edit_list {
         return undef;
     }
 
-    ## Checking no topic named "other"
-    foreach my $msg_topic (@{$new_admin->{'msg_topic'}}) {
-        if ($msg_topic->{'name'} =~ /^other$/i) {
-            $msg_topic->{'name'}  = undef;
-            $msg_topic->{'title'} = undef;
-            Sympa::Report::reject_report_web('user', 'topic_other', {},
-                $param->{'action'}, $list);
-            wwslog('notice', 'Topic other is a reserved word');
-            web_db_log(
-                {   'status'     => 'error',
-                    'error_type' => 'syntax_errors'
-                }
-            );
-            return undef;
-        }
-    }
-
     ## For changed msg_topic.name
     if (defined $new_admin->{'msg_topic'}
         and _notify_deleted_topic($new_admin->{'msg_topic'})) {
         Sympa::Report::notice_report_web('subscribers_noticed_deleted_topics',
             {}, $param->{'action'});
-    }
-
-    ## Checking that list owner address is not set to one of the special
-    ## addresses:
-    if (exists $changed{'owner'}) {
-        my @special = ();
-        push @special,
-            map { Sympa::get_address($list, $_) }
-            qw(owner editor return_path subscribe unsubscribe);
-        push @special, map {
-            sprintf '%s-%s@%s',
-                $list->{'name'}, lc $_, $list->{'admin'}{'host'}
-            }
-            split /[,\s]+/,
-            Conf::get_robot_conf($robot, 'list_check_suffixes');
-        my $bounce_email_re = quotemeta($list->get_bounce_address('ANY'));
-        $bounce_email_re =~ s/(?<=\\\+).*(?=\\\@)/.*/;
-
-        foreach my $owner (@{$new_admin->{'owner'}}) {
-            my $owner_email = lc $owner->{'email'};
-
-            if (grep { $owner_email eq $_ } @special
-                or $owner_email =~ /^$bounce_email_re$/) {
-                ## generate an error and return
-                Sympa::Report::reject_report_web('user', 'incorrect_email',
-                    {'email' => $owner->{'email'}},
-                    $param->{'action'}, $list);
-                wwslog('info', 'Reserved email address %s',
-                    $owner->{'email'});
-                web_db_log(
-                    {   'status'     => 'error',
-                        'error_type' => 'incorrect_email',
-                        'parameters' => $owner->{'email'}
-                    }
-                );
-                return undef;
-            }
-        }
     }
 
     ## Delete selected params

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -12416,13 +12416,6 @@ sub _prepare_data {
                 foreach my $elt (@{$struct->{'format'}}) {
                     $p_glob->{'value'}{$elt}{'selected'} = 0;
                 }
-
-                ## Check obsolete values ; they should not be printed
-                if (defined $struct->{'obsolete_values'}) {
-                    foreach my $elt (@{$struct->{'obsolete_values'}}) {
-                        delete $p_glob->{'value'}{$elt};
-                    }
-                }
             }
             if (ref($d)) {
                 next unless (ref($d) eq 'ARRAY');

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -12678,10 +12678,10 @@ sub _prepare_edit_form {
             $p->{'type'} = 'enum';
 
             my @topics;
-            foreach my $topic (@{$p->{'value'}}) {
-                push @topics, $topic->{'value'};
+            foreach my $topic (sort keys %{$p->{'value'}}) {
+                push @topics, $topic if $p->{'value'}{$topic}{'selected'};
             }
-            undef $p->{'value'};
+            delete $p->{'value'};
             my %list_of_topics = Sympa::Robot::load_topics($robot);
 
             if (defined $p->{'constraint'}) {

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -11619,30 +11619,6 @@ sub do_search_list {
 sub do_edit_list {
     wwslog('info', '');
 
-    ## Check if the list belong to a family.
-    my $family;
-    if (defined $list->{'admin'}{'family_name'}) {
-        unless ($family = $list->get_family()) {
-            Sympa::Report::reject_report_web('intern', 'unable_get_family',
-                {}, $param->{'action'}, $list, $param->{'user'}{'email'},
-                $robot);
-            wwslog('info', 'Impossible to get list %s\'s family',
-                $list->{'name'});
-            web_db_log(
-                {   'status'     => 'error',
-                    'error_type' => 'internal'
-                }
-            );
-            return undef;
-        }
-    }
-
-    # This hash will contain all the data gathered from the edit list form.
-    # The keys are the parameter names.
-    # The values are either the parameter value or an array containing this
-    # value if this is a multiple values parameter.
-    my $new_admin = _deserialize_changes();
-
     ## Check that the serial number sent by the form is the same as the one we
     ## expect.
     ## Avoid modifying a list previously modified by another way.
@@ -11665,538 +11641,109 @@ sub do_edit_list {
         return undef;
     }
 
-    ## Check changes & check syntax
-    ## %changed stores the names of the parameters whose values differs from
-    ## the value in the config file.
-    ## %stores the name of parameter for which values have been deleted. The
-    ## keys are the parameter name, the values are the index of the deleted
-    ## value.
-    ## @syntax_error stores the list of parameters for which syntax errors wre
-    ## founs while evaluating the data sent by the form.
-    my (%changed, %delete);
-    my @syntax_error;
+    # Start parsing the data sent by the edition form.
+    my $new_admin = _deserialize_changes();
 
-    ## Check family constraints.
-    ## %check_family is a hash whose keys are a parameter name and whose
-    ## values are the constraints
-    ## defined for this parameter.
-    my %check_family;
-
-    ## Getting changes about owners or editors
-    ## If changes occurred in the owner or editor definition, these scalars
-    ## are set to 1.
-    my $owner_update  = 0;
-    my $editor_update = 0;
-
-    ######################################################################
-    ## Start of the loop parsing the data sent by the edition form. ##
-    ######################################################################
-
-    foreach
-        my $pname (sort Sympa::List::by_order grep { exists $new_admin->{$_} }
-        keys %$pinfo) {
-
-        ## $p will contain the values of the current parameter in the previous
-        ## list config
-        ## $new_p  will contain the values sent by the form for the current
-        ## parameter.
-        my ($p, $new_p);
-
-        ## Check privileges first
-        next
-            unless (
-            $list->may_edit($pname, $param->{'user'}{'email'}) eq 'write');
-
-        # If the list belongs to a family, gather all the constraints for
-        # each edited parameter.
-        if (ref $family eq 'Sympa::Family') {
-            unless (ref $pinfo->{$pname}{'format'} eq 'HASH' or ref $pname) {
-                # Simple parameter.
-                my $constraint = $family->get_param_constraint($pname);
-
-                if (ref $constraint eq 'HASH') {
-                    # Controlled parameter.
-                    $check_family{$pname} = $constraint;
-
-                } elsif ($constraint ne '0') {
-                    # Fixed parameter (free : no control).
-                    next;
-                }
-            }
-        }
-
-        # Skip the obsolete parameters and alias names.
-        next if $pinfo->{$pname}{'obsolete'};
-
-        ## $to_index value will correspond to the number of not empty
-        ## parameters sent by the form.
-        my $to_index;
-
-        ####### Validation, step 1: remove empty entries ###########
-
-        ## If the parameter can have multiple values...
-        if ($pinfo->{$pname}{'occurrence'} =~ /n$/) {
-
-            ## They were either entries removed by the user or empty entries
-            ## added by wwsympa
-            ## The loop is going backward so we can remove empty entries
-            my @all = 0 .. $#{$new_admin->{$pname}};
-            foreach my $i (reverse @all) {
-                ## If the parameter has a complex structure
-                if (ref($pinfo->{$pname}{'format'}) eq 'HASH') {
-                    ## Check each component of the complex parameter.
-                    foreach my $key (keys %{$pinfo->{$pname}{'format'}}) {
-                        # Skip the obsolete component and the alias.
-                        next if $pinfo->{$pname}{'format'}{$key}{'obsolete'};
-
-                        ## As soon as a required component is found missing,
-                        ## the whole parameter instance is removed.
-                        if ($pinfo->{$pname}{'format'}{$key}{'occurrence'} =~
-                            /^1/
-                            && $new_admin->{$pname}[$i]{$key} =~ /^\s*$/) {
-                            splice(@{$new_admin->{$pname}}, $i, 1);
-                            last;
-                        }
-                    }
-                    ## Else if the parameter has only a scalar value
-                } else {
-                    ## Remove if empty
-                    if ($new_admin->{$pname}[$i] =~ /^\s*$/) {
-                        splice(@{$new_admin->{$pname}}, $i, 1);
-                        next;
-                    }
-                }
-            }
-
-            ## Now, %new_admin contains only entries for which all the
-            ## mandatory values are accounted for.
-
-            ## $last_index corresponds to the number of remaining instances of
-            ## this param sent by the form.
-            my $last_index = $#{$new_admin->{$pname}};
-
-            ## If a mandatory parameter is missing, issue an error and stop
-            ## here.
-            if ($pinfo->{$pname}{'occurrence'} =~ /^1/ && !($last_index >= 0))
-            {
-                delete $new_admin->{$pname};
-                wwslog('err', 'Parameter %s is mandatory', $pname);
-                Sympa::Report::reject_report_web('user',
-                    'mandatory_parameter', {'p_name' => $pname},
+    my $config = Sympa::List::Config->new($list, config => $list->{'admin'});
+    my $errors = [];
+    my $validity =
+        $config->submit($new_admin, $param->{'user'}{'email'}, $errors);
+    unless (defined $validity) {
+        if (my @intern = grep { $_->[0] eq 'intern' } @$errors) {
+            foreach my $err (@intern) {
+                Sympa::Report::reject_report_web('intern', $err->[1], {},
                     $param->{'action'}, $list);
-                web_db_log(
-                    {   'status'     => 'error',
-                        'error_type' => 'syntax_errors'
-                    }
-                );
-                next;
+                wwslog('err', 'Internal error %s', $err->[1]);
             }
-
-            ## If there are less entries in the config file than were sent by
-            ## the form,
-            ## $to_index must correspond to the number of entries sent.
-            if ($#{$list->{'admin'}{$pname}} < $last_index) {
-                $to_index = $last_index;
-                ## Otherwise, $to_index must correspond to the number of
-                ## entries in the config file.
-            } else {
-                $to_index = $#{$list->{'admin'}{$pname}};
-            }
-
-            $p     = $list->{'admin'}{$pname};
-            $new_p = $new_admin->{$pname};
-
-            ## If the parameter can't have multiple values...
         } else {
-
-            ## If the parameter has a complex structure
-            if (ref($pinfo->{$pname}{'format'}) eq 'HASH') {
-                ## Check each component of the complex parameter.
-                foreach my $key (keys %{$pinfo->{$pname}{'format'}}) {
-                    # Skip the obsolete component and the alias.
-                    next if $pinfo->{$pname}{'format'}{$key}{'obsolete'};
-
-                    ## Remove the full record if a component is emtpy and
-                    ## required
-                    if ($pinfo->{$pname}{'format'}{$key}{'occurrence'} =~ /^1/
-                        && $new_admin->{$pname}{$key} =~ /^\s*$/) {
-                        delete $new_admin->{$pname};
-                        last;
-                    }
-                }
-                ## If the parameter contains a simple scalar value.
-            } else {
-
-                ## Remove if empty
-                if ($new_admin->{$pname} =~ /^\s*$/) {
-                    delete $new_admin->{$pname};
-                    next;    # Go directly to the next parameter.
-                }
-            }
-
-            $p     = [$list->{'admin'}{$pname}];
-            $new_p = [$new_admin->{$pname}];
+            Sympa::Report::reject_report_web('intern', 'unknown', {},
+                $param->{'action'}, $list);
+            wwslog('err', 'Unknown error');
         }
-
-        ### Validation, step 2: - check if the parameter was modified.
-        ### ###
-        ###                     - check that the new values have the right
-        ###                     syntax. ###
-        ### Note: this step is performed for each occurrence of the parameter.
-        ### ###
-
-        foreach my $i (0 .. $to_index) {
-            unless (defined $new_p->[$i]) {
-                push @{$delete{$pname}}, $i;
-                $changed{$pname} = 1;
-                next;
+        web_db_log(
+            {   'status'     => 'error',
+                'error_type' => 'internal'
             }
-            ## If the parameter corresponds to a scenario or a task, mark it
-            ## as changed if its name was changed.
-            ## Example: 'subscribe'
-            if (   $pinfo->{$pname}{'scenario'}
-                || $pinfo->{$pname}{'task'}) {
-                if ($p->[$i]{'name'} ne $new_p->[$i]{'name'}) {
-                    $changed{$pname} = 1;
-                    next;
-                }
-                ## If the parameter has a complex structure, we need to check
-                ## all its components.
-                ## Example: 'owner'
-            } elsif (ref($pinfo->{$pname}{'format'}) eq 'HASH') {
-                ## Check each parameter component.
-                ## Example: 'owner->email'
-                foreach my $key (keys %{$pinfo->{$pname}{'format'}}) {
-                    # Skip the obsolete component and the alias.
-                    next if $pinfo->{$pname}{'format'}{$key}{'obsolete'};
-
-                    ## Check that the user is allowed to edit this parameter
-                    ## component.
-                    next
-                        unless (
-                        $list->may_edit("$pname.$key",
-                            $param->{'user'}{'email'}) eq 'write'
-                        );
-
-                    ## If the list belongs to a family, check the possible
-                    ## constraints on this parameter component.
-                    if (ref($family) eq 'Sympa::Family') {
-                        ## Test constraints only if the parameter component is
-                        ## not a complex structure.
-                        if (!ref($key)) {
-                            my $constraint =
-                                $family->get_param_constraint("$pname.$key");
-                            if (ref($constraint) eq 'HASH') {
-                                # controlled parameter
-                                $check_family{$pname}{$key} = $constraint;
-                            } elsif ($constraint ne '0') {   # fixed parameter
-                                next;    # Go to the next parameter component.
-                            }
-                        }
-                    }
-
-                    ## If the parameter component corresponds to a task or a
-                    ## scenario, mark it as changed if its name was changed.
-                    if (   $pinfo->{$pname}{'format'}{$key}{'scenario'}
-                        || $pinfo->{$pname}{'format'}{$key}{'task'}) {
-                        if ($p->[$i]{$key}{'name'} ne
-                            $new_p->[$i]{$key}{'name'}) {
-                            $changed{$pname} = 1;
-                            # Mark as changed and go to the next parameter
-                            # component.
-                            next;
-                        }
-                        ## If the parameter component doesn't correspond to a
-                        ## task or a scenario, we must check its content.
-                    } else {
-                        ## Parameter component check, case 1: this parameter
-                        ## component can have multiple occurrence.
-                        ## Example: 'digest->days'
-                        if ($pinfo->{$pname}{'format'}{$key}{'occurrence'} =~
-                            /n$/) {
-                            ## If the new value differs from the previous
-                            ## value, mark as changed and go to the next
-                            ## parameter component.
-                            if ($#{$p->[$i]{$key}} != $#{$new_p->[$i]{$key}})
-                            {
-                                $changed{$pname} = 1;
-                                next;
-                            }
-
-                            ## For each occurrence of this parameter
-                            ## component, check value
-                            foreach my $index (0 .. $#{$p->[$i]{$key}}) {
-                                my $format =
-                                    $pinfo->{$pname}{'format'}{$key}
-                                    {'format'};
-
-                                ## If the format has a complex structure, it
-                                ## is the description of a file format.
-                                if (ref($format)) {
-                                    $format =
-                                        $pinfo->{$pname}{'format'}{$key}
-                                        {'file_format'};
-                                }
-                                ## If this occurrence of the parameter
-                                ## component differs from the corresponding
-                                ## one in the config
-                                ## check the syntax and mark as changed.
-                                if ($p->[$i]{$key}[$index] ne
-                                    $new_p->[$i]{$key}[$index]) {
-
-                                    if (defined($new_p->[$i]{$key}[$index])
-                                        && $new_p->[$i]{$key}[$index] !~
-                                        /^$format$/i) {
-                                        wwslog('err',
-                                            "Syntax error : $pname/$i/$key/$index = $new_p->[$i]{$key}[$index]"
-                                        );
-                                        push @syntax_error, $pname;
-                                    }
-                                    $changed{$pname} = 1;
-                                    # Mark as changed and go to the next
-                                    # parameter component.
-                                    next;
-                                }
-                            }
-
-                            ## Parameter component check, case 2: this
-                            ## component is limited to one occurrence.
-                            ## Example: 'owner->email'
-                        } else {
-                            ## If the parameter component value differs from
-                            ## the corresponding one in the config, go on.
-                            if ($p->[$i]{$key} ne $new_p->[$i]{$key}) {
-                                my $format =
-                                    $pinfo->{$pname}{'format'}{$key}
-                                    {'format'};
-
-                                ## If the format has a complex structure, it
-                                ## is the description of a file format.
-                                if (ref($format)) {
-                                    $format =
-                                        $pinfo->{$pname}{'format'}{$key}
-                                        {'file_format'};
-                                }
-
-                                ## Check the syntax and mark as changed if the
-                                ## syntax is correct.
-                                if (defined($new_p->[$i]{$key})
-                                    && $new_p->[$i]{$key} !~ /^$format$/i) {
-                                    wwslog('err',
-                                        "Syntax error : $pname/$i/$key = $new_p->[$i]{$key}"
-                                    );
-                                    push @syntax_error, $pname;
-                                }
-
-                                $changed{$pname} = 1;
-                                # Mark as changed and go to the next parameter
-                                # component.
-                                next;
-                            }
-                        }
-                    }
-                }
-                ## If the parameter has just a scalar value, just check its
-                ## value.
-                ## Example: 'max_size'
-            } else {
-                ## If the value differs from the one in the config file, mark
-                ## parameter as changed if the syntax is correct.
-                if ($p->[$i] ne $new_p->[$i]) {
-                    unless (
-                        $new_p->[$i] =~ /^$pinfo->{$pname}{'file_format'}$/) {
-                        wwslog('err', 'Syntax error: %s/%s = %s',
-                            $pname, $i, $new_p->[$i]);
-                        push @syntax_error, $pname;
-                    }
-                    $changed{$pname} = 1;
-                }
-            }
-        }
+        );
+        return undef;
     }
-
-    ######################################################################
-    ## Validation of the form finished. Start of valid data treatments  ##
-    ######################################################################
-
-    ## Error if no parameter was edited
-    unless (keys %changed) {
-        Sympa::Report::reject_report_web('user', 'no_parameter_edited', {},
+    foreach my $err (
+        grep { $_->[0] eq 'user' and $_->[1] eq 'mandatory_parameter' }
+        @$errors) {
+        Sympa::Report::reject_report_web($err->[0], $err->[1],
+            {'p_name' => $err->[3]->[-1], %{$err->[5] || {}}},
             $param->{'action'}, $list);
-        wwslog('info', 'No parameter was edited by user');
+        wwslog('err', 'Error on parameter %s: Mandatory',
+            join '.', @{$err->[3]});
+        web_db_log(
+            {   'status'     => 'error',
+                'error_type' => 'syntax_errors'
+            }
+        );
+    }
+    if (my @syntax_errors =
+        grep { $_->[0] eq 'user' and $_->[1] eq 'syntax_errors' } @$errors) {
+        my $params = join ', ', map { $_->[3]->[-1] } @syntax_errors;
+        Sympa::Report::reject_report_web('user', 'syntax_errors',
+            {'params' => $params},
+            $param->{'action'}, $list);
+        wwslog('info', 'Syntax errors for parameters %s', $params);
+        web_db_log(
+            {   'status'     => 'error',
+                'error_type' => 'syntax_errors'
+            }
+        );
         return 'edit_list_request';
     }
-
-    ## Syntax errors
-    if ($#syntax_error > -1) {
-        Sympa::Report::reject_report_web('user', 'syntax_errors',
-            {'params' => join(',', @syntax_error)},
+    foreach my $err (
+        grep {
+                    $_->[0] eq 'user'
+                and $_->[1] ne 'mandatory_parameter'
+                and $_->[1] ne 'syntax_errors'
+        } @$errors
+        ) {
+        Sympa::Report::reject_report_web('user', $err->[1], ($err->[4] || {}),
             $param->{'action'}, $list);
         wwslog(
-            'info',
-            'Syntax errors for parameters %s',
-            join(',', @syntax_error)
+            'info', 'Error \'%s\' for parameters %s',
+            $err->[1], join('.', @{$err->[3] || []})
         );
         web_db_log(
             {   'status'     => 'error',
                 'error_type' => 'syntax_errors'
             }
         );
-        return undef;
     }
 
-    ## For changed msg_topic.name
-    if (defined $new_admin->{'msg_topic'}
-        and _notify_deleted_topic($new_admin->{'msg_topic'})) {
+    if ($validity eq '') {
+        Sympa::Report::reject_report_web('user', 'no_parameter_edited', {},
+            $param->{'action'}, $list);
+        wwslog('info', 'No parameter was edited by user');
+        return 'edit_list_request';
+    }
+
+    # Validation of the form finished. Start of valid data treatments.
+
+    # For changed msg_topic.name.
+    if (_notify_deleted_topic($config)) {
         Sympa::Report::notice_report_web('subscribers_noticed_deleted_topics',
             {}, $param->{'action'});
     }
+    # For changed owner/editor
+    _notify_added_admin($config);
+    #my $owner_update = 1
+    #   if $config->get_change('owner')
+    #       or $config->get_change('owner_include');
+    #my $editor_update = 1
+    #   if $config->get_change('editor')
+    #       or $config->get_change('editor_include');
+    my $data_source_updated = 1
+        if grep { $config->get_change($_) }
+            grep { $_ =~ /\Ainclude_/ or $_ eq 'ttl' }
+            keys %$pinfo;
 
-    ## Delete selected params
-    foreach my $p (keys %delete) {
-
-        if (($p eq 'owner') || ($p eq 'owner_include')) {
-            $owner_update = 1;
-        }
-
-        if (($p eq 'editor') || ($p eq 'editor_include')) {
-            $editor_update = 1;
-        }
-
-        ## Delete ALL entries
-        unless (ref($delete{$p})) {
-            undef $new_admin->{$p};
-            next;
-        }
-
-        ## Delete selected entries
-        foreach my $k (reverse @{$delete{$p}}) {
-            splice @{$new_admin->{$p}}, $k, 1;
-        }
-
-        if (defined $check_family{$p}) {    # $p is family controlled
-            if ($#{$new_admin->{$p}} < 0) {
-                Sympa::Report::reject_report_web('user',
-                    'p_family_controlled', {'param' => $p},
-                    $param->{'action'}, $list);
-                wwslog('info',
-                    'Parameter %s must have values (family context)', $p);
-                web_db_log(
-                    {   'status'     => 'error',
-                        'error_type' => 'missing_parameter'
-                    }
-                );
-                return undef;
-            }
-        }
-    }
-
-    # updating config_changes for deleted parameters
-    if (ref($family)) {
-        my @array_delete = keys %delete;
-        unless ($list->update_config_changes('param', \@array_delete)) {
-            Sympa::Report::reject_report_web('intern',
-                'update_config_changes', {}, $param->{'action'}, $list,
-                $param->{'user'}{'email'}, $robot);
-            wwslog(
-                'info',
-                'Cannot write in config_changes for deleted parameters from list %s',
-                $list->{'name'}
-            );
-            web_db_log(
-                {   'status'     => 'error',
-                    'error_type' => 'internal'
-                }
-            );
-            return undef;
-        }
-    }
-
-    ## Update config in memory
-    my $data_source_updated;
-    foreach my $parameter (keys %changed) {
-
-        my $pname;
-        if ($parameter =~ /^([\w-]+)\.([\w-]+)$/) {
-            $pname = $1;
-        } else {
-            $pname = $parameter;
-        }
-
-        ## If new owners/editors have been added, then notify them
-        foreach my $admin_type ('owner', 'editor') {
-            my (%previous_emails, %new_emails);
-
-            ## Check previous entries
-            foreach my $entry (@{$list->{'admin'}{$admin_type}}) {
-                $previous_emails{$entry->{'email'}} = 1;
-            }
-
-            ## Compare with new entries
-            foreach my $entry (@{$new_admin->{$admin_type}}) {
-                unless ($previous_emails{$entry->{'email'}}) {
-                    # Notify the new list owner/editor
-                    Sympa::send_notify_to_user(
-                        $list,
-                        'added_as_listadmin',
-                        $entry->{'email'},
-                        {   admin_type => $admin_type,
-                            delegator  => $param->{'user'}{'email'}
-                        }
-                    );
-                    Sympa::Report::notice_report_web('user_notified',
-                        {'notified_user' => $entry->{'email'}},
-                        $param->{'action'});
-                }
-            }
-        }
-
-        if (defined $check_family{$pname}) {    # $pname is CONTROLLED
-            _check_new_values(\%check_family, $pname, $new_admin);
-        }
-
-        ## If datasource config changed
-        if ($pname =~ /^(include_.*|ttl)$/) {
-            $data_source_updated = 1;
-        }
-
-        $list->{'admin'}{$pname} = $new_admin->{$pname};
-        if (defined $new_admin->{$pname} || $pinfo->{$pname}{'internal'}) {
-            delete $list->{'admin'}{'defaults'}{$pname};
-        } else {
-            $list->{'admin'}{'defaults'}{$pname} = 1;
-        }
-
-        if (($pname eq 'owner') || ($pname eq 'owner_include')) {
-            $owner_update = 1;
-        }
-
-        if (($pname eq 'editor') || ($pname eq 'editor_include')) {
-            $editor_update = 1;
-        }
-
-        # updating config_changes for changed parameters
-
-        if (ref($family)) {
-            my @array_changed = keys %changed;
-            unless ($list->update_config_changes('param', \@array_changed)) {
-                Sympa::Report::reject_report_web('intern',
-                    'update_config_changes', {}, $param->{'action'}, $list,
-                    $param->{'user'}{'email'}, $robot);
-                wwslog(
-                    'info',
-                    'Cannot write in config_changes for changed parameters from list %s',
-                    $list->{'name'}
-                );
-                web_db_log(
-                    {   'status'     => 'error',
-                        'error_type' => 'internal'
-                    }
-                );
-                return undef;
-            }
-        }
-    }
+    # Update config in memory.
+    $config->commit;
 
     ## Save config file
     unless ($list->save_config($param->{'user'}{'email'})) {
@@ -12239,8 +11786,8 @@ sub do_edit_list {
         }
     }
 
-    ## call sync_include_admin if there are changes about owners or editors
-    ## and we're in mode include2
+    # Call sync_include_admin if there are changes about owners or editors.
+    #FIXME:Update only when owner or editor was updated.
     unless ($list->sync_include_admin()) {
         Sympa::Report::reject_report_web('intern',
             'sync_include_admin_failed', {}, $param->{'action'}, $list,
@@ -12255,16 +11802,12 @@ sub do_edit_list {
     }
 
     ## Tag changed parameters
-    foreach my $pname (keys %changed) {
+    foreach my $pname (keys %{$config->get_changeset}) {
         $::changed_params{$pname} = 1;
     }
 
     ## Save stats
     $list->savestats();
-
-    #      print "Content-type: text/plain\n\n";
-    #    Sympa::Tools::Data::dump_var($list->{'admin'}{'msg_topic'},0);
-    #    Sympa::Tools::Data::dump_var($param->{'param'},0);
 
     Sympa::Report::notice_report_web('list_config_updated', {},
         $param->{'action'});
@@ -12273,7 +11816,13 @@ sub do_edit_list {
 }
 
 # Parses all the data sent from the web interface to the FCGI.
-# Fills the $new_admin.
+# Context:
+#   $list: Sympa::List instance.
+#   %in: Input from form.
+# Parameters:
+#   None.
+# Returns:
+#   Hashref containing parsed input.
 sub _deserialize_changes {
     my $new_admin = {};
 
@@ -12317,25 +11866,27 @@ sub _deserialize_changes {
 # Old name: Sympa::List::modifying_msg_topic_for_list_members().
 sub _notify_deleted_topic {
     $log->syslog('debug3', '(%s)', @_);
-    my $new_msg_topic = shift;
+    my $config = shift;
+
+    my @msg_topics         = @{$config->get('msg_topic') || []};
+    my @msg_topics_changes = $config->get_change('msg_topic');
+    return 0 unless @msg_topics_changes; # No changes.
+
+    my @msg_topics_deleted;
+    my ($msg_topics_changes) = @msg_topics_changes;
+    unless (defined $msg_topics_changes) {
+        @msg_topics_deleted = @msg_topics;
+    } else {
+        my %msg_topics_changes = %{$config->get_change('msg_topic') || {}};
+        @msg_topics_deleted = map {
+            $msg_topics[$_] ? ($msg_topics[$_]->{name}) : ();
+        } grep {
+            not defined $msg_topics_changes{$_}
+        } sort {$a <=> $b} keys %msg_topics_changes;
+    }
 
     my $deleted = 0;
-
-    my @old_msg_topic_name;
-    foreach my $msg_topic (@{$list->{'admin'}{'msg_topic'}}) {
-        push @old_msg_topic_name, $msg_topic->{'name'};
-    }
-
-    my @new_msg_topic_name;
-    foreach my $msg_topic (@{$new_msg_topic}) {
-        push @new_msg_topic_name, $msg_topic->{'name'};
-    }
-
-    my $msg_topic_changes =
-        Sympa::Tools::Data::diff_on_arrays(\@old_msg_topic_name,
-        \@new_msg_topic_name);
-
-    if (@{$msg_topic_changes->{'deleted'}}) {
+    if (@msg_topics_deleted) {
         for (
             my $subscriber = $list->get_first_list_member();
             $subscriber;
@@ -12343,7 +11894,7 @@ sub _notify_deleted_topic {
             ) {
             if ($subscriber->{'reception'} eq 'mail') {
                 my $topics = Sympa::Tools::Data::diff_on_arrays(
-                    $msg_topic_changes->{'deleted'},
+                    [@msg_topics_deleted],
                     Sympa::Tools::Data::get_array_from_splitted_string(
                         $subscriber->{'topics'}
                     )
@@ -12373,8 +11924,39 @@ sub _notify_deleted_topic {
             }
         }
     }
-    return 1 if $deleted;
-    return 0;
+    return $deleted;
+}
+
+sub _notify_added_admin {
+    my $config = shift;
+
+    # If new owners/editors have been added, then notify them.
+    foreach my $admin_type ('owner', 'editor') {
+        my %previous_emails = map {
+            ($_->{email} => 1)
+        } @{$config->get($admin_type) || []};
+        my %new_emails = map {
+            ($_->{email} => 1)
+        } grep {$_} values %{$config->get_change($admin_type) || {}};
+
+        # Compare with new entries.
+        foreach my $email (keys %new_emails) {
+            unless ($previous_emails{$email}) {
+                # Notify the new list owner/editor
+                Sympa::send_notify_to_user(
+                    $list,
+                    'added_as_listadmin',
+                    $email,
+                    {   admin_type => $admin_type,
+                        delegator  => $param->{'user'}{'email'}
+                    }
+                );
+                Sympa::Report::notice_report_web('user_notified',
+                    {'notified_user' => $email},
+                    $param->{'action'});
+            }
+        }
+    }
 }
 
 #=head2 sub do_edit_list_request
@@ -12422,122 +12004,8 @@ sub do_edit_list_request {
     return 1;
 }
 
-sub _check_new_values {
-    my $check_family = shift;
-    my $pname        = shift;
-    my $new_admin    = shift;
-    wwslog('debug3', '(%s)', $pname);
-
-    my $fake_list =
-        bless {'domain' => $robot, 'admin' => $new_admin} => 'Sympa::List';
-    ## TODO: update parameter cache
-    my $uncompellable_param = Sympa::Family::get_uncompellable_param();
-
-    if (ref($pinfo->{$pname}{'format'}) eq 'HASH') {    #composed parameter
-
-        foreach my $key (keys %{$check_family->{$pname}}) {
-
-            my $constraint = $check_family->{$pname}{$key};
-            my $values     = $fake_list->get_param_value("$pname.$key", 1);
-            my $nb_for     = 0;
-
-            # exception for uncompellable param
-            foreach my $p (keys %{$uncompellable_param}) {
-                if (($pname eq $p) && !($uncompellable_param->{$p})) {
-                    return 1;
-                }
-
-                if (($pname eq $p) && ($key eq $uncompellable_param->{$p})) {
-                    return 1;
-                }
-            }
-            foreach my $p_val (@{$values}) {    #each element value
-                $nb_for++;
-                if (ref($p_val) eq 'ARRAY') {    # multiple values
-                    foreach my $p (@{$p_val}) {
-                        if (  !($constraint->{$p})
-                            && (($nb_for == 1) || ($p ne ''))) {
-                            Sympa::Report::reject_report_web('user',
-                                'p_family_wrong',
-                                {'param' => $pname, 'val' => $p},
-                                $param->{'action'});
-                            wwslog(
-                                'info',
-                                'Parameter %s has got wrong value: %s (family context)',
-                                $pname,
-                                $p
-                            );
-                            return undef;
-                        }
-                    }
-                } else {    # single value
-                    if (  !($constraint->{$p_val})
-                        && (($nb_for == 1) || ($p_val ne ''))) {
-                        Sympa::Report::reject_report_web('user',
-                            'p_family_wrong',
-                            {'param' => $pname, 'val' => $p_val},
-                            $param->{'action'});
-                        wwslog(
-                            'info',
-                            'Parameter %s has got wrong value: %s (family context)',
-                            $pname,
-                            $p_val
-                        );
-                        return undef;
-                    }
-                }
-            }
-        }
-    } else {    #simple parameter
-
-        # exception for uncompellable param
-        foreach my $p (keys %{$uncompellable_param}) {
-            if ($pname eq $p) {
-                return 1;
-            }
-        }
-
-        my $constraint = $check_family->{$pname};
-        my $values     = $fake_list->get_param_value($pname, 1);
-        my $nb_for     = 0;
-
-        foreach my $p_val (@{$values}) {    #each element value
-            $nb_for++;
-            if (ref($p_val) eq 'ARRAY') {    # multiple values
-                foreach my $p (@{$p_val}) {
-                    if (  !($constraint->{$p})
-                        && (($nb_for == 1) || ($p ne ''))) {
-                        Sympa::Report::reject_report_web('user',
-                            'p_family_wrong',
-                            {'param' => $pname, 'val' => $p},
-                            $param->{'action'});
-                        wwslog(
-                            'info',
-                            'Parameter %s has got wrong value: %s (family context)',
-                            $pname,
-                            $p
-                        );
-                        return undef;
-                    }
-                }
-            } else {    # single value
-                if (  !($constraint->{$p_val})
-                    && (($nb_for == 1) || ($p_val ne ''))) {
-                    Sympa::Report::reject_report_web('user', 'p_family_wrong',
-                        {'param' => $pname, 'val' => $p_val},
-                        $param->{'action'});
-                    wwslog(
-                        'info',
-                        'Parameter %s has got wrong value: %s (family context)',
-                        $pname,
-                        $p_val
-                    );
-                    return undef;
-                }
-            }
-        }
-    }
-}
+# No longer used.
+#sub _check_new_values;
 
 #=head2 sub _prepare_edit_form(LIST)
 #

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -11637,50 +11637,11 @@ sub do_edit_list {
         }
     }
 
-    ## This hash will contain all the data gathered from the edit list form.
-    ## The keys are the parameter names.
-    ## The values are either the parameter value or an array containing this
-    ## value if this is a multiple values parameter.
-    ## The value can be a scalar or a hash.
-    my $new_admin = {};
-
-    ## This hash contains the names of all the parameters sent by the form to
-    ## the FCGI.
-    ## The keys are the parameters name, the value is always 1.
-    ## Used only to parse the data.
-    my $edited_param = {};
-
-    ## Parse all the data sent from the web interface to the FCGI.
-    ## Fills the $new_admin and $edited_param hashes.
-    foreach my $key (sort keys %in) {
-        next unless ($key =~ /^(single_param|multiple_param)\.(\S+)$/);
-
-        $key =~ /^(single_param|multiple_param)\.(\S+)$/;
-        my ($type, $name) = ($1, $2);
-
-        ## Tag parameter as present in the form
-        if (   $name =~ /^([^\.]+)(\.)/
-            || $name =~ /^([^\.]+)$/) {
-            $edited_param->{$1} = 1;
-        }
-
-        ## Parameter value
-        my $value = $in{$key};
-        next if ($value =~ /^\s*$/);
-
-        ## If the parameter is a multiple values parameter, store the values
-        ## into an array.
-        if ($type eq 'multiple_param') {
-            my @values = split /\0/, $value;
-            $value = \@values;
-        }
-
-        my @token = split(/\./, $name);
-
-        ## make it an entry in $new_admin
-        my $var = _shift_var(0, $new_admin, @token);
-        $$var = $value;
-    }
+    # This hash will contain all the data gathered from the edit list form.
+    # The keys are the parameter names.
+    # The values are either the parameter value or an array containing this
+    # value if this is a multiple values parameter.
+    my $new_admin = _deserialize_changes();
 
     ## Check that the serial number sent by the form is the same as the one we
     ## expect.
@@ -11731,7 +11692,9 @@ sub do_edit_list {
     ## Start of the loop parsing the data sent by the edition form. ##
     ######################################################################
 
-    foreach my $pname (sort Sympa::List::by_order keys %{$edited_param}) {
+    foreach
+        my $pname (sort Sympa::List::by_order grep { exists $new_admin->{$_} }
+        keys %$pinfo) {
 
         ## $p will contain the values of the current parameter in the previous
         ## list config
@@ -12364,54 +12327,43 @@ sub do_edit_list {
     return 'edit_list_request';
 }
 
-## Shift tokens to get a reference to the desired
-## entry in $var (recursive)
-sub _shift_var {
-    my ($i, $var, @tokens) = @_;
-    wwslog('debug3', '(%s, %s, %s)', $i, $var, join('.', @tokens));
-    my $newvar;
+# Parses all the data sent from the web interface to the FCGI.
+# Fills the $new_admin.
+sub _deserialize_changes {
+    my $new_admin = {};
 
-    my $token = shift @tokens;
+    foreach my $key (sort keys %in) {
+        next unless $key =~ /\A(single_param|multiple_param)[.](\S+)\z/;
+        my ($type, $name) = ($1, $2);
 
-    if ($token =~ /^\d+$/) {
-        return \$var->[$token]
-            if ($#tokens == -1);
-
-        if ($tokens[0] =~ /^\d+$/) {
-            unless (ref $var->[$token]) {
-                $var->[$token] = [];
-            }
-            $newvar = $var->[$token];
+        # If the parameter is a multiple values parameter, store the values
+        # into an array.
+        my $value;
+        if ($type eq 'multiple_param') {
+            $value = [grep {/\S/} split /\0/, $in{$key}];
         } else {
-            unless (ref $var->[$token]) {
-                $var->[$token] = {};
-            }
-            $newvar = $var->[$token];
-        }
-    } else {
-        return \$var->{$token}
-            if ($#tokens == -1);
-
-        if ($tokens[0] =~ /^\d+$/) {
-            unless (ref $var->{$token}) {
-                $var->{$token} = [];
-            }
-            $newvar = $var->{$token};
-        } else {
-            unless (ref $var->{$token}) {
-                $var->{$token} = {};
-            }
-            $newvar = $var->{$token};
+            $value = ($in{$key} =~ /\S/) ? $in{$key} : undef;
         }
 
+        # $in{'owner.0.gecos'} is stored into $new_admin->{owner}[0]{gecos}.
+        # Inconsistent subscripts will be ignored.
+        my @subscripts = map {
+            if (/\A\d+\z/) {
+                sprintf '[%s]', $_;
+            } elsif (/\A[-\w]+\z/) {
+                sprintf "{'%s'}", $_;
+            } else {
+                "{''}";
+            }
+        } split /[.]/, $name;
+        eval sprintf '$new_admin->%s = $value', join('->', @subscripts);
     }
 
-    if ($#tokens > -1) {
-        $i++;
-        return _shift_var($i, $newvar, @tokens);
-    }
-    return $newvar;
+    return $new_admin;
 }
+
+# No longer used.
+#sub _shift_var;
 
 # Deletes topics subscriber that does not exist anymore and send a notify to
 # concerned subscribers.

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -11651,7 +11651,7 @@ sub do_edit_list {
     unless (defined $validity) {
         if (my @intern = grep { $_->[0] eq 'intern' } @$errors) {
             foreach my $err (@intern) {
-                Sympa::Report::reject_report_web('intern', $err->[1], {},
+                Sympa::Report::reject_report_web($err->[0], $err->[1], {},
                     $param->{'action'}, $list);
                 wwslog('err', 'Internal error %s', $err->[1]);
             }
@@ -11675,8 +11675,9 @@ sub do_edit_list {
         Sympa::Report::reject_report_web(
             $err->[0],
             $err->[1],
-            {   'p_name' => $language->gettext($err->[2]->{gettext_id}),
-                %{$err->[4] || {}}
+            {   'p_name' =>
+                    $language->gettext($err->[2]->{p_info}->{gettext_id}),
+                %{$err->[2]}
             },
             $param->{'action'},
             $list
@@ -11684,7 +11685,7 @@ sub do_edit_list {
         wwslog(
             'err',
             'Error on parameter %s: %s',
-            join('.', @{$err->[3]}),
+            join('.', @{$err->[2]->{p_paths}}),
             $err->[1]
         );
         web_db_log(

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -11667,54 +11667,33 @@ sub do_edit_list {
         );
         return undef;
     }
-    foreach my $err (
-        grep { $_->[0] eq 'user' and $_->[1] eq 'mandatory_parameter' }
-        @$errors) {
-        Sympa::Report::reject_report_web($err->[0], $err->[1],
-            {'p_name' => $err->[3]->[-1], %{$err->[5] || {}}},
-            $param->{'action'}, $list);
-        wwslog('err', 'Error on parameter %s: Mandatory',
-            join '.', @{$err->[3]});
-        web_db_log(
-            {   'status'     => 'error',
-                'error_type' => 'syntax_errors'
-            }
+
+    my $error_return = 0;
+    foreach my $err (grep { $_->[0] eq 'user' } @$errors) {
+        $error_return = 1 unless $err->[1] eq 'mandatory_parameter';
+
+        Sympa::Report::reject_report_web(
+            $err->[0],
+            $err->[1],
+            {   'p_name' => $language->gettext($err->[2]->{gettext_id}),
+                %{$err->[4] || {}}
+            },
+            $param->{'action'},
+            $list
         );
-    }
-    if (my @syntax_errors =
-        grep { $_->[0] eq 'user' and $_->[1] eq 'syntax_errors' } @$errors) {
-        my $params = join ', ', map { $_->[3]->[-1] } @syntax_errors;
-        Sympa::Report::reject_report_web('user', 'syntax_errors',
-            {'params' => $params},
-            $param->{'action'}, $list);
-        wwslog('info', 'Syntax errors for parameters %s', $params);
-        web_db_log(
-            {   'status'     => 'error',
-                'error_type' => 'syntax_errors'
-            }
-        );
-        return 'edit_list_request';
-    }
-    foreach my $err (
-        grep {
-                    $_->[0] eq 'user'
-                and $_->[1] ne 'mandatory_parameter'
-                and $_->[1] ne 'syntax_errors'
-        } @$errors
-        ) {
-        Sympa::Report::reject_report_web('user', $err->[1], ($err->[4] || {}),
-            $param->{'action'}, $list);
         wwslog(
-            'info', 'Error \'%s\' for parameters %s',
-            $err->[1], join('.', @{$err->[3] || []})
+            'err',
+            'Error on parameter %s: %s',
+            join('.', @{$err->[3]}),
+            $err->[1]
         );
         web_db_log(
             {   'status'     => 'error',
                 'error_type' => 'syntax_errors'
             }
         );
-        return 'edit_list_request';
     }
+    return 'edit_list_request' if $error_return;
 
     if ($validity eq '') {
         Sympa::Report::notice_report_web('no_parameter_edited', {},

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -11713,11 +11713,12 @@ sub do_edit_list {
                 'error_type' => 'syntax_errors'
             }
         );
+        return 'edit_list_request';
     }
 
     if ($validity eq '') {
-        Sympa::Report::reject_report_web('user', 'no_parameter_edited', {},
-            $param->{'action'}, $list);
+        Sympa::Report::notice_report_web('no_parameter_edited', {},
+            $param->{'action'});
         wwslog('info', 'No parameter was edited by user');
         return 'edit_list_request';
     }

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -58,6 +58,7 @@ nobase_modules_DATA = \
 	Sympa/HTMLSanitizer.pm \
 	Sympa/Language.pm \
 	Sympa/List.pm \
+	Sympa/List/Config.pm \
 	Sympa/ListDef.pm \
 	Sympa/ListOpt.pm \
 	Sympa/LockedFile.pm \

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -46,6 +46,7 @@ use Sympa::Datasource;
 use Sympa::Family;
 use Sympa::Fetch;
 use Sympa::Language;
+use Sympa::List::Config;
 use Sympa::ListDef;
 use Sympa::LockedFile;
 use Sympa::Log;

--- a/src/lib/Sympa/List/Config.pm
+++ b/src/lib/Sympa/List/Config.pm
@@ -1,0 +1,529 @@
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+# $Id$
+
+# Sympa - SYsteme de Multi-Postage Automatique
+#
+# Copyright (c) 1997, 1998, 1999 Institut Pasteur & Christophe Wolfhugel
+# Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
+# 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
+# Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package Sympa::List::Config;
+
+use strict;
+use warnings;
+
+use Conf;
+use Sympa::Robot;
+use Sympa::Tools::Data;
+
+sub new {
+    my $class   = shift;
+    my $context = shift;
+    my $config  = shift;
+
+    die 'bug in logic. Ask developer' unless ref $context eq 'Sympa::List';
+
+    #FIXME: Should sanitize $config.
+    bless {context => $context, config => $config} => $class;
+}
+
+sub update {
+    my $self   = shift;
+    my $new    = shift;
+    my $user   = shift;
+    my $errors = shift;
+
+    my $changes = $self->_sanitize_changes($new, $user);
+
+    # Error if no parameter was edited.
+    unless ($changes and %$changes) {
+        push @$errors, ['user', 'no_parameter_edited'];
+        return '';
+    }
+
+    my $validity = $self->_validate_changes($changes, $errors);
+
+    return $validity;
+}
+
+# Sanitizes parsed input including changes.
+# Parameters:
+#   $new: Change information.
+#   $user: Operating user.  $param->{'user'}{'email'}.
+# Returns:
+#   Sanitized input, where "owner.0.gecos" will be stores in
+#   $hashref->{'owner'}{'0'}{'gecos'}.
+sub _sanitize_changes {
+    my $self = shift;
+    my $new  = shift;
+    my $user = shift;
+
+    return undef unless ref $new eq 'HASH';    # Sanity check
+
+    my $list = $self->{context};
+
+    my $authz = sub {
+        my $pnames = shift;
+        'write' eq $list->may_edit(join('.', @{$pnames || []}), $user);
+    };
+    my $pinfo = Sympa::Robot::list_params($list->{'domain'});
+
+    my %ret = map {
+        unless (exists $pinfo->{$_} and $pinfo->{$_}) {
+            ();    # Sanity check: unknown parameter
+        } else {
+            my $pii  = $pinfo->{$_};
+            my $pni  = [$_];
+            my $newi = $new->{$_};
+            my $curi = Sympa::Tools::Data::clone_var($self->{config}{$_});
+
+            my @r;
+            if ($pii->{occurrence} =~ /n$/) {
+                if (ref $pii->{format} eq 'ARRAY' or $pii->{split_char}) {
+                    @r =
+                        $self->_sanitize_changes_set($curi, $newi,
+                        $pii, $pni, $authz);
+                } else {
+                    @r =
+                        $self->_sanitize_changes_array($curi, $newi, $pii,
+                        $pni, $authz);
+                }
+            } elsif (ref $pii->{format} eq 'HASH') {
+                @r =
+                    $self->_sanitize_changes_paragraph($curi, $newi, $pii,
+                    $pni, $authz);
+            } else {
+                @r =
+                    $self->_sanitize_changes_leaf($curi, $newi, $pii, $pni,
+                    $authz);
+            }
+
+            # Omit removal if current configuration is already empty.
+            (@r and not defined $r[1] and not defined $curi) ? () : @r;
+        }
+    } sort keys %$new;
+
+    return {%ret};
+}
+
+# Sanitizes set.
+sub _sanitize_changes_set {
+    my $self   = shift;
+    my $cur    = shift;
+    my $new    = shift;
+    my $pitem  = shift;
+    my $pnames = shift;
+    my $authz  = shift;
+
+    return () unless ref $new eq 'ARRAY';    # Sanity check
+    return () if $pitem->{obsolete};
+    return () unless $authz->($pnames);
+
+    my $list = $self->{context};
+
+    # Apply default.
+    unless (defined $cur) {
+        my $default = $pitem->{default};
+        if (ref $default eq 'HASH' and exists $default->{conf}) {
+            $cur = Conf::get_robot_conf($list->{'domain'}, $default->{conf});
+        } else {
+            $cur = $default;
+        }
+        if ($pitem->{split_char}) {
+            my $split_char = $pitem->{split_char};
+            $cur = [split /\s*$split_char\s*/, $cur];
+        }
+    }
+
+    my $i       = -1;
+    my %updated = map {
+        $i++;
+        my $curi = $_;
+
+        if (grep { Sympa::Tools::Data::smart_eq($curi, $_) } @$new) {
+            ($i => $_);
+        } else {
+            ($i => undef);
+        }
+    } @$cur;
+    my %added = map {
+        my $newi = $_;
+
+        if (grep { Sympa::Tools::Data::smart_eq($newi, $_) } @$cur) {
+            ();
+        } else {
+            (++$i => $_);
+        }
+    } @$new;
+    my %ret = (%updated, %added);
+
+    # If all children are removed, remove parent.
+    while (my ($k, $v) = each %ret) {
+        $cur->[$k] = $v;
+    }
+    return ($pnames->[-1] => undef) unless grep { defined $_ } @$cur;
+
+    unless (%ret) {
+        return ();    # No valid changes
+    } else {
+        return ($pnames->[-1] => {%ret});
+    }
+}
+
+# Sanitizes array.
+sub _sanitize_changes_array {
+    my $self   = shift;
+    my $cur    = shift || [];
+    my $new    = shift;
+    my $pitem  = shift;
+    my $pnames = shift;
+    my $authz  = shift;
+
+    return () unless ref $new eq 'ARRAY';    # Sanity check
+    return () if $pitem->{obsolete};
+    return () unless $authz->($pnames);
+
+    my $i   = -1;
+    my %ret = map {
+        $i++;
+        my $curi = $cur->[$i];
+
+        my @r;
+        if (ref $pitem->{format} eq 'HASH') {
+            @r =
+                $self->_sanitize_changes_paragraph($curi, $_, $pitem, $pnames,
+                $authz);
+        } else {
+            @r =
+                $self->_sanitize_changes_leaf($curi, $_, $pitem, $pnames,
+                $authz);
+        }
+
+        # Omit removal if current configuration is already empty.
+        (@r and not defined $r[1] and not defined $curi)
+            ? ()
+            : (@r ? ($i => $r[1]) : ());
+    } @$new;
+
+    # If all children are removed, remove parent.
+    while (my ($k, $v) = each %ret) {
+        $cur->[$k] = $v;
+    }
+    return ($pnames->[-1] => undef) unless grep { defined $_ } @$cur;
+
+    unless (%ret) {
+        return ();    # No valid changes
+    } else {
+        return ($pnames->[-1] => {%ret});
+    }
+}
+
+# Sanitizes paragraph.
+sub _sanitize_changes_paragraph {
+    my $self   = shift;
+    my $cur    = shift || {};
+    my $new    = shift;
+    my $pitem  = shift;
+    my $pnames = shift;
+    my $authz  = shift;
+
+    return () unless ref $new eq 'HASH';    # Sanity check
+    return () if $pitem->{obsolete};
+    return () unless $authz->($pnames);
+
+    my %ret = map {
+        unless (exists $pitem->{format}->{$_} and $pitem->{format}->{$_}) {
+            ();                             # Sanity check: unknown parameter
+        } else {
+            my $pii  = $pitem->{format}->{$_};
+            my $pni  = [@$pnames, $_];
+            my $newi = $new->{$_};
+            my $curi = $cur->{$_};
+
+            my @r;
+            if ($pii->{occurrence} =~ /n$/) {
+                if (ref $pii->{format} eq 'ARRAY' or $pii->{split_char}) {
+                    @r =
+                        $self->_sanitize_changes_set($curi, $newi,
+                        $pii, $pni, $authz);
+                } else {
+                    @r =
+                        $self->_sanitize_changes_array($curi, $newi, $pii,
+                        $pni, $authz);
+                }
+            } elsif (ref $pii->{format} eq 'HASH') {
+                @r =
+                    $self->_sanitize_changes_paragraph($curi, $newi, $pii,
+                    $pni, $authz);
+            } else {
+                @r =
+                    $self->_sanitize_changes_leaf($curi, $newi, $pii, $pni,
+                    $authz);
+            }
+
+            # Omit removal if current configuration is already empty.
+            (@r and not defined $r[1] and not defined $curi) ? () : @r;
+        }
+    } sort keys %$new;
+
+    # As soon as a required component is found to be removed,
+    # the whole parameter instance is removed.
+    while (my ($k, $v) = each %ret) {
+        next if defined $v;
+        return ($pnames->[-1] => undef)
+            if $pitem->{format}->{$k}->{occurrence} =~ /^1/;
+    }
+
+    # If all children are removed, remove parent.
+    while (my ($k, $v) = each %ret) {
+        $cur->{$k} = $v;
+    }
+    return ($pnames->[-1] => undef) unless grep { defined $_ } values %$cur;
+
+    unless (%ret) {
+        return ();    # No valid changes
+    } else {
+        return ($pnames->[-1] => {%ret});
+    }
+}
+
+# Sanitizes leaf.
+sub _sanitize_changes_leaf {
+    my $self   = shift;
+    my $cur    = shift;
+    my $new    = shift;
+    my $pitem  = shift;
+    my $pnames = shift;
+    my $authz  = shift;
+
+    return () if ref $new eq 'ARRAY';    # Sanity check: Hashref or scalar
+    return () if $pitem->{obsolete};
+    return () unless $authz->($pnames);
+
+    my $list = $self->{context};
+
+    # If the parameter corresponds to a scenario or a task, mark it
+    # as changed if its name was changed.  Example: 'subscribe'.
+    if ($pitem->{scenario} or $pitem->{task}) {
+        return () unless ref($new || {}) eq 'HASH';    # Sanity check
+        $cur = ($cur || {})->{name};
+        $new = ($new || {})->{name};
+    }
+    # Apply default.
+    unless (defined $cur) {
+        my $default = $pitem->{default};
+        if (ref $default eq 'HASH' and exists $default->{conf}) {
+            $cur = Conf::get_robot_conf($list->{'domain'}, $default->{conf});
+        } else {
+            $cur = $default;
+        }
+    }
+
+    if (Sympa::Tools::Data::smart_eq($cur, $new)) {
+        return ();    # Not changed
+    }
+
+    if ($pitem->{scenario} or $pitem->{task}) {
+        return ($pnames->[-1] => {name => $new});
+    } else {
+        return ($pnames->[-1] => $new);
+    }
+}
+
+# Validates changes on list configuration.
+# Context:
+# - $list: An instance of Sympa::List.
+# Parameters:
+# - $new: Hashref including changes.
+# - $errors: Error information, initially may be empty arrayref.
+# Returns:
+# - 'valid' if changes are valid; 'invalid' otherwise;
+#   '' if no changes necessary; undef if internal error occurred.
+# - $new may be modified, if there are any omittable changes.
+# - Error information will be added to $errors.
+sub _validate_changes {
+    my $self   = shift;
+    my $new    = shift;
+    my $errors = shift;
+
+    my $list  = $self->{context};
+    my $pinfo = Sympa::Robot::list_params($list->{'domain'});
+
+    my $ret = 'valid';
+    foreach my $pname (sort Sympa::List::by_order keys %$new) {
+        my $newi = $new->{$pname};
+        my $pii  = $pinfo->{$pname};
+        my $pni  = [$pname];
+
+        my $r;
+        if ($pii->{occurrence} =~ /n$/) {
+            $r =
+                $self->_validate_changes_multiple($newi, $pii, $pni, $errors);
+        } elsif (ref $pii->{format} eq 'HASH') {
+            $r =
+                $self->_validate_changes_paragraph($newi, $pii, $pni,
+                $errors);
+        } else {
+            $r = $self->_validate_changes_leaf($newi, $pii, $pni, $errors);
+        }
+
+        return undef unless defined $r;
+        delete $new->{$pname} if $r eq 'omit';
+        $ret = 'invalid' if $r eq 'invalid';
+    }
+
+    return '' unless %$new;
+    return $ret;
+}
+
+# Validates array or set.
+sub _validate_changes_multiple {
+    my $self   = shift;
+    my $new    = shift;
+    my $pitem  = shift;
+    my $pnames = shift;
+    my $errors = shift;
+
+    if (not defined $new and $pitem->{occurrence} =~ /^1/) {
+        push @$errors, ['user', 'mandatory_parameter', $pitem, $pnames];
+        return 'omit';
+    }
+
+    my $ret = 'valid';
+    if (defined $new) {
+        foreach my $i (sort { $a <=> $b } keys %$new) {
+            my $newi = $new->{$i};
+
+            my $r;
+            if (ref $pitem->{format} eq 'HASH') {
+                $r =
+                    $self->_validate_changes_paragraph($newi, $pitem, $pnames,
+                    $errors);
+            } else {
+                $r =
+                    $self->_validate_changes_leaf($newi, $pitem, $pnames,
+                    $errors);
+            }
+
+            return undef unless defined $r;
+            delete $new->{$i} if $r eq 'omit';
+            $ret = 'invalid' if $r eq 'invalid';
+        }
+
+        return 'omit' unless %$new;
+    }
+
+    return $ret;
+}
+
+# Validates paragraph.
+sub _validate_changes_paragraph {
+    my $self   = shift;
+    my $new    = shift;
+    my $pitem  = shift;
+    my $pnames = shift;
+    my $errors = shift;
+
+    if (not defined $new and $pitem->{occurrence} =~ /^1/) {
+        push @$errors, ['user', 'mandatory_parameter', $pitem, $pnames];
+        return 'omit';
+    }
+
+    my $ret = 'valid';
+    if (defined $new) {
+        foreach my $key (sort keys %$new) {
+            my $pii  = $pitem->{format}->{$key};
+            my $pni  = [@$pnames, $key];
+            my $newi = $new->{$key};
+
+            my $r;
+            if ($pii->{occurrence} =~ /n$/) {
+                $r =
+                    $self->_validate_changes_multiple($newi, $pii, $pni,
+                    $errors);
+            } elsif (ref $pii->{format} eq 'HASH') {
+                $r =
+                    $self->_validate_changes_paragraph($newi, $pii, $pni,
+                    $errors);
+            } else {
+                $r =
+                    $self->_validate_changes_leaf($newi, $pii, $pni, $errors);
+            }
+
+            return undef unless defined $r;
+            delete $new->{$key} if $r eq 'omit';
+            $ret = 'invalid' if $r eq 'invalid';
+        }
+
+        return 'omit' unless %$new;
+    }
+
+    return $ret;
+}
+
+# Validates leaf.
+sub _validate_changes_leaf {
+    my $self   = shift;
+    my $new    = shift;
+    my $pitem  = shift;
+    my $pnames = shift;
+    my $errors = shift;
+
+    # If the parameter corresponds to a scenario or a task, mark it
+    # as changed if its name was changed.  Example: 'subscribe'.
+    if ($pitem->{scenario} or $pitem->{task}) {
+        $new = $new->{name} if defined $new;
+    }
+
+    if (not defined $new and $pitem->{occurrence} =~ /^1/) {
+        push @$errors, ['user', 'mandatory_parameter', $pitem, $pnames];
+        return 'omit';
+    }
+
+    # Check that the new values have the right syntax.
+    if (defined $new) {
+        my $format = $pitem->{format};
+        $format = $pitem->{file_format} if ref $format;
+        unless ($new =~ /^$format$/) {
+            wwslog('err', 'Syntax error: %s = %s', join('.', $pnames), $new);
+            push @$errors, ['user', 'syntax_errors', $pitem, $pnames];
+            return 'invalid';
+        }
+    }
+
+    return 'valid';
+}
+
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Sympa::Language - Handling languages and locales
+
+=head1 SYNOPSIS
+
+  use Sympa::List::Config;
+  my $config = Sympa::List::Config->new($list, {...});
+  
+  my $result = $config->update({...});
+
+=head1 DESCRIPTION
+

--- a/src/lib/Sympa/List/Config.pm
+++ b/src/lib/Sympa/List/Config.pm
@@ -501,6 +501,20 @@ sub _validate_changes_paragraph {
 }
 
 my %validations = (
+    # Checking that list editor address is not set to editor special address.
+    list_editor_address => sub {
+        my $self = shift;
+        my $new  = shift;
+
+        my $list = $self->{context};
+
+        my $email = Sympa::Tools::Text::canonic_email($new);
+        return 'syntax_errors'
+            unless defined $email;
+
+        return 'incorrect_email'
+            if Sympa::get_address($list, 'editor') eq $new;
+    },
     # Checking that list owner address is not set to one of the special
     # addresses.
     list_special_addresses => sub {

--- a/src/lib/Sympa/List/Config.pm
+++ b/src/lib/Sympa/List/Config.pm
@@ -634,7 +634,16 @@ sub commit {
         }
     }
 
-    die 'Not yet implemented';
+    # Update 'defaults' item to indicate default settings, for compatibility.
+    #FIXME:Multiple levels of keys should be possible.
+    foreach my $pname (sort keys %{$self->{changes}}) {
+        if (defined $self->{changes}->{$pname}
+            or $pinfo->{$pname}->{internal}) {
+            delete $self->{config}->{defaults}->{$pname};
+        } else {
+            $self->{config}->{defaults}->{$pname} = 1;
+        }
+    }
 }
 
 sub _merge_changes_multiple {

--- a/src/lib/Sympa/List/Config.pm
+++ b/src/lib/Sympa/List/Config.pm
@@ -190,7 +190,7 @@ sub submit {
     # Error if no parameter was edited.
     unless ($changes and %$changes) {
         $self->{_changes} = {};
-        push @$errors, ['user', 'no_parameter_edited'];
+        push @$errors, ['notice', 'no_parameter_edited'];
         return '';
     }
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -80,7 +80,8 @@ our %pinfo = (
                 'gettext_id' => "email address",
                 'format'     => Sympa::Regexps::email(),
                 'occurrence' => '1',
-                'length'     => 30
+                'length'     => 30,
+                validations  => ['list_special_addresses'],
             },
             'gecos' => {
                 'order'      => 2,
@@ -379,7 +380,8 @@ our %pinfo = (
                 'gettext_id' => "Message topic name",
                 'format'     => '[\-\w]+',
                 'occurrence' => '1',
-                'length'     => 15
+                'length'     => 15,
+                validations  => ['reserved_msg_topic_name'],
             },
             'keywords' => {
                 'order'      => 2,
@@ -2467,6 +2469,10 @@ that should always be saved in the config file.
 =item field_type
 
 Used to select passwords web input type.
+
+=item validations
+
+TBD.
 
 =back
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -228,7 +228,7 @@ our %pinfo = (
     'topics' => {
         'group'      => 'description',
         'gettext_id' => "Topics for the list",
-        'format'     => '[\-\w]+(\/[\-\w]+)?',
+        'format'     => [],     # Sympa::Robot::load_topics() called later
         'split_char' => ',',
         'occurrence' => '0-n'
     },
@@ -2490,7 +2490,6 @@ Some of them can include other type of nodes recursively.
 =item *
 
 {format}: Arrayref.
-Or, it is regexp and {split_char} is defined.
 
 =back
 
@@ -2509,10 +2508,6 @@ The set cannot contain paragraphs, sets or arrays.
 =item *
 
 {format}: Regexp or hashref.
-
-=item *
-
-{split_char}: Not defined.
 
 =back
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2216,7 +2216,9 @@ our %pinfo = (
             'optional' => {
                 'order'      => 6,
                 'gettext_id' => "is the attribute optional?",
-                'format'     => ['required', 'optional']
+                'format'     => ['required', 'optional'],
+                'default'    => 'optional',
+                'occurrence' => 1
             }
         },
         'occurrence' => '0-n'

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -164,7 +164,8 @@ our %pinfo = (
                 'gettext_id' => "email address",
                 'format'     => Sympa::Regexps::email(),
                 'occurrence' => '1',
-                'length'     => 30
+                'length'     => 30,
+                validations  => ['list_editor_address'],
             },
             'reception' => {
                 'order'      => 4,

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2459,6 +2459,8 @@ Or arrayref containing all possible values of parameter.
 If the parameter is paragraph, value of this item is a hashref containing
 definitions of sub-parameters.
 
+See also L</"Node types">.
+
 =item file_format
 
 Config file format of the parameter might not be
@@ -2467,6 +2469,7 @@ the same in memory.
 =item split_char
 
 Character used to separate multiple parameters.
+Used with the set or the array of scalars.
 
 =item length
 
@@ -2480,6 +2483,10 @@ Tells that the parameter is a scenario, providing its name.
 
 Default value for the param ; may be a robot configuration
 parameter (conf).
+
+If occurrence is C<0-1> or C<0-n>,
+default value will be assigned
+only when list is created or new node is added to configuration.
 
 =item synonym
 
@@ -2599,7 +2606,8 @@ The array cannot contain sets or arrays.
 
 =item *
 
-{occurrence}: C<'0-1'> or C<'1'>, if the node is not an item of array or set.
+{occurrence}: If the node is an item of array, C<'0-n'> or C<'1-n'>.
+Otherwise, C<'0-1'> or C<'1'>.
 
 =item *
 
@@ -2617,12 +2625,13 @@ are defined as member of {format}.
 
 =item *
 
-{occurrence}: C<'0-1'> or C<'1'>, if the value is not an item of
-the set or the array.
+{occurrence}: If the node is an item of array, C<'0-n'> or C<'1-n'>.
+Otherwise, C<'0-1'> or C<'1'>.
 
 =item *
 
-{format}: Regexp or arrayref.
+{format}: If the node is an item of array, regexp.
+Otherwise, regexp or arrayref.
 
 =back
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2381,6 +2381,7 @@ List parameters format accepts the following keywords :
 
 Regexp aplied to the configuration file entry;
 some common regexps are defined in L<Sympa::Regexps>.
+Or arrayref containing all possible values of parameter.
 
 If the parameter is paragraph, value of this item is a hashref containing
 definitions of sub-parameters.
@@ -2423,6 +2424,8 @@ strings in NLS catalogs.
 Occurrence of the parameter in the config file
 possible values: C<0-1>, C<1>, C<0-n> and C<1-n>.
 Example: A list may have multiple owner.
+
+See also L</"Node types">.
 
 =item gettext_id
 
@@ -2467,9 +2470,97 @@ Used to select passwords web input type.
 
 =back
 
+=head2 Node types
+
+Each node of configuration has one of following four types.
+Some of them can include other type of nodes recursively.
+
+=over
+
+=item Set (multiple enumerated values)
+
+=over
+
+=item *
+
+{occurrence}: C<'0-n'> or C<'1-n'>.
+
+=item *
+
+{format}: Arrayref.
+Or, it is regexp and {split_char} is defined.
+
+=back
+
+List of unique items not considering order.
+Items are scalars, and cannot be special values (scenario or task).
+The set cannot contain paragraphs, sets or arrays.
+
+=item Array (multiple values)
+
+=over
+
+=item *
+
+{occurrence}: C<'0-n'> or C<'1-n'>.
+
+=item *
+
+{format}: Regexp or hashref.
+
+=item *
+
+{split_char}: Not defined.
+
+=back
+
+List of the same type of nodes in order.
+Type of all nodes can be one of paragraph,
+scalar or special value (scenario or task).
+The array cannot contain sets or arrays.
+
+=item Paragraph (structured value)
+
+=over
+
+=item *
+
+{occurrence}: C<'0-1'> or C<'1'>, if the node is not an item of array or set.
+
+=item *
+
+{format}: Hashref.
+
+=back
+
+Compound node of one or more named nodes.
+Paragraph can contain any type of nodes, and each of their names and types
+are defined as member of {format}.
+
+=item Leaf (simple value)
+
+=over
+
+=item *
+
+{occurrence}: C<'0-1'> or C<'1'>, if the value is not an item of
+the set or the array.
+
+=item *
+
+{format}: Regexp or arrayref.
+
+=back
+
+Scalar or special value (scenario or task).
+Leaf cannot contain any other nodes.
+
+=back
+
 =head1 SEE ALSO
 
-L<config(5)>.
+L<config(5)>,
+L<Sympa::ListOpt>.
 
 =head1 HISTORY
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2522,6 +2522,8 @@ defines parameter alias name mainly for backward compatibility.
 
 =item obsolete_values
 
+B<Deprecated>.
+
 Defined obsolete values for a parameter.
 These values should not get proposed on the web interface
 edition form.

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -35,15 +35,8 @@ our %default = (
     'length'     => 25
 );
 
-our @param_order =
-    qw (subject visibility info subscribe add unsubscribe del owner owner_include
-    send editor editor_include delivery_time account topics
-    host lang process_archive web_archive archive digest digest_max_size available_user_options
-    default_user_options msg_topic msg_topic_keywords_apply_on msg_topic_tagging reply_to_header reply_to forced_reply_to *
-    verp_rate tracking welcome_return_path remind_return_path user_data_source include_file include_remote_file
-    include_sympa_list include_remote_sympa_list include_ldap_query
-    include_ldap_2level_query include_sql_query include_voot_group ttl distribution_ttl creation update
-    status serial custom_attribute include_ldap_ca include_ldap_2level_ca include_sql_ca);
+# DEPRECATED. No longer used.
+#our @param_order;
 
 # List parameter alias names
 # DEPRECATED.  Use 'obsolete' elements.
@@ -54,6 +47,7 @@ our %pinfo = (
     ### Global definition page ###
 
     'subject' => {
+        order        => 10.01,
         'group'      => 'description',
         'gettext_id' => "Subject of the list",
         'format'     => '.+',
@@ -62,6 +56,7 @@ our %pinfo = (
     },
 
     'visibility' => {
+        order        => 10.02,
         'group'      => 'description',
         'gettext_id' => "Visibility of the list",
         'scenario'   => 'visibility',
@@ -72,6 +67,7 @@ our %pinfo = (
     },
 
     'owner' => {
+        order        => 10.03,
         'group'      => 'description',
         'gettext_id' => "Owner",
         'format'     => {
@@ -118,6 +114,7 @@ our %pinfo = (
     },
 
     'owner_include' => {
+        order        => 10.04,
         'group'      => 'description',
         'gettext_id' => 'Owners defined in an external data source',
         'format'     => {
@@ -156,6 +153,7 @@ our %pinfo = (
     },
 
     'editor' => {
+        order        => 10.05,
         'group'      => 'description',
         'gettext_id' => "Moderators",
         'format'     => {
@@ -196,6 +194,7 @@ our %pinfo = (
     },
 
     'editor_include' => {
+        order        => 10.06,
         'group'      => 'description',
         'gettext_id' => 'Moderators defined in an external data source',
         'format'     => {
@@ -228,6 +227,7 @@ our %pinfo = (
     },
 
     'topics' => {
+        order        => 10.07,
         'group'      => 'description',
         'gettext_id' => "Topics for the list",
         'format'     => [],     # Sympa::Robot::load_topics() called later
@@ -236,6 +236,7 @@ our %pinfo = (
     },
 
     'host' => {
+        order        => 10.08,
         'group'      => 'description',
         'gettext_id' => "Internet domain",
         'format'     => Sympa::Regexps::host(),
@@ -244,6 +245,7 @@ our %pinfo = (
     },
 
     'lang' => {
+        order        => 10.09,
         'group'      => 'description',
         'gettext_id' => "Language of the list",
         'format' => [],    ## Sympa::get_supported_languages() called later
@@ -252,6 +254,7 @@ our %pinfo = (
     },
 
     'family_name' => {
+        order        => 10.10,
         'group'      => 'description',
         'gettext_id' => 'Family name',
         'format'     => Sympa::Regexps::family_name(),
@@ -260,6 +263,7 @@ our %pinfo = (
     },
 
     'max_list_members' => {
+        order          => 10.11,
         'group'        => 'description',
         'gettext_id'   => "Maximum number of list members",
         'gettext_unit' => 'list members',
@@ -269,6 +273,7 @@ our %pinfo = (
     },
 
     'priority' => {
+        order        => 10.12,
         'group'      => 'description',
         'gettext_id' => "Priority",
         'format'     => [0 .. 9, 'z'],
@@ -279,12 +284,14 @@ our %pinfo = (
     ### Sending page ###
 
     'send' => {
+        order        => 20.01,
         'group'      => 'sending',
         'gettext_id' => "Who can send messages",
         'scenario'   => 'send'
     },
 
     'delivery_time' => {
+        order        => 20.02,
         'group'      => 'sending',
         'gettext_id' => "Delivery time (hh:mm)",
         'format'     => '[0-2]?\d\:[0-6]\d',
@@ -293,6 +300,7 @@ our %pinfo = (
     },
 
     'digest' => {
+        order         => 20.03,
         'group'       => 'sending',
         'gettext_id'  => "Digest frequency",
         'file_format' => '\d+(\s*,\s*\d+)*\s+\d+:\d+',
@@ -322,6 +330,7 @@ our %pinfo = (
     },
 
     'digest_max_size' => {
+        order          => 20.04,
         'group'        => 'sending',
         'gettext_id'   => "Digest maximum number of messages",
         'gettext_unit' => 'messages',
@@ -331,6 +340,7 @@ our %pinfo = (
     },
 
     'available_user_options' => {
+        order        => 20.05,
         'group'      => 'sending',
         'gettext_id' => "Available subscription options",
         'format'     => {
@@ -350,6 +360,7 @@ our %pinfo = (
     },
 
     'default_user_options' => {
+        order        => 20.06,
         'group'      => 'sending',
         'gettext_id' => "Subscription profile",
         'format'     => {
@@ -373,6 +384,7 @@ our %pinfo = (
     },
 
     'msg_topic' => {
+        order        => 20.07,
         'group'      => 'sending',
         'gettext_id' => "Topics for message categorization",
         'format'     => {
@@ -402,6 +414,7 @@ our %pinfo = (
     },
 
     'msg_topic_keywords_apply_on' => {
+        order   => 20.08,
         'group' => 'sending',
         'gettext_id' =>
             "Defines to which part of messages topic keywords are applied",
@@ -411,6 +424,7 @@ our %pinfo = (
     },
 
     'msg_topic_tagging' => {
+        order        => 20.09,
         'group'      => 'sending',
         'gettext_id' => "Message tagging",
         'format'     => ['required_sender', 'required_moderator', 'optional'],
@@ -438,6 +452,7 @@ our %pinfo = (
     'forced_reply-to' => {'obsolete' => 'forced_reply_to'},
 
     'reply_to_header' => {
+        order        => 20.10,
         'group'      => 'sending',
         'gettext_id' => "Reply address",
         'format'     => {
@@ -463,12 +478,14 @@ our %pinfo = (
     },
 
     'anonymous_sender' => {
+        order        => 20.11,
         'group'      => 'sending',
         'gettext_id' => "Anonymous sender",
         'format'     => '.+'
     },
 
     'custom_header' => {
+        order        => 20.12,
         'group'      => 'sending',
         'gettext_id' => "Custom header field",
         'format'     => '\S+:\s+.*',
@@ -478,6 +495,7 @@ our %pinfo = (
     'custom-header' => {'obsolete' => 'custom_header'},
 
     'custom_subject' => {
+        order        => 20.13,
         'group'      => 'sending',
         'gettext_id' => "Subject tagging",
         'format'     => '.+',
@@ -486,6 +504,7 @@ our %pinfo = (
     'custom-subject' => {'obsolete' => 'custom_subject'},
 
     'footer_type' => {
+        order        => 20.14,
         'group'      => 'sending',
         'gettext_id' => "Attachment type",
         'format'     => ['mime', 'append'],
@@ -493,6 +512,7 @@ our %pinfo = (
     },
 
     'max_size' => {
+        order          => 20.15,
         'group'        => 'sending',
         'gettext_id'   => "Maximum message size",
         'gettext_unit' => 'bytes',
@@ -503,6 +523,7 @@ our %pinfo = (
     'max-size' => {'obsolete' => 'max_size'},
 
     'merge_feature' => {
+        order        => 20.16,
         'group'      => 'sending',
         'gettext_id' => "Allow message personalization",
         'format'     => ['on', 'off'],
@@ -511,6 +532,7 @@ our %pinfo = (
     },
 
     'reject_mail_from_automates_feature' => {
+        order        => 20.18,
         'group'      => 'sending',
         'gettext_id' => "Reject mail from automates (crontab, etc)?",
         'format'     => ['on', 'off'],
@@ -519,6 +541,7 @@ our %pinfo = (
     },
 
     'remove_headers' => {
+        order        => 20.19,
         'group'      => 'sending',
         'gettext_id' => 'Incoming SMTP header fields to be removed',
         'format'     => '\S+',
@@ -528,6 +551,7 @@ our %pinfo = (
     },
 
     'remove_outgoing_headers' => {
+        order        => 20.20,
         'group'      => 'sending',
         'gettext_id' => 'Outgoing SMTP header fields to be removed',
         'format'     => '\S+',
@@ -537,6 +561,7 @@ our %pinfo = (
     },
 
     'rfc2369_header_fields' => {
+        order        => 20.21,
         'group'      => 'sending',
         'gettext_id' => "RFC 2369 Header fields",
         'format' =>
@@ -547,6 +572,7 @@ our %pinfo = (
     },
 
     'message_hook' => {
+        order        => 20.17,
         'group'      => 'sending',
         'gettext_id' => 'Hook modules for message processing',
         'format'     => {
@@ -566,12 +592,14 @@ our %pinfo = (
     ### Command page ###
 
     'info' => {
+        order        => 30.01,
         'group'      => 'command',
         'gettext_id' => "Who can view list information",
         'scenario'   => 'info'
     },
 
     'subscribe' => {
+        order        => 30.02,
         'group'      => 'command',
         'gettext_id' => "Who can subscribe to the list",
         'scenario'   => 'subscribe'
@@ -579,12 +607,14 @@ our %pinfo = (
     'subscription' => {'obsolete' => 'subscribe'},
 
     'add' => {
+        order        => 30.03,
         'group'      => 'command',
         'gettext_id' => "Who can add subscribers",
         'scenario'   => 'add'
     },
 
     'unsubscribe' => {
+        order        => 30.04,
         'group'      => 'command',
         'gettext_id' => "Who can unsubscribe",
         'scenario'   => 'unsubscribe'
@@ -592,24 +622,28 @@ our %pinfo = (
     'unsubscription' => {'obsolete' => 'unsubscribe'},
 
     'del' => {
+        order        => 30.05,
         'group'      => 'command',
         'gettext_id' => "Who can delete subscribers",
         'scenario'   => 'del'
     },
 
     'invite' => {
+        order        => 30.06,
         'group'      => 'command',
         'gettext_id' => "Who can invite people",
         'scenario'   => 'invite'
     },
 
     'remind' => {
+        order        => 30.07,
         'group'      => 'command',
         'gettext_id' => "Who can start a remind process",
         'scenario'   => 'remind'
     },
 
     'review' => {
+        order        => 30.08,
         'group'      => 'command',
         'gettext_id' => "Who can review subscribers",
         'scenario'   => 'review',
@@ -617,6 +651,7 @@ our %pinfo = (
     },
 
     'shared_doc' => {
+        order        => 30.09,
         'group'      => 'command',
         'gettext_id' => "Shared documents",
         'format'     => {
@@ -644,6 +679,7 @@ our %pinfo = (
     ### Archives page ###
 
     'process_archive' => {
+        order        => 40.01,
         'group'      => 'archives',
         'gettext_id' => "Store distributed messages into archive",
         'format'     => ['on', 'off'],
@@ -679,6 +715,7 @@ our %pinfo = (
         }
     },
     'archive' => {
+        order        => 40.02,
         'group'      => 'archives',
         'gettext_id' => "Archives",
         'format'     => {
@@ -726,6 +763,7 @@ our %pinfo = (
     },
 
     'archive_crypted_msg' => {
+        order        => 40.03,
         'group'      => 'archives',
         'gettext_id' => "Archive encrypted mails as cleartext",
         'format'     => ['original', 'decrypted'],
@@ -733,6 +771,7 @@ our %pinfo = (
     },
 
     'web_archive_spam_protection' => {
+        order        => 40.04,
         'group'      => 'archives',
         'gettext_id' => "email address protection method",
         'format'     => ['cookie', 'javascript', 'at', 'none'],
@@ -742,6 +781,7 @@ our %pinfo = (
     ### Bounces page ###
 
     'bounce' => {
+        order        => 50.01,
         'group'      => 'bounces',
         'gettext_id' => "Bounces management",
         'format'     => {
@@ -766,6 +806,7 @@ our %pinfo = (
     },
 
     'bouncers_level1' => {
+        order        => 50.02,
         'group'      => 'bounces',
         'gettext_id' => "Management of bouncers, 1st level",
         'format'     => {
@@ -793,6 +834,7 @@ our %pinfo = (
     },
 
     'bouncers_level2' => {
+        order        => 50.03,
         'group'      => 'bounces',
         'gettext_id' => "Management of bouncers, 2nd level",
         'format'     => {
@@ -820,6 +862,7 @@ our %pinfo = (
     },
 
     'verp_rate' => {
+        order        => 50.04,
         'group'      => 'bounces',
         'gettext_id' => "percentage of list members in VERP mode",
         'format' =>
@@ -828,6 +871,7 @@ our %pinfo = (
     },
 
     'tracking' => {
+        order        => 50.05,
         'group'      => 'bounces',
         'gettext_id' => "Message tracking feature",
         'format'     => {
@@ -865,6 +909,7 @@ our %pinfo = (
     },
 
     'welcome_return_path' => {
+        order        => 50.06,
         'group'      => 'bounces',
         'gettext_id' => "Welcome return-path",
         'format'     => ['unique', 'owner'],
@@ -872,6 +917,7 @@ our %pinfo = (
     },
 
     'remind_return_path' => {
+        order        => 50.07,
         'group'      => 'bounces',
         'gettext_id' => "Return-path of the REMIND command",
         'format'     => ['unique', 'owner'],
@@ -881,6 +927,7 @@ our %pinfo = (
     ### Datasources page ###
 
     'inclusion_notification_feature' => {
+        order   => 60.01,
         'group' => 'data_source',
         'gettext_id' =>
             "Notify subscribers when they are included from a data source?",
@@ -890,6 +937,7 @@ our %pinfo = (
     },
 
     'sql_fetch_timeout' => {
+        order          => 60.03,
         'group'        => 'data_source',
         'gettext_id'   => "Timeout for fetch of include_sql_query",
         'gettext_unit' => 'seconds',
@@ -907,6 +955,7 @@ our %pinfo = (
     },
 
     'include_file' => {
+        order        => 60.04,
         'group'      => 'data_source',
         'gettext_id' => "File inclusion",
         'format'     => '\S+',
@@ -915,6 +964,7 @@ our %pinfo = (
     },
 
     'include_remote_file' => {
+        order        => 60.05,
         'group'      => 'data_source',
         'gettext_id' => "Remote file inclusion",
         'format'     => {
@@ -960,6 +1010,7 @@ our %pinfo = (
     },
 
     'include_sympa_list' => {
+        order        => 60.06,
         'group'      => 'data_source',
         'gettext_id' => "List inclusion",
         'format'     => {
@@ -986,6 +1037,7 @@ our %pinfo = (
     },
 
     'include_remote_sympa_list' => {
+        order        => 60.07,
         'group'      => 'data_source',
         'gettext_id' => "remote list inclusion",
         'format'     => {
@@ -1027,6 +1079,7 @@ our %pinfo = (
     },
 
     'member_include' => {
+        order        => 60.02,
         'group'      => 'data_source',
         'gettext_id' => 'Users included from parameterizable data sources',
         'format'     => {
@@ -1047,6 +1100,7 @@ our %pinfo = (
     },
 
     'include_ldap_query' => {
+        order        => 60.08,
         'group'      => 'data_source',
         'gettext_id' => "LDAP query inclusion",
         'format'     => {
@@ -1165,6 +1219,7 @@ our %pinfo = (
     },
 
     'include_ldap_2level_query' => {
+        order        => 60.09,
         'group'      => 'data_source',
         'gettext_id' => "LDAP 2-level query inclusion",
         'format'     => {
@@ -1334,6 +1389,7 @@ our %pinfo = (
     },
 
     'include_sql_query' => {
+        order        => 60.10,
         'group'      => 'data_source',
         'gettext_id' => "SQL query inclusion",
         'format'     => {
@@ -1414,6 +1470,7 @@ our %pinfo = (
     },
 
     'include_voot_group' => {
+        order        => 60.11,
         'group'      => 'data_source',
         'gettext_id' => "VOOT group inclusion",
         'format'     => {
@@ -1446,6 +1503,7 @@ our %pinfo = (
     },
 
     'ttl' => {
+        order          => 60.12,
         'group'        => 'data_source',
         'gettext_id'   => "Inclusions timeout",
         'gettext_unit' => 'seconds',
@@ -1455,6 +1513,7 @@ our %pinfo = (
     },
 
     'distribution_ttl' => {
+        order          => 60.13,
         'group'        => 'data_source',
         'gettext_id'   => "Inclusions timeout for message distribution",
         'gettext_unit' => 'seconds',
@@ -1463,6 +1522,7 @@ our %pinfo = (
     },
 
     'include_ldap_ca' => {
+        order        => 60.14,
         'group'      => 'data_source',
         'gettext_id' => "LDAP query custom attribute",
         'format'     => {
@@ -1587,6 +1647,7 @@ our %pinfo = (
     },
 
     'include_ldap_2level_ca' => {
+        order        => 60.15,
         'group'      => 'data_source',
         'gettext_id' => "LDAP 2-level query custom attribute",
         'format'     => {
@@ -1762,6 +1823,7 @@ our %pinfo = (
     },
 
     'include_sql_ca' => {
+        order        => 60.16,
         'group'      => 'data_source',
         'gettext_id' => "SQL query custom attribute",
         'format'     => {
@@ -1849,6 +1911,7 @@ our %pinfo = (
     ### DKIM page ###
 
     'dkim_feature' => {
+        order        => 70.01,
         'group'      => 'dkim',
         'gettext_id' => "Insert DKIM signature to messages sent to the list",
         'gettext_comment' =>
@@ -1859,6 +1922,7 @@ our %pinfo = (
     },
 
     'dkim_parameters' => {
+        order        => 70.02,
         'group'      => 'dkim',
         'gettext_id' => "DKIM configuration",
         'gettext_comment' =>
@@ -1891,7 +1955,7 @@ our %pinfo = (
                 'format'     => '\S+',
                 'occurrence' => '0-1',
                 #'default'    => {'conf' => 'dkim_header_list'},
-                'obsolete'   => 1,
+                'obsolete' => 1,
             },
             'signer_domain' => {
                 'order' => 5,
@@ -1917,6 +1981,7 @@ our %pinfo = (
     },
 
     'dkim_signature_apply_on' => {
+        order   => 70.03,
         'group' => 'dkim',
         'gettext_id' =>
             "The categories of messages sent to the list that will be signed using DKIM.",
@@ -1933,6 +1998,7 @@ our %pinfo = (
     },
 
     'dmarc_protection' => {
+        order    => 70.04,
         'format' => {
             'mode' => {
                 'format' => [
@@ -2007,6 +2073,7 @@ our %pinfo = (
     },
 
     'clean_delay_queuemod' => {
+        order          => 90.01,
         'group'        => 'other',
         'gettext_id'   => "Expiration of unmoderated messages",
         'gettext_unit' => 'days',
@@ -2016,6 +2083,7 @@ our %pinfo = (
     },
 
     'cookie' => {
+        order        => 90.02,
         'group'      => 'other',
         'gettext_id' => "Secret string for generating unique keys",
         'format'     => '\S+',
@@ -2024,6 +2092,7 @@ our %pinfo = (
     },
 
     'custom_vars' => {
+        order        => 90.04,
         'group'      => 'other',
         'gettext_id' => "custom parameters",
         'format'     => {
@@ -2044,12 +2113,14 @@ our %pinfo = (
     },
 
     'expire_task' => {
+        order        => 90.05,
         'group'      => 'other',
         'gettext_id' => "Periodical subscription expiration task",
         'task'       => 'expire'
     },
 
     'latest_instantiation' => {
+        order        => 99.01,
         'group'      => 'other',
         'gettext_id' => 'Latest family instantiation',
         'format'     => {
@@ -2075,6 +2146,7 @@ our %pinfo = (
     },
 
     'loop_prevention_regex' => {
+        order   => 90.06,
         'group' => 'other',
         'gettext_id' =>
             "Regular expression applied to prevent loops with robots",
@@ -2084,6 +2156,7 @@ our %pinfo = (
     },
 
     'pictures_feature' => {
+        order   => 90.07,
         'group' => 'other',
         'gettext_id' =>
             "Allow picture display? (must be enabled for the current robot)",
@@ -2093,6 +2166,7 @@ our %pinfo = (
     },
 
     'remind_task' => {
+        order        => 90.08,
         'group'      => 'other',
         'gettext_id' => 'Periodical subscription reminder task',
         'task'       => 'remind',
@@ -2100,6 +2174,7 @@ our %pinfo = (
     },
 
     'spam_protection' => {
+        order        => 90.09,
         'group'      => 'other',
         'gettext_id' => "email address protection method",
         'format'     => ['at', 'javascript', 'none'],
@@ -2107,6 +2182,7 @@ our %pinfo = (
     },
 
     'creation' => {
+        order        => 99.02,
         'group'      => 'other',
         'gettext_id' => "Creation of the list",
         'format'     => {
@@ -2133,6 +2209,7 @@ our %pinfo = (
     },
 
     'update' => {
+        order        => 99.03,
         'group'      => 'other',
         'gettext_id' => "Last update of config",
         'format'     => {
@@ -2162,6 +2239,7 @@ our %pinfo = (
     },
 
     'status' => {
+        order        => 99.04,
         'group'      => 'other',
         'gettext_id' => "Status of the list",
         'format' =>
@@ -2171,6 +2249,7 @@ our %pinfo = (
     },
 
     'serial' => {
+        order        => 99.05,
         'group'      => 'other',
         'gettext_id' => "Serial number of the config",
         'format'     => '\d+',
@@ -2180,6 +2259,7 @@ our %pinfo = (
     },
 
     'custom_attribute' => {
+        order        => 90.03,
         'group'      => 'other',
         'gettext_id' => "Custom user attributes",
         'format'     => {
@@ -2232,18 +2312,6 @@ _apply_defaults();
 
 ## Apply defaults to parameters definition (%pinfo)
 sub _apply_defaults {
-    return if exists $default{'order'};    # already loaded
-
-    ## Parameter order
-    foreach my $index (0 .. $#param_order) {
-        if ($param_order[$index] eq '*') {
-            $default{'order'} = $index;
-        } else {
-            $pinfo{$param_order[$index]}{'order'} = $index;
-        }
-    }
-
-    ## Parameters
     foreach my $p (keys %pinfo) {
         cleanup($p, $pinfo{$p});
     }

--- a/src/lib/Sympa/Robot.pm
+++ b/src/lib/Sympa/Robot.pm
@@ -369,7 +369,24 @@ sub list_params {
     my $robot_id = shift;
 
     my $pinfo = Sympa::Tools::Data::clone_var(\%Sympa::ListDef::pinfo);
-    $pinfo->{'lang'}{'format'} = [Sympa::get_supported_languages($robot_id)];
+    $pinfo->{lang}{format} = [Sympa::get_supported_languages($robot_id)];
+
+    my %topics = Sympa::Robot::load_topics($robot_id);
+    my @topics = map {
+        my $topic = $_;
+        if ($topics{$topic}->{sub}) {
+            (   $topic,
+                map { $topic . '/' . $_ } sort keys %{$topics{$topic}->{sub}}
+            );
+        } else {
+            ($topic);
+        }
+    } sort keys %topics;
+    $pinfo->{topics}{format} = [@topics];
+    # Compat.
+    $pinfo->{topics}{file_format} = sprintf '(%s)(,(%s))*',
+        join('|', @topics),
+        join('|', @topics);
 
     return $pinfo;
 }

--- a/src/lib/Sympa/Robot.pm
+++ b/src/lib/Sympa/Robot.pm
@@ -172,8 +172,9 @@ sub update_email_netidmap_db {
     return 1;
 }
 
-## Loads the list of topics if updated
-## FIXME: This might be moved to Robot package.
+# Loads the list of topics if updated.
+# The topic names "others" and "topicsless" are reserved words therefore
+# ignored.  Note: "other" is not reserved and may be used.
 sub load_topics {
     my $robot = shift;
     $log->syslog('debug2', '(%s)', $robot);
@@ -210,7 +211,10 @@ sub load_topics {
         my (@rough_data, $topic);
         while (<FILE>) {
             Encode::from_to($_, $Conf::Conf{'filesystem_encoding'}, 'utf8');
-            if (/^([\-\w\/]+)\s*$/) {
+            if (/\A(others|topicsless)\s*\z/) {
+                # "others" and "topicsless" are reserved words. Ignore.
+                next;
+            } elsif (/^([\-\w\/]+)\s*$/) {
                 $index++;
                 $topic = {
                     'name'  => $1,


### PR DESCRIPTION
Rewriting code for list config semantics.

* New class Sympa::List::Config which may replace aged code.
* wwsympa/edit_list was rewritten along with following bug fixes:
  * Possible crash due to malformed input.
  * Can't remove the value of optional scalar parameter (e.g. custom_subject).
  * LIST-editor address of the list itself can be set as value of editor.email.
  * and several other insignificant bugs.
* Now configuration definition allows recursion with any depth.
* Processing of family constraint became simpler.

Config file parser would be also rewritten using this new class.
