### PR TITLE
[6.2] Rewriting code on list configuration form

### DIFF
--- a/default/web_tt2/copy_template.tt2
+++ b/default/web_tt2/copy_template.tt2
@@ -24,8 +24,9 @@
 [%|loc%](This template is the default for all languages unless it is redefined for a specific language)[%END%]
 [%- ELSE -%]
 <strong class="neutral"
-lang="[%tpl_lang_lang%]" xml:lang="[%tpl_lang_lang%]"
-> [%tpl_lang_title%] </strong>
+ lang="[%tpl_lang_lang%]" xml:lang="[%tpl_lang_lang%]">
+[%~ tpl_lang | optdesc('lang',1) ~%]
+</strong>
 [%- END %] <br />
 
 </fieldset>
@@ -43,7 +44,10 @@ lang="[%tpl_lang_lang%]" xml:lang="[%tpl_lang_lang%]"
 	<option value="default">[%|loc%]default[%END%]</option>
 	[% FOREACH lg = languages %]
         <option lang="[%lg.key%]" xml:lang="[%lg.key%]"
-        value="[%lg.key%]" [% IF tpl_lang_lang == lg.key %]selected[% END %]>[%lg.value.complete%]</option>
+         value="[%lg.key%]"
+         [%~ IF tpl_lang_lang == lg.key %] selected="selected"[% END %]>
+        [%~ lg.key | optdesc('lang') ~%]
+        </option>
 	[%END%]
 	</select><br />
   <label for="list_out">[%|loc%]Enter list name: [%END%] </label><input id="list_out" type="text" name="list_out" size="20" value="[% list %]" /><br />

--- a/default/web_tt2/create_list_request.tt2
+++ b/default/web_tt2/create_list_request.tt2
@@ -39,44 +39,32 @@
 
   <label for="subject">[%|loc%]Subject:[%END%]</label> <input type="text" name="subject" id="subject" size="60" value="[% saved.subject %]" />
 
-[% SET single_topic = "other" %]
-[% FOREACH topic = list_of_topics %]
-  [% IF loop.size > 1 || (topic.key && topic.key != "other") %]
-    [% SET single_topic = "" %]
+[% SET single_topic = 1 ~%]
+[% FOREACH topic = list_of_topics ~%]
+  [% IF loop.size > 1 || (topic.key && topic.key != "other") ~%]
+    [% SET single_topic = 0 ~%]
     [% LAST %]
-  [% ELSIF topic.value.sub %]
-    [% FOREACH subtopic = topic.value.sub %]
-      [% SET single_topic = "" %]
-      [% LAST %]
-    [% END %]
-  [% END %]
-[% END %]
-[% IF single_topic != "" %]
-  <input id="topics" name="topics" type="hidden" value="[% single_topic %]" />
-[% ELSE %]
+  [%~ END ~%]
+[%~ END ~%]
+[% IF single_topic ~%]
+  <input id="topics" name="topics" type="hidden" value="other" />
+[%~ ELSE ~%]
   <label for="topics">[%|loc%]Audience:[%END%]</label>
-    <select id="topics" name="topics">
-	<option value="">[%|loc%]-- Select an Audience --[%END%]</option>
-	[% SET topic_other = 0 %]
-	[% FOREACH topic = list_of_topics %]
-	  [% IF topic.key == "other" %][% SET topic_other = 1 %][% END %]
-	  <option value="[% topic.key %]"
-	  [% IF topic.value.selected %]
-	    selected="selected"
-	  [% END %]
-	  >[% topic.value.current_title %]</option>
-	  [% IF topic.value.sub %]
-	  [% FOREACH subtopic = topic.value.sub %]
-	     <option value="[% topic.key %]/[% subtopic.key %]">[% topic.value.current_title %] / [% subtopic.value.current_title %]</option>
-	  [% END %]
-	  [% END %]
-	[% END %]
-	[% UNLESS topic_other %]
-	<option value="other">[%|loc%]Other[%END%]</option>
-	[% END %]
-     </select>
-   <br />
-[% END %]
+  <select id="topics" name="topics">
+  <option value="">[%|loc%]-- Select an Audience --[%END%]</option>
+  [% FOREACH topic = list_of_topics ~%]
+    [% IF topic.key == "other" ~%]
+      [% NEXT %]
+    [%~ END ~%]
+    <option value="[% topic.key %]"
+     [%~ IF topic.value.selected %] selected="selected"[% END %]>
+    [%~ topic.key | optdesc('listtopic') ~%]
+    </option>
+  [% END %]
+  <option value="other">[%|loc%]Other[%END%]</option>
+  </select>
+  <br />
+[%~ END %]
 
    <label for="info" class="align_top">[%|loc%]Description:[%END%]</label><textarea class="desc" id="info" name="info" rows="10" cols="80">[% saved.info %]</textarea>
    <input class="MainMenuLinks" type="submit" name="action_create_list" value="[%|loc%]Submit your creation request[%END%]" />

--- a/default/web_tt2/css.tt2
+++ b/default/web_tt2/css.tt2
@@ -1124,6 +1124,7 @@ table td.review_cels_mail {
     font-size:1rem;
 }
 
+[%# No longer used.
 .edit_list_request_enum{ 
 	margin: 0 0 1rem;
 	padding-left: 1em;
@@ -1131,17 +1132,22 @@ table td.review_cels_mail {
 	font-size: 1em;
 }
 
+~%]
+[%# No longer used.
 .edit_list_request_enum span.divider:first-child { 
 	display:none;
 }
+~%]
 
+[%# No longer used.
  /*.edit_list_request_enum label{
 	display: block;
 	float: left;
 	width: 150px;
 }
 */
-                         
+~%]
+
 .list_admin { 
 	font-size: 1em;
 }

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -150,11 +150,11 @@
                                            [%~ END %]
                                            name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]" value="[% key.value %]" size="[% key.length %]" />
                                         [% ELSIF key.may_edit == 'read' %]
-                                          [% IF key.field_type == 'password' %]
-                                            [% key.hidden_field %]
-                                          [% ELSE %]
+                                          [% IF key.field_type == 'password' ~%]
+                                            [% x = '*'; x.repeat(key.value.length()) %]
+                                          [%~ ELSE ~%]
                                             [% key.value %]
-                                          [% END %]
+                                          [%~ END %]
                                         [% END %]
                                         [% key.unit %]
                                       [% END %]
@@ -164,9 +164,17 @@
                             [% ELSE %]
                               <!-- Scalar -->
                                   [% IF p.may_edit == 'write' %]
-                                    <input type="text" name="single_param.[% p.name %].[% o_INDEX %]" id="param.[% p.name %].[% o_INDEX %]" value="[% o.value %]" size="[% o.length %]" />
+                                    <input
+                                     [%~ IF p.field_type == 'password' %] type="password"
+                                     [%~ ELSE %] type="text"
+                                     [%~ END %]
+                                     name="single_param.[% p.name %].[% o_INDEX %]" id="param.[% p.name %].[% o_INDEX %]" value="[% o.value %]" size="[% o.length %]" />
                                   [% ELSIF p.may_edit == 'read' %]
-                                    [% o.value %]
+                                    [% IF p.field_type == 'password' ~%]
+                                      [% x = '*'; x.repeat(o.value.length()) %]
+                                    [%~ ELSE ~%]
+                                      [% o.value %]
+                                    [%~ END %]
                                   [% END %]
                                   [% o.unit %]
                             [% END %]
@@ -358,9 +366,17 @@
                                       [% ELSE %]
                                         <!-- Scalar -->
                                         [% IF key.may_edit == 'write' %]
-                                          <input type="text" name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" value="[% key.value %]" size="[% key.length %]" />
+                                          <input
+                                           [%~ IF key.field_type == 'password' %] type="password"
+                                           [%~ ELSE %] type="text"
+                                           [%~ END %]
+                                           name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" value="[% key.value %]" size="[% key.length %]" />
                                         [% ELSIF key.may_edit == 'read' %]
-                                          [% key.value %]
+                                          [% IF key.field_type == 'password' ~%]
+                                            [% x = '*'; x.repeat(key.value.length()) %]
+                                          [%~ ELSE ~%]
+                                            [% key.value %]
+                                          [%~ END %]
                                         [% END %]
                                         [% key.unit %]
 
@@ -408,9 +424,17 @@
                           [% ELSE %]
                             <!-- Scalar -->
                             [% IF p.may_edit == 'write' %]
-                              <input type="text" name="single_param.[% p.name %]" id="param.[% p.name %]" value="[% p.value %]" size="[% p.length %]" />
+                              <input
+                               [%~ IF p.field_type == 'password' %] type="password"
+                               [%~ ELSE %] type="text"
+                               [%~ END %]
+                               name="single_param.[% p.name %]" id="param.[% p.name %]" value="[% p.value %]" size="[% p.length %]" />
                             [% ELSIF p.may_edit == 'read' %]
-                              [% p.value %]
+                              [% IF p.field_type == 'password' ~%]
+                                [% x = '*'; x.repeat(p.value.length()) %]
+                              [%~ ELSE ~%]
+                                [% p.value %]
+                              [%~ END %]
                             [% END %]
                             [% p.unit %]
                           [% END %]

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -3,490 +3,390 @@
 
 <h2>[%|loc%]Edit List Configuration[%END%] <a  href="[% 'nomenu/help/listconfig' | url_rel %]" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=800,height=400')" target="wws_help"><i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i></a></h2>
 
-[% IF !group %]
-  [% IF GROUP == 'description' %][% SET class = 'menuLinksCurrentPage' %][% ELSE %][% SET class = 'menuLinks' %][% END %]
+[% IF !group ~%]
+  [% IF GROUP == 'description' ~%]
+    [% SET class = 'menuLinksCurrentPage' %]
+  [%~ ELSE ~%]
+    [% SET class = 'menuLinks' %]
+  [%~ END ~%]
   <p>[%|loc%]Here you can edit your list's configuration parameters.[% END %]</p>
-[% ELSE %]
+[%~ ELSE ~%]
   <form class="bold_label"  action="[% path_cgi %]" method="post">
-    <fieldset>
-      <input type="hidden" name="serial" value="[% serial %]" />
-      [% FOREACH p = param %]
-
-        [% IF p.may_edit != 'hidden' %]
-
-          [% IF p.changed == '1' %]
-            <div class="CurrentBlock">
-          [% ELSE %]
-            <div class="block">
-          [% END %]
-
-          <h4>
-          [% IF p.title %]
-            [% p.title %]
-            [% IF is_listmaster %]
-              ([% p.name %])
-            [% END %]
-          [% ELSE %]
-            [% p.name %]
-          [% END %]
-          [% IF is_listmaster %]
-            [% IF p.default == '1' %]
-              [%|loc%](default)[%END%]
-            [% END %]
-          [% END %]
-          <span class="edit_list_request_help">
-          [% IF p.type == 'scenario' %]
-            [% IF is_listmaster %]
-              &nbsp;<a class="input" href="[% 'dump_scenario' | url_rel([list,p.name]) %]" title="[%|loc%]scenario source[%END%]">[%|loc%]scenario source[%END%]</a>
-            [% END %]
-          [% END %]
-          <a  href="[% 'nomenu/help/editlist' | url_rel %]#[% p.name %]" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=800,height=400')" target="wws_help"><i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i></a>
-          </span>
-          </h4>
-
-          <div class="edit_list_request_enum">
-
-                    [% IF p.occurrence == 'multiple' %]
-                      <!-- Multiple params -->
-
-                      [% IF p.type == 'enum' %]
-                          <!-- set -->[% ppaths = [p.name]; pitem = p; val = p.value %]
-                          [% IF pitem.may_edit == 'write' %]
-                            <select name="multiple_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]" multiple="multiple" size="[% val.size %]"
-                             [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
-                            [% FOREACH enum = val ~%]
-                              <option value="[% enum.key %]"
-                               [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
-                               [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[% END %]>
-                              [%~ IF enum.value.title ~%]
-                                [% enum.value.title %]
-                              [%~ ELSE ~%]
-                                [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-                              [%~ END ~%]
-                              </option>
-                            [% END %]
-                            </select>
-                          [% ELSIF pitem.may_edit == 'read' %]
-                            [% FOREACH enum = val ~%]
-                              [% IF enum.value.selected == '1' ~%]
-                                [%~ IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
-                                [% IF enum.value.title ~%]
-                                  [% enum.value.title %]
-                                [%~ ELSE ~%]
-                                  [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-                                [%~ END %]
-                                [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
-                              [%~ END %]
-                            [%~ END %]
-                          [% END %]
-                          <!-- end set -->
-                      [% ELSE %]
-                        [% o_INDEX = 0 %]
-                        [% FOREACH o = p.value %]
-
-                          <!-- Foreach occurrence -->
-
-                            [% IF p.type == 'paragraph' %]
-                              <!-- ParagrapH -->
-                                 <span class="divider"></span>
-                              [% FOREACH key = o.value %]
-
-                                [% IF key.may_edit != 'hidden' %] 
-
-                                      <label for="param.[% p.name %].[% o_INDEX %].[% key.name %]">
-                                        [% IF key.title %]
-                                          [% key.title %][% IF is_listmaster %] ([% key.name %])[% END %][%|loc%]:[%END%]
-                                        [% ELSE %]
-                                          [% key.name %][%|loc%]:[%END%]
-                                        [% END %]
-                                      </label>
-
-                                      [% IF key.type == 'enum' %]
-                                        <!-- enum -->[% ppaths = [p.name,o_INDEX,key.name]; pitem = key; val = key.value %]
-                                        [% IF pitem.may_edit == 'write' %]
-                                          <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
-                                           [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
-                                          [% FOREACH enum = val ~%]
-                                            <option value="[% enum.key %]"
-                                             [%~ IF enum.value.selected == '1' %] selected="selected"[% END ~%]
-                                             [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
-                                            [%~ IF enum.value.title ~%]
-                                              [% enum.value.title %]
-                                            [%~ ELSE ~%]
-                                              [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-                                            [%~ END ~%]
-                                            </option>
-                                          [% END %]
-                                          </select>
-                                        [% ELSIF pitem.may_edit == 'read' %]
-                                          [% FOREACH enum = val ~%]
-                                            [% IF enum.value.selected == '1' ~%]
-                                              [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
-                                              [% IF enum.value.title ~%]
-                                                [% enum.value.title %]
-                                              [%~ ELSE ~%]
-                                                [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-                                              [%~ END %]
-                                              [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
-                                            [%~ END %]
-                                          [%~ END %]
-                                        [% END %]
-                                        <!-- end enum -->
-                                      [% ELSIF key.type == 'datasource' %]
-                                        <!-- datasource -->[% ppaths = [p.name,o_INDEX,key.name]; pitem = key; val = key.value %]
-                                        [% IF pitem.may_edit == 'write' %]
-                                          <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]">
-                                          [% FOREACH source = val ~%]
-                                            <option value="[% source.value.name %]"
-                                             [%~ IF source.value.selected == '1' %] selected="selected"[% END %]>
-                                            [%~ source.value.title %] ([% source.value.name %])</option>
-                                          [% END %]
-                                          </select>
-                                        [% ELSIF pitem.may_edit == 'read' %]
-                                          [% FOREACH source = val ~%]
-                                            [% IF source.value.selected == '1' ~%]
-                                              [% source.value.title %] ([% source.value.name %])
-                                            [%~ END %]
-                                          [%~ END %]
-                                        [% END %]
-                                        <!-- end datasource -->
-                                      [% ELSE %]
-                                        <!-- scalar -->[% ppaths = [p.name,o_INDEX,key.name]; pitem = key; val = key.value %]
-                                        [% IF pitem.may_edit == 'write' %]
-                                          <input name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
-                                           value="[% val %]" size="[% pitem.length %]"
-                                           [%~ IF pitem.field_type == 'password' %] type="password"
-                                           [%~ ELSE %] type="text"
-                                           [%~ END %]
-                                           [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %] />
-                                        [% ELSIF pitem.may_edit == 'read' %]
-                                          [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%val%]" xml:lang="[%val%]">[% END ~%]
-                                          [% IF pitem.field_type ~%]
-                                            [% val | optdesc(pitem.field_type,is_listmaster) %]
-                                          [%~ ELSE ~%]
-                                            [% val %]
-                                          [%~ END %]
-                                          [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
-                                        [% END %]
-                                        [% pitem.unit %]
-                                        <!-- end scalar -->
-                                      [% END %]
-                                  
-                                [% END %]
-                              [% END %]
-                            [% ELSE %]
-                                  <!-- scalar -->[% ppaths = [p.name,o_INDEX]; pitem = p; val = o.value %]
-                                  [% IF pitem.may_edit == 'write' %]
-                                    <input name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
-                                     value="[% val %]" size="[% pitem.length %]"
-                                     [%~ IF pitem.field_type == 'password' %] type="password"
-                                     [%~ ELSE %] type="text"
-                                     [%~ END %]
-                                     [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %] />
-                                  [% ELSIF pitem.may_edit == 'read' %]
-                                    [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%val%]" xml:lang="[%val%]">[% END ~%]
-                                    [% IF pitem.field_type ~%]
-                                      [% val | optdesc(pitem.field_type,is_listmaster) %]
-                                    [%~ ELSE ~%]
-                                      [% val %]
-                                    [%~ END %]
-                                    [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
-                                  [% END %]
-                                  [% pitem.unit %]
-                                  <!-- end scalar -->
-                            [% END %]
-                            [% o_INDEX = o_INDEX + 1 %]
-                          [% END %]
-                          <!-- END Foreach occurrence -->
-                        [%END%]
-
-                        <!-- ENDIF Enum -->
-
-                      [% ELSE %]
-                        <!-- Single params -->
-                          [% IF p.type == 'scenario' %]
-                            <!-- scenario -->[% ppaths = [p.name]; pitem = p; val = p.value %]
-                            [% IF pitem.may_edit == 'write' %]
-                              <select name="single_param.[% ppaths.join('.') %].name" id="param.[% ppaths.join('.') %]">
-                                [% FOREACH scenario = val ~%]
-                                  [% UNLESS scenario.value.name == 'default' ~%]
-                                    <option value="[% scenario.value.name %]"
-                                     [%~ IF scenario.value.selected == '1' %] selected="selected"[% END %]>
-                                    [% scenario.value.web_title %] ([% scenario.value.name %])</option>
-                                  [%~ END %]
-                                [% END %]
-                              </select>
-                            [% ELSIF pitem.may_edit == 'read' %]
-                              [% FOREACH scenario = val ~%]
-                                [% IF scenario.value.selected == '1' ~%]
-                                  [% scenario.value.web_title %] ([% scenario.value.name %])
-                                [%~ END %]
-                              [%~ END %]
-                            [% END %]
-                            <!-- end scenario -->
-                          [% ELSIF p.type == 'task' %]
-                            <!-- task -->[% ppaths = [p.name]; pitem = p; val = p.value %]
-                            [% IF pitem.may_edit == 'write' %]
-                              <select name="single_param.[% ppaths.join('.') %].name" id="param.[% ppaths.join('.') %]">
-                              [% FOREACH task = val ~%]
-                                <option value="[% task.value.name %]"
-                                 [%~ IF task.value.selected == '1' %] selected="selected"[% END %]>
-                                [%~ task.value.title %] ([% task.value.name %])</option>
-                              [% END %]
-                              </select>
-                            [% ELSIF pitem.may_edit == 'read' %]
-                              [% FOREACH task = val ~%]
-                                [% IF task.value.selected == '1' ~%]
-                                  [% task.value.title %] ([% task.value.name %])
-                                [%~ END %]
-                              [%~ END %]
-                            [% END %]
-                            <!-- end task -->
-                          [% ELSIF p.type == 'datasource' %]
-                            <!-- datasource -->[% ppaths = [p.name]; pitem = p; val = p.value %]
-                            [% IF pitem.may_edit == 'write' %]
-                              <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]">
-                              [% FOREACH source = val ~%]
-                                <option value="[% source.value.name %]"
-                                 [%~ IF source.value.selected == '1' %] selected="selected"[% END %]>
-                                [%~ source.value.title %] ([% source.value.name %])</option>
-                              [% END %]
-                              </select>
-                            [% ELSIF pitem.may_edit == 'read' %]
-                              [% FOREACH source = val ~%]
-                                [% IF source.value.selected == '1' ~%]
-                                  [% source.value.title %] ([% source.value.name %])
-                                [%~ END %]
-                              [%~ END %]
-                            [% END %]
-                            <!-- end datasource -->
-                          [% ELSIF p.type == 'paragraph' %]
-                              <!-- Paragraph -->
-                              [% FOREACH key = p.value %]
-                                [% IF key.may_edit != 'hidden' %] 
-                                      <label for="param.[% p.name %].[% key.name %]">
-                                        [% IF key.title %]
-                                          [% key.title %][% IF is_listmaster %] ([% key.name %])[% END %][%|loc%]:[%END%]
-                                        [% ELSE %]
-                                          [% key.name %][%|loc%]:[%END%]
-                                        [% END %]
-                                      </label>
-
-                                      [% IF key.type == 'scenario' %]
-                                        <!-- scenario -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
-                                        [% IF pitem.may_edit == 'write' %]
-                                          <select name="single_param.[% ppaths.join('.') %].name" id="param.[% ppaths.join('.') %]">
-                                          [% FOREACH scenario = val ~%]
-                                            [% UNLESS scenario.value.name == 'default' ~%]
-                                              <option value="[% scenario.value.name %]"
-                                               [%~ IF scenario.value.selected == '1' %] selected="selected"[% END %]>
-                                              [%~ scenario.value.web_title %] ([% scenario.value.name %])</option>
-                                            [%~ END %]
-                                          [% END %]
-                                          </select>
-                                        [% ELSIF pitem.may_edit == 'read' %]
-                                          [% FOREACH scenario = val ~%]
-                                            [% IF scenario.value.selected == '1' ~%]
-                                              [% scenario.value.web_title %] ([% scenario.value.name %])
-                                            [%~ END %]
-                                          [%~ END %]
-                                        [% END %]
-                                        <!-- end scenario -->
-                                      [% ELSIF key.type == 'task' %]
-                                        <!-- task -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
-                                        [% IF pitem.may_edit == 'write' %]
-                                          <select name="single_param.[% ppaths.join('.') %].name" id="param.[% ppaths.join('.') %]">
-                                          [% FOREACH task = val ~%]
-                                            <option value="[% task.value.name %]"
-                                            [%~ IF task.value.selected == '1' %] selected="selected"[% END %]>
-                                            [%~ task.value.title %] ([% task.value.name %])</option>
-                                          [% END %]
-                                          </select>
-                                        [% ELSIF pitem.may_edit == 'read' %]
-                                          [% FOREACH task = val ~%]
-                                            [% IF task.value.selected == '1' ~%]
-                                              [% task.value.title %] ([% task.value.name %])
-                                            [%~ END %]
-                                          [%~ END %]
-                                        [% END %]
-                                        <!-- end task -->
-                                      [% ELSIF key.type == 'datasource' %]
-                                        <!-- datasource -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
-                                        [% IF pitem.may_edit == 'write' %]
-                                          <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]">
-                                          [% FOREACH source = val ~%]
-                                            <option value="[% source.value.name %]"
-                                             [%~ IF source.value.selected == '1' %] selected="selected"[% END %]>
-                                            [%~ source.value.title %] ([% source.value.name %])</option>
-                                          [% END %]
-                                          </select>
-                                        [% ELSIF pitem.may_edit == 'read' %]
-                                          [% FOREACH source = val ~%]
-                                            [% IF source.value.selected == '1' ~%]
-                                              [% source.value.title %] ([% source.value.name %])
-                                            [%~ END %]
-                                          [%~ END %]
-                                        [% END %]
-                                        <!-- end datasource -->
-                                      [% ELSIF key.type == 'enum' %]
-                                        [% IF key.occurrence == 'multiple' %]
-                                          <!-- set -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
-                                          [% IF pitem.may_edit == 'write' %]
-                                            <select name="multiple_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]" multiple="multiple" size="[% val.size %]"
-                                             [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
-                                            [% FOREACH enum = val ~%]
-                                              <option value="[% enum.key %]"
-                                               [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
-                                               [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
-                                              [%~ IF enum.value.title ~%]
-                                                [% enum.value.title %]
-                                              [%~ ELSE ~%]
-                                                [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-                                              [%~ END ~%]
-                                              </option>
-                                            [% END %]
-                                            </select>
-                                          [% ELSIF pitem.may_edit == 'read' %]
-                                            [% FOREACH enum = val ~%]
-                                              [% IF enum.value.selected == '1' ~%]
-                                                [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
-                                                [%~ IF enum.value.title ~%]
-                                                  [% enum.value.title %]
-                                                [%~ ELSE ~%]
-                                                  [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-                                                [%~ END %]
-                                                [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
-                                              [%~ END %]
-                                            [% END %]
-                                          [% END %]
-                                          <!-- end set -->
-                                        [% ELSE %]
-                                          <!-- enum -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
-                                          [% IF pitem.may_edit == 'write' %]
-                                            <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
-                                             [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
-                                            [% FOREACH enum = val ~%]
-                                              <option value="[% enum.key %]"
-                                               [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
-                                               [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
-                                              [%~ IF enum.value.title ~%]
-                                                [% enum.value.title %]
-                                              [%~ ELSE ~%]
-                                                [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-                                              [%~ END ~%]
-                                              </option>
-                                            [% END %]
-                                            </select>
-                                          [% ELSIF pitem.may_edit == 'read' %]
-                                            [% FOREACH enum = val ~%]
-                                              [% IF enum.value.selected == '1' ~%]
-                                                [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
-                                                [% IF enum.value.title ~%]
-                                                  [% enum.value.title %]
-                                                [%~ ELSE ~%]
-                                                  [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-                                                [%~ END %]
-                                                [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
-                                              [%~ END %]
-                                            [%~ END %]
-                                          [% END %]
-                                          <!-- end enum -->
-                                        [% END %]
-                                      [% ELSE %]
-                                        <!-- scalar -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
-                                        [% IF pitem.may_edit == 'write' %]
-                                          <input name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
-                                           value="[% val %]" size="[% pitem.length %]"
-                                           [%~ IF pitem.field_type == 'password' %] type="password"
-                                           [%~ ELSE %] type="text"
-                                           [%~ END %]
-                                           [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %] />
-                                        [% ELSIF pitem.may_edit == 'read' %]
-                                          [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%val%]" xml:lang="[%val%]">[% END ~%]
-                                          [% IF pitem.field_type ~%]
-                                            [% val | optdesc(pitem.field_type,is_listmaster) %]
-                                          [%~ ELSE ~%]
-                                            [% val %]
-                                          [%~ END %]
-                                          [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
-                                        [% END %]
-                                        [% pitem.unit %]
-                                        <!-- end scalar -->
-                                      [% END %]
-                              [% END %]
-                            [% END %]
-                          [% ELSIF p.type == 'enum' %]
-                            <!-- enum -->[% ppaths = [p.name]; pitem = p; val = p.value %]
-                            [% IF pitem.may_edit == 'write' %]
-                              <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
-                               [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
-                              [% FOREACH enum = val ~%]
-                                <option value="[% enum.key %]"
-                                 [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
-                                 [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
-                                [%~ IF enum.value.title ~%]
-                                  [% enum.value.title %]
-                                [%~ ELSE ~%]
-                                  [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-                                [%~ END ~%]
-                                </option>
-                              [% END %]
-                              </select>
-                            [% ELSIF pitem.may_edit == 'read' %]
-                              [% FOREACH enum = val ~%]
-                                [% IF enum.value.selected == '1' ~%]
-                                  [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
-                                  [% IF enum.value.title ~%]
-                                    [% enum.value.title %]
-                                  [%~ ELSE ~%]
-                                    [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-                                  [%~ END %]
-                                  [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
-                                [%~ END %]
-                              [%~ END %]
-                            [% END %]
-                            <!-- end enum -->
-                          [% ELSE %]
-                            <!-- scalar -->[% ppaths = [p.name]; pitem = p; val = p.value %]
-                            [% IF pitem.may_edit == 'write' %]
-                              <input name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
-                               value="[% val %]" size="[% pitem.length %]"
-                               [%~ IF pitem.field_type == 'password' %] type="password"
-                               [%~ ELSE %] type="text"
-                               [%~ END %]
-                               [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %] />
-                            [% ELSIF pitem.may_edit == 'read' %]
-                              [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[% val %]" xml:lang="[% val %]">[% END ~%]
-                              [% IF pitem.field_type ~%]
-                                [% val | optdesc(pitem.field_type,is_listmaster) %]
-                              [%~ ELSE ~%]
-                                [% val %]
-                              [%~ END %]
-                              [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
-                            [% END %]
-                            [% pitem.unit %]
-                            <!-- end scalar -->
-                          [% END %]
-
-                      [% END %]
-          </div>[%# class="edit_list_request_enum" #%]
-          [% IF p.default == '1' %]
-            <div class="default" style="clear: both;"><span>[%|loc%]default[%END%]</span></div>
-          [% END %]
-
-          </div>
+  <fieldset>
+  <input type="hidden" name="serial" value="[% serial %]" />
+  [% FOREACH p = param %]
+    [% IF p.may_edit != 'hidden' %]
+      [% IF p.changed == '1' %]
+        <div class="CurrentBlock">
+      [% ELSE %]
+        <div class="block">
+      [% END %]
+      <h4>
+      [% IF p.title %]
+        [% p.title %]
+        [% IF is_listmaster %]
+          ([% p.name %])
+        [% END %]
+      [% ELSE %]
+        [% p.name %]
+      [% END %]
+      [% IF is_listmaster %]
+        [% IF p.default == '1' %]
+          [%|loc%](default)[%END%]
         [% END %]
       [% END %]
-
-      <input type="hidden" name="list" value="[% list %]" />
-      <input type="hidden" name="group" value="[% group %]" />
-      <input type="hidden" name="action" value="edit_list" />
-      [% IF is_form_editable == '1' %]
-        <input class="MainMenuLinks" type="submit" name="action_edit_list" value="[%|loc%]Update[%END%]" />
+      <span class="edit_list_request_help">
+      [% IF p.type == 'scenario' %]
+        [% IF is_listmaster %]
+          &nbsp;<a class="input" href="[% 'dump_scenario' | url_rel([list,p.name]) %]" title="[%|loc%]scenario source[%END%]">[%|loc%]scenario source[%END%]</a>
+        [% END %]
       [% END %]
-    </fieldset>
+      <a  href="[% 'nomenu/help/editlist' | url_rel %]#[% p.name %]" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=800,height=400')" target="wws_help"><i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i></a>
+      </span>
+      </h4>
+
+      <div class="edit_list_request_enum">
+      [% IF p.occurrence == 'multiple' %]
+
+        <!-- Multiple params -->
+        [% IF p.type == 'enum' %]
+          [% PROCESS EditListSet 
+             ppaths=[p.name]
+             pitem=p
+             val=p.value
+          %]
+        [% ELSE %]
+          [% o_INDEX = 0 %]
+        [% FOREACH o = p.value %]
+
+          <!-- Foreach occurrence -->
+            [% IF p.type == 'paragraph' %]
+
+              <!-- ParagrapH -->
+              <span class="divider"></span>
+              [% FOREACH key = o.value %]
+                [% IF key.may_edit != 'hidden' %] 
+                  <label for="param.[% p.name %].[% o_INDEX %].[% key.name %]">
+                  [% IF key.title %]
+                    [% key.title %][% IF is_listmaster %] ([% key.name %])[% END %][%|loc%]:[%END%]
+                  [% ELSE %]
+                    [% key.name %][%|loc%]:[%END%]
+                  [% END %]
+                  </label>
+
+                  [% IF key.type == 'enum' %]
+                    [% PROCESS EditListEnum 
+                       ppaths=[p.name,o_INDEX,key.name]
+                       pitem=key
+                       val=key.value
+                    %]
+                  [% ELSIF key.type == 'datasource' %]
+                    [% PROCESS EditListDatasource 
+                       ppaths=[p.name,o_INDEX,key.name]
+                       pitem=key
+                       val=key.value
+                    %]
+                  [% ELSE %]
+                    [% PROCESS EditListScalar 
+                       ppaths=[p.name,o_INDEX,key.name]
+                       pitem=key
+                       val=key.value
+                    %]
+                  [% END %]
+                [% END %]
+              [% END %]
+            [% ELSE %]
+              [% PROCESS EditListScalar 
+                 ppaths=[p.name,o_INDEX]
+                 pitem=p
+                 val=o.value
+              %]
+            [% END %]
+            [% o_INDEX = o_INDEX + 1 %]
+          [% END %]
+          <!-- END Foreach occurrence -->
+        [%END%]
+        <!-- ENDIF Enum -->
+      [% ELSE %]
+
+        <!-- Single params -->
+        [% IF p.type == 'scenario' %]
+          [% PROCESS EditListScenario 
+             ppaths=[p.name]
+             pitem=p
+             val=p.value
+          %]
+        [% ELSIF p.type == 'task' %]
+          [% PROCESS EditListTask 
+             ppaths=[p.name]
+             pitem=p
+             val=p.value
+          %]
+        [% ELSIF p.type == 'datasource' %]
+          [% PROCESS EditListDatasource 
+             ppaths=[p.name]
+             pitem=p
+             val=p.value
+          %]
+        [% ELSIF p.type == 'paragraph' %]
+
+          <!-- Paragraph -->
+          [% FOREACH key = p.value %]
+            [% IF key.may_edit != 'hidden' %] 
+              <label for="param.[% p.name %].[% key.name %]">
+              [% IF key.title %]
+                [% key.title %][% IF is_listmaster %] ([% key.name %])[% END %][%|loc%]:[%END%]
+              [% ELSE %]
+                [% key.name %][%|loc%]:[%END%]
+              [% END %]
+              </label>
+
+              [% IF key.type == 'scenario' %]
+                [% PROCESS EditListScenario 
+                   ppaths=[p.name,key.name]
+                   pitem=key
+                   val=key.value
+                %]
+              [% ELSIF key.type == 'task' %]
+                [% PROCESS EditListTask 
+                   ppaths=[p.name,key.name]
+                   pitem=key
+                   val=key.value
+                %]
+              [% ELSIF key.type == 'datasource' %]
+                [% PROCESS EditListDatasource 
+                   ppaths=[p.name,key.name]
+                   pitem=key
+                   val=key.value
+                %]
+              [% ELSIF key.type == 'enum' %]
+                [% IF key.occurrence == 'multiple' %]
+                  [% PROCESS EditListSet 
+                     ppaths=[p.name,key.name]
+                     pitem=key
+                     val=key.value
+                  %]
+                [% ELSE %]
+                  [% PROCESS EditListEnum 
+                     ppaths=[p.name,key.name]
+                     pitem=key
+                     val=key.value
+                  %]
+                [% END %]
+              [% ELSE %]
+                [% PROCESS EditListScalar 
+                   ppaths=[p.name,key.name]
+                   pitem=key
+                   val=key.value
+                %]
+              [% END %]
+            [% END %]
+          [% END %]
+        [% ELSIF p.type == 'enum' %]
+          [% PROCESS EditListEnum 
+             ppaths=[p.name]
+             pitem=p
+             val=p.value
+          %]
+        [% ELSE %]
+          [% PROCESS EditListScalar 
+             ppaths=[p.name]
+             pitem=p
+             val=p.value
+          %]
+        [% END %]
+      [% END %]
+      </div>[%# class="edit_list_request_enum" #%]
+
+      [% IF p.default == '1' %]
+        <div class="default" style="clear: both;"><span>[%|loc%]default[%END%]</span></div>
+      [% END %]
+      </div>
+    [% END %]
+  [% END %]
+
+  <input type="hidden" name="list" value="[% list %]" />
+  <input type="hidden" name="group" value="[% group %]" />
+  <input type="hidden" name="action" value="edit_list" />
+  [% IF is_form_editable == '1' %]
+    <input class="MainMenuLinks" type="submit" name="action_edit_list"
+     value="[%|loc%]Update[%END%]" />
+  [% END %]
+  </fieldset>
   </form>
-[% END %]
+[%~ END %]
 
 </div >
+
+[%# Block definitions ~%]
+
+[%~ BLOCK EditListSet ~%]
+  <!-- set -->[%# ppaths,pitem,val %]
+  [% IF pitem.may_edit == 'write' %]
+    <select name="multiple_param.[% ppaths.join('.') %]"
+     id="param.[% ppaths.join('.') %]"
+     multiple="multiple" size="[% val.size %]"
+     [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
+    [% FOREACH enum = val ~%]
+      <option value="[% enum.key %]"
+       [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
+       [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[% END %]>
+      [%~ IF enum.value.title ~%]
+        [% enum.value.title %]
+      [%~ ELSE ~%]
+        [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
+      [%~ END ~%]
+      </option>
+    [% END %]
+    </select>
+  [% ELSIF pitem.may_edit == 'read' %]
+    [% FOREACH enum = val ~%]
+      [% IF enum.value.selected == '1' ~%]
+        [%~ IF pitem.field_type == 'lang' ~%]
+          <span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">
+        [%~ END ~%]
+        [% IF enum.value.title ~%]
+          [% enum.value.title %]
+        [%~ ELSE ~%]
+          [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
+        [%~ END %]
+        [%~ IF pitem.field_type == 'lang' ~%]
+          </span>
+        [%~ END %]
+      [%~ END %]
+    [%~ END %]
+  [% END %]
+  <!-- end set -->
+[%~ END ~%]
+
+[%~ BLOCK EditListEnum ~%]
+  <!-- enum -->[%# ppaths, pitem, val %]
+  [% IF pitem.may_edit == 'write' %]
+    <select name="single_param.[% ppaths.join('.') %]"
+     id="param.[% ppaths.join('.') %]"
+     [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
+    [% FOREACH enum = val ~%]
+      <option value="[% enum.key %]"
+       [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
+       [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
+      [%~ IF enum.value.title ~%]
+        [% enum.value.title %]
+      [%~ ELSE ~%]
+        [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
+      [%~ END ~%]
+      </option>
+    [% END %]
+    </select>
+  [% ELSIF pitem.may_edit == 'read' %]
+    [% FOREACH enum = val ~%]
+      [% IF enum.value.selected == '1' ~%]
+        [% IF pitem.field_type == 'lang' ~%]
+          <span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">
+        [%~ END ~%]
+        [% IF enum.value.title ~%]
+          [% enum.value.title %]
+        [%~ ELSE ~%]
+          [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
+        [%~ END %]
+        [%~ IF pitem.field_type == 'lang' ~%]
+          </span>
+        [%~ END %]
+      [%~ END %]
+    [%~ END %]
+  [% END %]
+  <!-- end enum -->
+[%~ END ~%]
+
+[%~ BLOCK EditListScenario ~%]
+  <!-- scenario -->[%# ppaths, pitem, val %]
+  [% IF pitem.may_edit == 'write' %]
+    <select name="single_param.[% ppaths.join('.') %].name"
+     id="param.[% ppaths.join('.') %]">
+    [% FOREACH scenario = val ~%]
+      [% UNLESS scenario.value.name == 'default' ~%]
+        <option value="[% scenario.value.name %]"
+         [%~ IF scenario.value.selected == '1' %] selected="selected"[% END %]>
+        [%~ scenario.value.web_title %] ([% scenario.value.name %])</option>
+      [%~ END %]
+    [% END %]
+    </select>
+  [% ELSIF pitem.may_edit == 'read' %]
+    [% FOREACH scenario = val ~%]
+      [% IF scenario.value.selected == '1' ~%]
+        [% scenario.value.web_title %] ([% scenario.value.name %])
+      [%~ END %]
+    [%~ END %]
+  [% END %]
+  <!-- end scenario -->
+[%~ END ~%]
+
+[%~ BLOCK EditListTask ~%]
+  <!-- task -->[%# ppaths, pitem, val %]
+  [% IF pitem.may_edit == 'write' %]
+    <select name="single_param.[% ppaths.join('.') %].name"
+     id="param.[% ppaths.join('.') %]">
+    [% FOREACH task = val ~%]
+      <option value="[% task.value.name %]"
+       [%~ IF task.value.selected == '1' %] selected="selected"[% END %]>
+      [%~ task.value.title %] ([% task.value.name %])</option>
+    [% END %]
+    </select>
+  [% ELSIF pitem.may_edit == 'read' %]
+    [% FOREACH task = val ~%]
+      [% IF task.value.selected == '1' ~%]
+        [% task.value.title %] ([% task.value.name %])
+      [%~ END %]
+    [%~ END %]
+  [% END %]
+  <!-- end task -->
+[%~ END ~%]
+
+[%~ BLOCK EditListDatasource ~%]
+  <!-- datasource -->[%# ppaths, pitem, val %]
+  [% IF pitem.may_edit == 'write' %]
+    <select name="single_param.[% ppaths.join('.') %]"
+     id="param.[% ppaths.join('.') %]">
+    [% FOREACH source = val ~%]
+      <option value="[% source.value.name %]"
+       [%~ IF source.value.selected == '1' %] selected="selected"[% END %]>
+      [%~ source.value.title %] ([% source.value.name %])</option>
+    [% END %]
+    </select>
+  [% ELSIF pitem.may_edit == 'read' %]
+    [% FOREACH source = val ~%]
+      [% IF source.value.selected == '1' ~%]
+        [% source.value.title %] ([% source.value.name %])
+      [%~ END %]
+    [%~ END %]
+  [% END %]
+  <!-- end datasource -->
+[%~ END ~%]
+
+[%~ BLOCK EditListScalar ~%]
+  <!-- scalar -->[%# ppaths, pitem, val %]
+  [% IF pitem.may_edit == 'write' %]
+    <input name="single_param.[% ppaths.join('.') %]"
+     id="param.[% ppaths.join('.') %]"
+     value="[% val %]" size="[% pitem.length %]"
+     [%~ IF pitem.field_type == 'password' %] type="password"
+     [%~ ELSE %] type="text"
+     [%~ END %]
+     [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %] />
+  [% ELSIF pitem.may_edit == 'read' %]
+    [% IF pitem.field_type == 'lang' ~%]
+      <span class="neutral" lang="[% val %]" xml:lang="[% val %]">
+    [%~ END ~%]
+    [% IF pitem.field_type ~%]
+      [% val | optdesc(pitem.field_type,is_listmaster) %]
+    [%~ ELSE ~%]
+      [% val %]
+    [%~ END %]
+    [%~ IF pitem.field_type == 'lang' ~%]
+      </span>
+    [%~ END %]
+  [% END %]
+  [% pitem.unit %]
+  <!-- end scalar -->
+[%~ END ~%]
+
 <!-- end edit_list_request.tt2 -->

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -50,34 +50,34 @@
                       <!-- Multiple params -->
 
                       [% IF p.type == 'enum' %]
-                          <!-- set -->
-                          [% IF p.may_edit == 'write' %]
-                            <select name="multiple_param.[% p.name %]" id="param.[% p.name %]" multiple="multiple" size="[% p.value.size %]"
-                             [%~ IF p.field_type == 'lang' %] class="neutral"[% END %]>
-                              [% FOREACH enum = p.value %]
-                                <option value="[% enum.key %]"
-                                 [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
-                                 [%~ IF p.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[% END %]>
-                                [%~ IF enum.value.title ~%]
-                                  [% enum.value.title %]
-                                [%~ ELSE ~%]
-                                  [% enum.key | optdesc(p.field_type,is_listmaster) %]
-                                [%~ END ~%]
-                                </option>
-                              [% END %]
+                          <!-- set -->[% ppaths = [p.name]; pitem = p; val = p.value %]
+                          [% IF pitem.may_edit == 'write' %]
+                            <select name="multiple_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]" multiple="multiple" size="[% val.size %]"
+                             [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
+                            [% FOREACH enum = val ~%]
+                              <option value="[% enum.key %]"
+                               [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
+                               [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[% END %]>
+                              [%~ IF enum.value.title ~%]
+                                [% enum.value.title %]
+                              [%~ ELSE ~%]
+                                [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
+                              [%~ END ~%]
+                              </option>
+                            [% END %]
                             </select>
-                          [% ELSIF p.may_edit == 'read' %]
-                            [% FOREACH enum = p.value %]
+                          [% ELSIF pitem.may_edit == 'read' %]
+                            [% FOREACH enum = val ~%]
                               [% IF enum.value.selected == '1' ~%]
-                                [%~ IF p.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
+                                [%~ IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
                                 [% IF enum.value.title ~%]
                                   [% enum.value.title %]
                                 [%~ ELSE ~%]
-                                  [% enum.key | optdesc(p.field_type,is_listmaster) %]
+                                  [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
                                 [%~ END %]
-                                [%~ IF p.field_type == 'lang' %]</span>[% END %]
+                                [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
                               [%~ END %]
-                            [% END %]
+                            [%~ END %]
                           [% END %]
                           <!-- end set -->
                       [% ELSE %]
@@ -102,97 +102,97 @@
                                       </label>
 
                                       [% IF key.type == 'enum' %]
-                                        <!-- enum -->
-                                        [% IF key.may_edit == 'write' %]
-                                          <select name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]"
-                                           [%~ IF key.field_type == 'lang' %] class="neutral"[% END %]>
-                                          [% FOREACH enum = key.value %]
+                                        <!-- enum -->[% ppaths = [p.name,o_INDEX,key.name]; pitem = key; val = key.value %]
+                                        [% IF pitem.may_edit == 'write' %]
+                                          <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
+                                           [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
+                                          [% FOREACH enum = val ~%]
                                             <option value="[% enum.key %]"
                                              [%~ IF enum.value.selected == '1' %] selected="selected"[% END ~%]
                                              [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
                                             [%~ IF enum.value.title ~%]
                                               [% enum.value.title %]
                                             [%~ ELSE ~%]
-                                              [% enum.key | optdesc(key.field_type,is_listmaster) %]
-                                            [%~ END %]
+                                              [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
+                                            [%~ END ~%]
                                             </option>
                                           [% END %]
                                           </select>
-                                        [% ELSIF key.may_edit == 'read' %]
-                                          [% FOREACH enum = key.value %]
+                                        [% ELSIF pitem.may_edit == 'read' %]
+                                          [% FOREACH enum = val ~%]
                                             [% IF enum.value.selected == '1' ~%]
-                                              [%~ IF key.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
+                                              [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
                                               [% IF enum.value.title ~%]
                                                 [% enum.value.title %]
                                               [%~ ELSE ~%]
-                                                [% enum.key | optdesc(key.field_type,is_listmaster) %]
+                                                [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
                                               [%~ END %]
-                                              [%~ IF key.field_type == 'lang' %]</span>[% END ~%]
+                                              [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
                                             [%~ END %]
-                                          [% END %]
+                                          [%~ END %]
                                         [% END %]
                                         <!-- end enum -->
                                       [% ELSIF key.type == 'datasource' %]
-                                        <!-- datasource -->
-                                        [% IF key.may_edit == 'write' %]
-                                          <select name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]">
-                                          [% FOREACH source = key.value %]
+                                        <!-- datasource -->[% ppaths = [p.name,o_INDEX,key.name]; pitem = key; val = key.value %]
+                                        [% IF pitem.may_edit == 'write' %]
+                                          <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]">
+                                          [% FOREACH source = val ~%]
                                             <option value="[% source.value.name %]"
                                              [%~ IF source.value.selected == '1' %] selected="selected"[% END %]>
                                             [%~ source.value.title %] ([% source.value.name %])</option>
                                           [% END %]
                                           </select>
-                                        [% ELSIF key.may_edit == 'read' %]
-                                          [% FOREACH source = key.value %]
-                                            [% IF source.value.selected == '1' %]
+                                        [% ELSIF pitem.may_edit == 'read' %]
+                                          [% FOREACH source = val ~%]
+                                            [% IF source.value.selected == '1' ~%]
                                               [% source.value.title %] ([% source.value.name %])
-                                            [% END %]
-                                          [% END %]
+                                            [%~ END %]
+                                          [%~ END %]
                                         [% END %]
                                         <!-- end datasource -->
                                       [% ELSE %]
-                                        <!-- scalar -->
-                                        [% IF key.may_edit == 'write' %]
-                                          <input
-                                           [%~ IF key.field_type == 'password' %] type="password"
+                                        <!-- scalar -->[% ppaths = [p.name,o_INDEX,key.name]; pitem = key; val = key.value %]
+                                        [% IF pitem.may_edit == 'write' %]
+                                          <input name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
+                                           value="[% val %]" size="[% pitem.length %]"
+                                           [%~ IF pitem.field_type == 'password' %] type="password"
                                            [%~ ELSE %] type="text"
                                            [%~ END %]
-                                           name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]" value="[% key.value %]" size="[% key.length %]"
-                                           [%~ IF key.field_type == 'lang' %] class="neutral"[% END %] />
-                                        [% ELSIF key.may_edit == 'read' ~%]
-                                          [% IF key.field_type == 'lang' %]<span class="neutral" lang="[%key.value%]" xml:lang="[%key.value%]">[% END ~%]
-                                          [% IF key.field_type ~%]
-                                            [% key.value | optdesc(key.field_type,is_listmaster) %]
+                                           [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %] />
+                                        [% ELSIF pitem.may_edit == 'read' %]
+                                          [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%val%]" xml:lang="[%val%]">[% END ~%]
+                                          [% IF pitem.field_type ~%]
+                                            [% val | optdesc(pitem.field_type,is_listmaster) %]
                                           [%~ ELSE ~%]
-                                            [% key.value %]
+                                            [% val %]
                                           [%~ END %]
-                                          [%~ IF key.field_type == 'lang' %]</span>[% END %]
-                                        [%~ END %]
-                                        [% key.unit %]
+                                          [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
+                                        [% END %]
+                                        [% pitem.unit %]
                                         <!-- end scalar -->
                                       [% END %]
                                   
                                 [% END %]
                               [% END %]
                             [% ELSE %]
-                                  <!-- scalar -->
-                                  [% IF p.may_edit == 'write' %]
-                                    <input
-                                     [%~ IF p.field_type == 'password' %] type="password"
+                                  <!-- scalar -->[% ppaths = [p.name,o_INDEX]; pitem = p; val = o.value %]
+                                  [% IF pitem.may_edit == 'write' %]
+                                    <input name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
+                                     value="[% val %]" size="[% pitem.length %]"
+                                     [%~ IF pitem.field_type == 'password' %] type="password"
                                      [%~ ELSE %] type="text"
                                      [%~ END %]
-                                     name="single_param.[% p.name %].[% o_INDEX %]" id="param.[% p.name %].[% o_INDEX %]" value="[% o.value %]" size="[% p.length %]"
-                                     [%~ IF p.field_type == 'lang' %] class="neutral"[% END %] />
-                                  [% ELSIF p.may_edit == 'read' ~%]
-                                    [% IF p.field_type == 'lang' %]<span class="neutral" lang="[%o.value%]" xml:lang="[%o.value%]">[% END ~%]
-                                    [% IF p.field_type ~%]
-                                      [% o.value | optdesc(p.field_type,is_listmaster) %]
+                                     [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %] />
+                                  [% ELSIF pitem.may_edit == 'read' %]
+                                    [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%val%]" xml:lang="[%val%]">[% END ~%]
+                                    [% IF pitem.field_type ~%]
+                                      [% val | optdesc(pitem.field_type,is_listmaster) %]
                                     [%~ ELSE ~%]
-                                      [% o.value %]
+                                      [% val %]
                                     [%~ END %]
-                                    [%~ IF p.field_type == 'lang' %]</span>[% END %]
-                                  [%~ END %]
-                                  [% p.unit %]
+                                    [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
+                                  [% END %]
+                                  [% pitem.unit %]
                                   <!-- end scalar -->
                             [% END %]
                             [% o_INDEX = o_INDEX + 1 %]
@@ -205,64 +205,59 @@
                       [% ELSE %]
                         <!-- Single params -->
                           [% IF p.type == 'scenario' %]
-                            <!-- scenario -->
-                            [% IF p.may_edit == 'write' %]
-                              <select name="single_param.[% p.name %].name" id="param.[% p.name %]">
-                                [% FOREACH scenario = p.value %]
+                            <!-- scenario -->[% ppaths = [p.name]; pitem = p; val = p.value %]
+                            [% IF pitem.may_edit == 'write' %]
+                              <select name="single_param.[% ppaths.join('.') %].name" id="param.[% ppaths.join('.') %]">
+                                [% FOREACH scenario = val ~%]
                                   [% UNLESS scenario.value.name == 'default' ~%]
                                     <option value="[% scenario.value.name %]"
                                      [%~ IF scenario.value.selected == '1' %] selected="selected"[% END %]>
-                                    [% scenario.value.web_title %] ([% scenario.value.name %])
-                                    </option>
+                                    [% scenario.value.web_title %] ([% scenario.value.name %])</option>
                                   [%~ END %]
                                 [% END %]
                               </select>
-                            [% ELSIF p.may_edit == 'read' %]
-                              [% FOREACH scenario = p.value %]
-                                [% IF scenario.value.selected == '1' %]
+                            [% ELSIF pitem.may_edit == 'read' %]
+                              [% FOREACH scenario = val ~%]
+                                [% IF scenario.value.selected == '1' ~%]
                                   [% scenario.value.web_title %] ([% scenario.value.name %])
-                                [% END %]
-                              [% END %]
+                                [%~ END %]
+                              [%~ END %]
                             [% END %]
                             <!-- end scenario -->
                           [% ELSIF p.type == 'task' %]
-                            <!-- task -->
-                            [% IF p.may_edit == 'write' %]
-                              <select name="single_param.[% p.name %].name" id="param.[% p.name %]">
-                                [% FOREACH task = p.value %]
-                                  <option value="[% task.value.name %]"
-                                  [% IF task.value.selected == '1' %]
-                                    selected="selected"
-                                  [% END %]
-                                  >[% task.value.title %] ([% task.value.name %])</option>
-                                [% END %]
-                              </select>
-                            [% ELSIF p.may_edit == 'read' %]
-                              [% FOREACH task = p.value %]
-                                [% IF task.value.selected == '1' %]
-                                  [% task.value.title %] ([% task.value.name %])
-                                [% END %]
+                            <!-- task -->[% ppaths = [p.name]; pitem = p; val = p.value %]
+                            [% IF pitem.may_edit == 'write' %]
+                              <select name="single_param.[% ppaths.join('.') %].name" id="param.[% ppaths.join('.') %]">
+                              [% FOREACH task = val ~%]
+                                <option value="[% task.value.name %]"
+                                 [%~ IF task.value.selected == '1' %] selected="selected"[% END %]>
+                                [%~ task.value.title %] ([% task.value.name %])</option>
                               [% END %]
+                              </select>
+                            [% ELSIF pitem.may_edit == 'read' %]
+                              [% FOREACH task = val ~%]
+                                [% IF task.value.selected == '1' ~%]
+                                  [% task.value.title %] ([% task.value.name %])
+                                [%~ END %]
+                              [%~ END %]
                             [% END %]
                             <!-- end task -->
                           [% ELSIF p.type == 'datasource' %]
-                            <!-- datasource -->
-                            [% IF p.may_edit == 'write' %]
-                              <select name="single_param.[% p.name %]" id="param.[% p.name %]">
-                                [% FOREACH source = p.value %]
-                                  <option value="[% source.value.name %]"
-                                  [% IF source.value.selected == '1' %]
-                                    selected="selected"
-                                  [% END %]
-                                  >[% source.value.title %] ([% source.value.name %])</option>
-                                [% END %]
-                              </select>
-                            [% ELSIF p.may_edit == 'read' %]
-                              [% FOREACH source = p.value %]
-                                [% IF source.value.selected == '1' %]
-                                  [% source.value.title %] ([% source.value.name %])
-                                [% END %]
+                            <!-- datasource -->[% ppaths = [p.name]; pitem = p; val = p.value %]
+                            [% IF pitem.may_edit == 'write' %]
+                              <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]">
+                              [% FOREACH source = val ~%]
+                                <option value="[% source.value.name %]"
+                                 [%~ IF source.value.selected == '1' %] selected="selected"[% END %]>
+                                [%~ source.value.title %] ([% source.value.name %])</option>
                               [% END %]
+                              </select>
+                            [% ELSIF pitem.may_edit == 'read' %]
+                              [% FOREACH source = val ~%]
+                                [% IF source.value.selected == '1' ~%]
+                                  [% source.value.title %] ([% source.value.name %])
+                                [%~ END %]
+                              [%~ END %]
                             [% END %]
                             <!-- end datasource -->
                           [% ELSIF p.type == 'paragraph' %]
@@ -278,201 +273,198 @@
                                       </label>
 
                                       [% IF key.type == 'scenario' %]
-                                        <!-- scenario -->
-                                        [% IF key.may_edit == 'write' %]
-                                          <select name="single_param.[% p.name %].[% key.name %].name" id="param.[% p.name %].[% key.name %]">
-                                            [% FOREACH scenario = key.value %]
-                                              [% UNLESS scenario.value.name == 'default' ~%]
-                                                <option value="[% scenario.value.name %]"
-                                                 [% IF scenario.value.selected == '1' %] selected="selected"[% END %]>
-                                                [% scenario.value.web_title %] ([% scenario.value.name %])
-                                                </option>
-                                              [%~ END %]
-                                            [% END %]
-                                          </select>
-                                        [% ELSIF key.may_edit == 'read' %]
-                                          [% FOREACH scenario = key.value %]
-                                            [% IF scenario.value.selected == '1' %]
-                                              [% scenario.value.web_title %] ([% scenario.value.name %])
-                                            [% END %]
+                                        <!-- scenario -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
+                                        [% IF pitem.may_edit == 'write' %]
+                                          <select name="single_param.[% ppaths.join('.') %].name" id="param.[% ppaths.join('.') %]">
+                                          [% FOREACH scenario = val ~%]
+                                            [% UNLESS scenario.value.name == 'default' ~%]
+                                              <option value="[% scenario.value.name %]"
+                                               [%~ IF scenario.value.selected == '1' %] selected="selected"[% END %]>
+                                              [%~ scenario.value.web_title %] ([% scenario.value.name %])</option>
+                                            [%~ END %]
                                           [% END %]
+                                          </select>
+                                        [% ELSIF pitem.may_edit == 'read' %]
+                                          [% FOREACH scenario = val ~%]
+                                            [% IF scenario.value.selected == '1' ~%]
+                                              [% scenario.value.web_title %] ([% scenario.value.name %])
+                                            [%~ END %]
+                                          [%~ END %]
                                         [% END %]
                                         <!-- end scenario -->
                                       [% ELSIF key.type == 'task' %]
-                                        <!-- task -->
-                                        [% IF key.may_edit == 'write' %]
-                                          <select name="single_param.[% p.name %].[% key.name %].name" id="param.[% p.name %].[% key.name %]">
-                                            [% FOREACH task = key.value %]
-                                              <option value="[% task.value.name %]"
-                                              [% IF task.value.selected == '1' %]
-                                                selected="selected"
-                                              [% END %]
-                                              >[% task.value.title %] ([% task.value.name %])</option>
-                                            [% END %]
-                                          </select>
-                                        [% ELSIF key.may_edit == 'read' %]
-                                          [% FOREACH task = key.value %]
-                                            [% IF task.value.selected == '1' %]
-                                              [% task.value.title %] ([% task.value.name %])
-                                            [% END %]
+                                        <!-- task -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
+                                        [% IF pitem.may_edit == 'write' %]
+                                          <select name="single_param.[% ppaths.join('.') %].name" id="param.[% ppaths.join('.') %]">
+                                          [% FOREACH task = val ~%]
+                                            <option value="[% task.value.name %]"
+                                            [%~ IF task.value.selected == '1' %] selected="selected"[% END %]>
+                                            [%~ task.value.title %] ([% task.value.name %])</option>
                                           [% END %]
+                                          </select>
+                                        [% ELSIF pitem.may_edit == 'read' %]
+                                          [% FOREACH task = val ~%]
+                                            [% IF task.value.selected == '1' ~%]
+                                              [% task.value.title %] ([% task.value.name %])
+                                            [%~ END %]
+                                          [%~ END %]
                                         [% END %]
                                         <!-- end task -->
                                       [% ELSIF key.type == 'datasource' %]
-                                        <!-- datasource -->
-                                        [% IF key.may_edit == 'write' %]
-                                          <select name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]">
-                                            [% FOREACH source = key.value %]
-                                              <option value="[% source.value.name %]"
-                                               [%~ IF source.value.selected == '1' %] selected="selected"[% END %]>
-                                              [%~ source.value.title %] ([% source.value.name %])</option>
-                                            [% END %]
-                                          </select>
-                                        [% ELSIF key.may_edit == 'read' %]
-                                          [% FOREACH source = key.value %]
-                                            [% IF source.value.selected == '1' %]
-                                              [% source.value.title %] ([% source.value.name %])
-                                            [% END %]
+                                        <!-- datasource -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
+                                        [% IF pitem.may_edit == 'write' %]
+                                          <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]">
+                                          [% FOREACH source = val ~%]
+                                            <option value="[% source.value.name %]"
+                                             [%~ IF source.value.selected == '1' %] selected="selected"[% END %]>
+                                            [%~ source.value.title %] ([% source.value.name %])</option>
                                           [% END %]
+                                          </select>
+                                        [% ELSIF pitem.may_edit == 'read' %]
+                                          [% FOREACH source = val ~%]
+                                            [% IF source.value.selected == '1' ~%]
+                                              [% source.value.title %] ([% source.value.name %])
+                                            [%~ END %]
+                                          [%~ END %]
                                         [% END %]
                                         <!-- end datasource -->
                                       [% ELSIF key.type == 'enum' %]
                                         [% IF key.occurrence == 'multiple' %]
-                                          <!-- set -->
-                                          [% IF key.may_edit == 'write' %]
-                                            <select name="multiple_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" multiple="multiple" size="[% key.value.size %]"
-                                             [%~ IF key.field_type == 'lang' %] class="neutral"[% END %]>
-                                            [% FOREACH enum = key.value %]
+                                          <!-- set -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
+                                          [% IF pitem.may_edit == 'write' %]
+                                            <select name="multiple_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]" multiple="multiple" size="[% val.size %]"
+                                             [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
+                                            [% FOREACH enum = val ~%]
                                               <option value="[% enum.key %]"
-                                              [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
-                                              [%~ IF key.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
+                                               [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
+                                               [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
                                               [%~ IF enum.value.title ~%]
                                                 [% enum.value.title %]
                                               [%~ ELSE ~%]
-                                                [% enum.key | optdesc(key.field_type,is_listmaster) %]
+                                                [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
                                               [%~ END ~%]
                                               </option>
                                             [% END %]
                                             </select>
-                                          [% ELSIF key.may_edit == 'read' %]
-                                            [% FOREACH enum = key.value %]
+                                          [% ELSIF pitem.may_edit == 'read' %]
+                                            [% FOREACH enum = val ~%]
                                               [% IF enum.value.selected == '1' ~%]
-                                                [% IF key.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
+                                                [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
                                                 [%~ IF enum.value.title ~%]
                                                   [% enum.value.title %]
                                                 [%~ ELSE ~%]
-                                                  [% enum.key | optdesc(key.field_type,is_listmaster) %]
-                                                [%~ END ~%]
-                                                [% IF key.field_type == 'lang' %]</span>[% END %]
-                                              [% END %]
+                                                  [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
+                                                [%~ END %]
+                                                [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
+                                              [%~ END %]
                                             [% END %]
                                           [% END %]
                                           <!-- end set -->
                                         [% ELSE %]
-                                          <!-- enum -->
-                                          [% IF key.may_edit == 'write' %]
-                                            <select name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]"
-                                             [%~ IF key.field_type == 'lang' %] class="neutral"[% END %]>
-                                            [% FOREACH enum = key.value %]
+                                          <!-- enum -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
+                                          [% IF pitem.may_edit == 'write' %]
+                                            <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
+                                             [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
+                                            [% FOREACH enum = val ~%]
                                               <option value="[% enum.key %]"
                                                [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
-                                               [%~ IF key.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
+                                               [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
                                               [%~ IF enum.value.title ~%]
                                                 [% enum.value.title %]
                                               [%~ ELSE ~%]
-                                                [% enum.key | optdesc(key.field_type,is_listmaster) %]
+                                                [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
                                               [%~ END ~%]
                                               </option>
                                             [% END %]
                                             </select>
-                                          [% ELSIF key.may_edit == 'read' %]
-                                            [% FOREACH enum = key.value %]
+                                          [% ELSIF pitem.may_edit == 'read' %]
+                                            [% FOREACH enum = val ~%]
                                               [% IF enum.value.selected == '1' ~%]
-                                                [% IF key.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
-                                                [%~ IF enum.value.title ~%]
+                                                [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
+                                                [% IF enum.value.title ~%]
                                                   [% enum.value.title %]
                                                 [%~ ELSE ~%]
-                                                  [% enum.key | optdesc(key.field_type,is_listmaster) %]
-                                                [%~ END ~%]
-                                                [% IF key.field_type == 'lang' %]</span>[% END %]
-                                              [% END %]
-                                            [% END %]
+                                                  [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
+                                                [%~ END %]
+                                                [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
+                                              [%~ END %]
+                                            [%~ END %]
                                           [% END %]
                                           <!-- end enum -->
                                         [% END %]
                                       [% ELSE %]
-                                        <!-- scalar -->
-                                        [% IF key.may_edit == 'write' %]
-                                          <input
-                                           [%~ IF key.field_type == 'password' %] type="password"
+                                        <!-- scalar -->[% ppaths = [p.name,key.name]; pitem = key; val = key.value %]
+                                        [% IF pitem.may_edit == 'write' %]
+                                          <input name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
+                                           value="[% val %]" size="[% pitem.length %]"
+                                           [%~ IF pitem.field_type == 'password' %] type="password"
                                            [%~ ELSE %] type="text"
                                            [%~ END %]
-                                           name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" value="[% key.value %]" size="[% key.length %]"
-                                           [%~ IF key.field_type == 'lang' %] class="neutral"[% END %] />
-                                        [% ELSIF key.may_edit == 'read' ~%]
-                                          [%~ IF key.field_type == 'lang' %]<span class="neutral" lang="[%key.value%]" xml:lang="[%key.value%]">[%END%]
-                                          [% IF key.field_type ~%]
-                                            [% key.value | optdesc(key.field_type,is_listmaster) %]
+                                           [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %] />
+                                        [% ELSIF pitem.may_edit == 'read' %]
+                                          [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%val%]" xml:lang="[%val%]">[% END ~%]
+                                          [% IF pitem.field_type ~%]
+                                            [% val | optdesc(pitem.field_type,is_listmaster) %]
                                           [%~ ELSE ~%]
-                                            [% key.value %]
+                                            [% val %]
                                           [%~ END %]
-                                          [%~ IF key.field_type == 'lang' %]</span>[% END %]
-                                        [%~ END %]
-                                        [% key.unit %]
+                                          [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
+                                        [% END %]
+                                        [% pitem.unit %]
                                         <!-- end scalar -->
                                       [% END %]
                               [% END %]
                             [% END %]
                           [% ELSIF p.type == 'enum' %]
-                            <!-- enum -->
-                            [% IF p.may_edit == 'write' %]
-                              <select name="single_param.[% p.name %]" id="param.[% p.name %]"
-                               [%~ IF p.field_type == 'lang' %] class="neutral"[% END %]>
-                                [% FOREACH enum = p.value %]
-                                  <option value="[% enum.key %]"
-                                   [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
-                                   [%~ IF p.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
+                            <!-- enum -->[% ppaths = [p.name]; pitem = p; val = p.value %]
+                            [% IF pitem.may_edit == 'write' %]
+                              <select name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
+                               [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
+                              [% FOREACH enum = val ~%]
+                                <option value="[% enum.key %]"
+                                 [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
+                                 [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
+                                [%~ IF enum.value.title ~%]
+                                  [% enum.value.title %]
+                                [%~ ELSE ~%]
+                                  [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
+                                [%~ END ~%]
+                                </option>
+                              [% END %]
+                              </select>
+                            [% ELSIF pitem.may_edit == 'read' %]
+                              [% FOREACH enum = val ~%]
+                                [% IF enum.value.selected == '1' ~%]
+                                  [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
                                   [% IF enum.value.title ~%]
                                     [% enum.value.title %]
                                   [%~ ELSE ~%]
-                                    [% enum.key | optdesc(p.field_type,is_listmaster) %]
+                                    [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
                                   [%~ END %]
-                                  </option>
-                                [% END %]
-                              </select>
-                            [% ELSIF p.may_edit == 'read' %]
-                              [% FOREACH enum = p.value %]
-                                [% IF enum.value.selected == '1' %]
-                                  [%~ IF p.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END %]
-                                  [%~ IF enum.value.title ~%]
-                                    [% enum.value.title %]
-                                  [%~ ELSE ~%]
-                                    [% enum.key | optdesc(p.field_type,is_listmaster) %]
-                                  [%~ END %]
-                                  [%~ IF p.field_type == 'lang' %]</span>[% END %]
-                                [% END %]
-                              [% END %]
+                                  [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
+                                [%~ END %]
+                              [%~ END %]
                             [% END %]
                             <!-- end enum -->
                           [% ELSE %]
-                            <!-- scalar -->
-                            [% IF p.may_edit == 'write' ~%]
-                              <input
-                               [%~ IF p.field_type == 'password' %] type="password"
+                            <!-- scalar -->[% ppaths = [p.name]; pitem = p; val = p.value %]
+                            [% IF pitem.may_edit == 'write' %]
+                              <input name="single_param.[% ppaths.join('.') %]" id="param.[% ppaths.join('.') %]"
+                               value="[% val %]" size="[% pitem.length %]"
+                               [%~ IF pitem.field_type == 'password' %] type="password"
                                [%~ ELSE %] type="text"
                                [%~ END %]
-                               name="single_param.[% p.name %]" id="param.[% p.name %]" value="[% p.value %]" size="[% p.length %]"
-                               [%~ IF p.field_type == 'lang' %] class="neutral"[% END %] />
-                            [%~ ELSIF p.may_edit == 'read' ~%]
-                              [%~ IF p.field_type == 'lang' %]<span class="neutral" lang="[% p.value %]" xml:lang="[% p.value %]">[% END ~%]
-                              [% IF p.field_type ~%]
-                                [% p.value | optdesc(p.field_type,is_listmaster) %]
+                               [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %] />
+                            [% ELSIF pitem.may_edit == 'read' %]
+                              [% IF pitem.field_type == 'lang' %]<span class="neutral" lang="[% val %]" xml:lang="[% val %]">[% END ~%]
+                              [% IF pitem.field_type ~%]
+                                [% val | optdesc(pitem.field_type,is_listmaster) %]
                               [%~ ELSE ~%]
-                                [% p.value %]
+                                [% val %]
                               [%~ END %]
-                              [%~ IF p.field_type == 'lang' %]</span>[% END %]
+                              [%~ IF pitem.field_type == 'lang' %]</span>[% END %]
                             [% END %]
-                            [% p.unit %]
+                            [% pitem.unit %]
                             <!-- end scalar -->
                           [% END %]
 

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -53,7 +53,7 @@
                         <!-- Multiple Enum -->
 
                           [% IF p.may_edit == 'write' %]
-                            <select name="multiple_param.[% p.name %]" multiple="multiple" size="[% p.value.size %]">
+                            <select name="multiple_param.[% p.name %]" id="param.[% p.name %]" multiple="multiple" size="[% p.value.size %]">
                               [% FOREACH enum = p.value %]
                                 <option value="[% enum.key %]"
                                 [% IF enum.value.selected == '1' %]
@@ -90,7 +90,7 @@
 
                                 [% IF key.may_edit != 'hidden' %] 
 
-                                      <label for="single_param.[% p.name %].[% o_INDEX %].[% key.name %]">
+                                      <label for="param.[% p.name %].[% o_INDEX %].[% key.name %]">
                                         [% IF key.title %]
                                           [% key.title %][% IF is_listmaster %] ([% key.name %])[% END %][%|loc%]:[%END%]
                                         [% ELSE %]
@@ -102,7 +102,7 @@
                                         <!-- Enum -->
                                         
                                         [% IF key.may_edit == 'write' %]
-                                          <select name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="single_param.[% p.name %].[% o_INDEX %].[% key.name %]">
+                                          <select name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]">
                                             [% FOREACH enum = key.value %]
                                               <option value="[% enum.key %]"
                                               [%- IF enum.value.selected == '1' -%]
@@ -116,7 +116,6 @@
                                           [% FOREACH enum = key.value %]
                                             [% IF enum.value.selected == '1' %]
                                               [% IF enum.value.title %][% enum.value.title %][% ELSE %][%|optdesc('',is_listmaster)%][% enum.key %][%END%][% END %]
-                                              <input type="hidden" name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" value="[% enum.key %]" />
                                             [% END %]
                                           [% END %]
                                         [% END %]
@@ -125,7 +124,7 @@
                                       [% ELSIF key.type == 'datasource' %]
                                         <!-- Datasource -->
                                         [% IF key.may_edit == 'write' %]
-                                          <select name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="single_param.[% p.name %].[% o_INDEX %].[% key.name %]">
+                                          <select name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]">
                                             [% FOREACH source = key.value %]
                                               <option value="[% source.value.name %]"
                                               [% IF source.value.selected == '1' %]
@@ -139,25 +138,23 @@
                                           [% FOREACH source = key.value %]
                                             [% IF source.value.selected == '1' %]
                                               [% source.value.title %] ([% source.value.name %])
-                                              <input type="hidden" name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" value="[% source.value.name %]" />
                                             [% END %]
                                           [% END %]
                                         [% END %]
                                       [% ELSE %]
                                         <!-- Scalar -->
                                         [% IF key.may_edit == 'write' %]
-                                          [% IF key.field_type == 'password' %]
-                                            <input type="password" name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" value="[% key.value %]" size="[% key.length %]" />
-                                          [% ELSE %]
-                                            <input type="text" name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" value="[% key.value %]" size="[% key.length %]" />
-                                          [% END %]
+                                          <input
+                                           [%~ IF key.field_type == 'password' %] type="password"
+                                           [%~ ELSE %] type="text"
+                                           [%~ END %]
+                                           name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]" value="[% key.value %]" size="[% key.length %]" />
                                         [% ELSIF key.may_edit == 'read' %]
                                           [% IF key.field_type == 'password' %]
                                             [% key.hidden_field %]
                                           [% ELSE %]
                                             [% key.value %]
                                           [% END %]
-                                          <input type="hidden" name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" value="[% key.value %]" />
                                         [% END %]
                                         [% key.unit %]
                                       [% END %]
@@ -167,7 +164,7 @@
                             [% ELSE %]
                               <!-- Scalar -->
                                   [% IF p.may_edit == 'write' %]
-                                    <input type="text" name="single_param.[% p.name %].[% o_INDEX %]" id="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" value="[% o.value %]" size="[% o.length %]" />
+                                    <input type="text" name="single_param.[% p.name %].[% o_INDEX %]" id="param.[% p.name %].[% o_INDEX %]" value="[% o.value %]" size="[% o.length %]" />
                                   [% ELSIF p.may_edit == 'read' %]
                                     [% o.value %]
                                   [% END %]
@@ -185,7 +182,7 @@
                           [% IF p.type == 'scenario' %]
                             <!-- Scenario -->
                             [% IF p.may_edit == 'write' %]
-                              <select name="single_param.[% p.name %].name" id="single_param.[% p.name %].name">
+                              <select name="single_param.[% p.name %].name" id="param.[% p.name %]">
                                 [% FOREACH scenario = p.value %]
                                   [% UNLESS scenario.value.name.match('(default)\s*$') %]
                                     <option value="[% scenario.value.name %]"
@@ -208,7 +205,7 @@
                           [% ELSIF p.type == 'task' %]
                             <!-- Task -->
                             [% IF p.may_edit == 'write' %]
-                              <select name="single_param.[% p.name %].name" id="single_param.[% p.name %].name">
+                              <select name="single_param.[% p.name %].name" id="param.[% p.name %]">
                                 [% FOREACH task = p.value %]
                                   <option value="[% task.value.name %]"
                                   [% IF task.value.selected == '1' %]
@@ -227,7 +224,7 @@
                           [% ELSIF p.type == 'datasource' %]
                             <!-- Datasource -->
                             [% IF p.may_edit == 'write' %]
-                              <select name="single_param.[% p.name %].name" id="single_param.[% p.name %].name">
+                              <select name="single_param.[% p.name %]" id="param.[% p.name %]">
                                 [% FOREACH source = p.value %]
                                   <option value="[% source.value.name %]"
                                   [% IF source.value.selected == '1' %]
@@ -247,7 +244,7 @@
                               <!-- Paragraph -->
                               [% FOREACH key = p.value %]
                                 [% IF key.may_edit != 'hidden' %] 
-                                      <label for="single_param.[% p.name %].[% key.name %].name">
+                                      <label for="param.[% p.name %].[% key.name %]">
                                         [% IF key.title %]
                                           [% key.title %][% IF is_listmaster %] ([% key.name %])[% END %][%|loc%]:[%END%]
                                         [% ELSE %]
@@ -258,7 +255,7 @@
                                       [% IF key.type == 'scenario' %]
                                         <!-- Scenario -->
                                         [% IF key.may_edit == 'write' %]
-                                          <select name="single_param.[% p.name %].[% key.name %].name" id="single_param.[% p.name %].[% key.name %].name">
+                                          <select name="single_param.[% p.name %].[% key.name %].name" id="param.[% p.name %].[% key.name %]">
                                             [% FOREACH scenario = key.value %]
                                               <option value="[% scenario.value.name %]"
                                               [% IF scenario.value.selected == '1' %]
@@ -278,7 +275,7 @@
                                       [% ELSIF key.type == 'task' %]
                                         <!-- Task -->
                                         [% IF key.may_edit == 'write' %]
-                                          <select name="single_param.[% p.name %].[% key.name %].name" id="single_param.[% p.name %].[% key.name %].name">
+                                          <select name="single_param.[% p.name %].[% key.name %].name" id="param.[% p.name %].[% key.name %]">
                                             [% FOREACH task = key.value %]
                                               <option value="[% task.name %]"
                                               [% IF task.value.selected == '1' %]
@@ -297,7 +294,7 @@
                                       [% ELSIF key.type == 'datasource' %]
                                         <!-- Datasource -->
                                         [% IF key.may_edit == 'write' %]
-                                          <select name="single_param.[% p.name %].[% key.name %].name" id="single_param.[% p.name %].[% key.name %].name">
+                                          <select name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]">
                                             [% FOREACH source = key.value %]
                                               <option value="[% source.name %]"
                                               [% IF source.value.selected == '1' %]
@@ -318,9 +315,9 @@
                                         <!-- Enum -->
                                         [% IF key.may_edit == 'write' %]
                                           [% IF key.occurrence == 'multiple' %]
-                                            <select name="multiple_param.[% p.name %].[% key.name %]" id="single_param.[% p.name %].[% key.name %].name" multiple="multiple" size="[% key.value.size %]">
+                                            <select name="multiple_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" multiple="multiple" size="[% key.value.size %]">
                                           [% ELSE %]
-                                            <select name="single_param.[% p.name %].[% key.name %]" id="single_param.[% p.name %].[% key.name %].name" class="neutral">
+                                            <select name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" class="neutral">
                                           [% END %]
                                           [% FOREACH enum = key.value %]
                                             <option value="[% enum.key %]"
@@ -361,7 +358,7 @@
                                       [% ELSE %]
                                         <!-- Scalar -->
                                         [% IF key.may_edit == 'write' %]
-                                          <input type="text" name="single_param.[% p.name %].[% key.name %]" id="single_param.[% p.name %].[% key.name %].name" value="[% key.value %]" size="[% key.length %]" />
+                                          <input type="text" name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" value="[% key.value %]" size="[% key.length %]" />
                                         [% ELSIF key.may_edit == 'read' %]
                                           [% key.value %]
                                         [% END %]
@@ -373,7 +370,7 @@
                           [% ELSIF p.type == 'enum' %]
                           <!-- Enum -->
                             [% IF p.may_edit == 'write' %]
-                              <select name="single_param.[% p.name %]" id="single_param.[% p.name %].name" class="neutral">
+                              <select name="single_param.[% p.name %]" id="param.[% p.name %]" class="neutral">
                                 [% FOREACH enum = p.value %]
                                   <option value="[% enum.key %]"
                                   [% IF enum.value.selected == '1' %]
@@ -411,7 +408,7 @@
                           [% ELSE %]
                             <!-- Scalar -->
                             [% IF p.may_edit == 'write' %]
-                              <input type="text" name="single_param.[% p.name %]" id="single_param.[% p.name %].name" value="[% p.value %]" size="[% p.length %]" />
+                              <input type="text" name="single_param.[% p.name %]" id="param.[% p.name %]" value="[% p.value %]" size="[% p.length %]" />
                             [% ELSIF p.may_edit == 'read' %]
                               [% p.value %]
                             [% END %]

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -40,14 +40,14 @@
     [%~ END %]
     [%~ IF is_listmaster && pS.default_value %] [%|loc%](default)[%END%][% END %]
     <span class="edit_list_request_help">
-    [% IF pS.scenario ~%]
-      [% IF is_listmaster ~%]
-        &nbsp;<a class="input"
-         href="[% 'dump_scenario' | url_rel([list,pS.name]) %]"
-         title="[%|loc%]scenario source[%END%]">[%|loc%]scenario source[%END~%]
-        </a>
-      [%~ END %]
+
+    [%~ IF pS.scenario && is_listmaster ~%]
+      &nbsp;<a class="input"
+       href="[% 'dump_scenario' | url_rel([list,pS.name]) %]"
+       title="[%|loc%]scenario source[%END%]">[%|loc%]scenario source[%END~%]
+      </a>
     [%~ END %]
+
     <a href="[% 'nomenu/help/editlist' | url_rel %]#[% pS.name %]"
      title="[%|loc%]Open in a new window[%END%]"
      onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=800,height=400')"
@@ -88,10 +88,11 @@
             <label for="param.[% pS.name %].[% oI %].[% kS.name %]">
             [% IF kS.title ~%]
               [% kS.title %]
-              [%~ IF is_listmaster %] ([% kS.name %])[% END %][%|loc%]:[%END%]
+              [%~ IF is_listmaster %] ([% kS.name %])[% END %]
             [%~ ELSE ~%]
-              [% kS.name %][%|loc%]:[%END%]
-            [%~ END %]
+              [% kS.name %]
+            [%~ END ~%]
+            [%|loc%]:[%END%]
             </label>
 
             [% IF kS.type == 'set' ~%]
@@ -115,6 +116,7 @@
             <div class="small-3 large-2 columns">
             [% PROCESS EditListArrayDel
                ppaths=[pS.name,oI]
+               pitem=pS
             %]
             </div>
           [%~ END %]
@@ -137,6 +139,7 @@
             <div class="small-3 large-2 columns">
             [% PROCESS EditListArrayDel
                ppaths=[pS.name,oI]
+               pitem=pS
             %]
             </div>
           [%~ END %]
@@ -160,10 +163,11 @@
             <label for="param.[% pS.name %].[% oI %].[% kS.name %]">
             [% IF kS.title ~%]
               [% kS.title %]
-              [%~ IF is_listmaster %] ([% kS.name %])[% END %][%|loc%]:[%END%]
+              [%~ IF is_listmaster %] ([% kS.name %])[% END %]
             [%~ ELSE ~%]
-              [% kS.name %][%|loc%]:[%END%]
-            [%~ END %]
+              [% kS.name ~%]
+            [%~ END ~%]
+            [%|loc%]:[%END%]
             </label>
 
             [% IF kS.type == 'set' ~%]
@@ -214,10 +218,11 @@
           <label for="param.[% pS.name %].[% kS.name %]">
           [% IF kS.title ~%]
             [% kS.title %]
-            [%~ IF is_listmaster %] ([% kS.name %])[% END %][%|loc%]:[%END%]
+            [%~ IF is_listmaster %] ([% kS.name %])[% END %]
           [%~ ELSE ~%]
-            [% kS.name %][%|loc%]:[%END%]
-          [%~ END %]
+            [% kS.name %]
+          [%~ END ~%]
+          [%|loc%]:[%END%]
           </label>
 
           [% IF kS.type == 'set' ~%]
@@ -315,13 +320,15 @@
   <!-- end set -->
 [%~ END ~%]
 
-[%~ BLOCK EditListArrayDel # (ppaths) ~%]
+[%~ BLOCK EditListArrayDel # (ppaths,pitem) ~%]
   <!-- del -->
-  <input type="checkbox" name="deleted_param.[% ppaths.join('.') %]"
-   id="del.[% ppaths.join('.') %]"
-   class="fadeIfChecked" data-selector="#item\.[% ppaths.join('\\.') %]"
-   value="del" />
-  <label for="del.[% ppaths.join('.') %]">[%|loc%]Delete[%END%]</label>
+  [% IF pitem.privilege == 'write' ~%]
+    <input type="checkbox" name="deleted_param.[% ppaths.join('.') %]"
+     id="del.[% ppaths.join('.') %]"
+     class="fadeIfChecked" data-selector="#item\.[% ppaths.join('\\.') %]"
+     value="del" />
+    <label for="del.[% ppaths.join('.') %]">[%|loc%]Delete[%END%]</label>
+  [%~ END %]
   <!-- end del -->
 [%~ END ~%]
 
@@ -458,6 +465,9 @@
 [%~ BLOCK EditListScalar # (ppaths,pitem,val) ~%]
   <!-- scalar -->
   [% IF pitem.privilege == 'write' ~%]
+    [% IF pitem.unit ~%]
+      <span style="display:inline-block">[%# FIXME %]
+    [%~ END %]
     <input name="single_param.[% ppaths.join('.') %]"
      id="param.[% ppaths.join('.') %]"
      value="[% val %]" size="[% pitem.length %]"
@@ -465,6 +475,11 @@
      [%~ ELSE %] type="text"
      [%~ END %]
      [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %] />
+    [% IF pitem.unit ~%]
+      </span>
+    [%~ END %]
+
+    [% pitem.unit %]
   [%~ ELSE ~%]
     [% IF pitem.field_type == 'lang' ~%]
       <span class="neutral" lang="[% val %]" xml:lang="[% val %]">
@@ -477,7 +492,11 @@
     [%~ IF pitem.field_type == 'lang' ~%]
       </span>
     [%~ END %]
-  [%~ END %] [% pitem.unit %]
+
+    [% IF val.length() ~%]
+      [% pitem.unit %]
+    [%~ END %]
+  [%~ END %]
   <!-- end scalar -->
 [%~ END ~%]
 

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -269,11 +269,7 @@
       <option value="[% enum.key %]"
        [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
        [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
-      [%~ IF enum.value.title ~%]
-        [% enum.value.title %]
-      [%~ ELSE ~%]
-        [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-      [%~ END ~%]
+      [%~ enum.key | optdesc(pitem.field_type,is_listmaster) ~%]
       </option>
     [% END %]
     </select>
@@ -283,11 +279,7 @@
         [% IF pitem.field_type == 'lang' ~%]
           <span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">
         [%~ END ~%]
-        [% IF enum.value.title ~%]
-          [% enum.value.title %]
-        [%~ ELSE ~%]
-          [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-        [%~ END %]
+        [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
         [%~ IF pitem.field_type == 'lang' ~%]
           </span>
         [%~ END %]

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -231,11 +231,7 @@
       <option value="[% enum.key %]"
        [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
        [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[% END %]>
-      [%~ IF enum.value.title ~%]
-        [% enum.value.title %]
-      [%~ ELSE ~%]
-        [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-      [%~ END ~%]
+      [%~ enum.key | optdesc(pitem.field_type,is_listmaster) ~%]
       </option>
     [% END %]
     </select>
@@ -245,11 +241,7 @@
         [%~ IF pitem.field_type == 'lang' ~%]
           <span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">
         [%~ END ~%]
-        [% IF enum.value.title ~%]
-          [% enum.value.title %]
-        [%~ ELSE ~%]
-          [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-        [%~ END %]
+        [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
         [%~ IF pitem.field_type == 'lang' ~%]
           </span>
         [%~ END %]

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -278,6 +278,9 @@
     <select name="single_param.[% ppaths.join('.') %]"
      id="param.[% ppaths.join('.') %]"
      [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
+    [% IF pitem.occurrence.match('^0') ~%]
+      <option value=""></option>
+    [%~ END %]
     [% FOREACH enum = pitem.format ~%]
       <option value="[% enum %]"
        [%~ IF enum == val %] selected="selected"[% END %]
@@ -363,6 +366,9 @@
   [% IF pitem.privilege == 'write' ~%]
     <select name="single_param.[% ppaths.join('.') %]"
      id="param.[% ppaths.join('.') %]">
+    [% IF pitem.occurrence.match('^0') ~%]
+      <option value=""></option>
+    [%~ END %]
     [% FOREACH source = pitem.format ~%]
       <option value="[% source.value.name %]"
        [%~ IF source.value.name == val %] selected="selected"[% END %]>

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -1,7 +1,14 @@
 <!-- $Id$ -->
 <div class="block">
 
-<h2>[%|loc%]Edit List Configuration[%END%] <a  href="[% 'nomenu/help/listconfig' | url_rel %]" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=800,height=400')" target="wws_help"><i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i></a></h2>
+<h2>[%|loc%]Edit List Configuration[%END%]
+<a href="[% 'nomenu/help/listconfig' | url_rel %]"
+ title="[%|loc%]Open in a new window[%END%]"
+ onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=800,height=400')"
+ target="wws_help">
+<i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i>
+</a>
+</h2>
 
 [% IF !group ~%]
   [% IF GROUP == 'description' ~%]
@@ -9,209 +16,202 @@
   [%~ ELSE ~%]
     [% SET class = 'menuLinks' %]
   [%~ END ~%]
-  <p>[%|loc%]Here you can edit your list's configuration parameters.[% END %]</p>
+  <p>
+  [%|loc%]Here you can edit your list's configuration parameters.[% END %]
+  </p>
 [%~ ELSE ~%]
-  <form class="bold_label"  action="[% path_cgi %]" method="post">
+  <form class="bold_label" action="[% path_cgi %]" method="post">
   <fieldset>
   <input type="hidden" name="serial" value="[% serial %]" />
-  [% FOREACH p = param %]
-    [% IF p.may_edit != 'hidden' %]
-      [% IF p.changed == '1' %]
-        <div class="CurrentBlock">
-      [% ELSE %]
-        <div class="block">
-      [% END %]
-      <h4>
-      [% IF p.title %]
-        [% p.title %]
-        [% IF is_listmaster %]
-          ([% p.name %])
-        [% END %]
-      [% ELSE %]
-        [% p.name %]
-      [% END %]
-      [% IF is_listmaster %]
-        [% IF p.default == '1' %]
-          [%|loc%](default)[%END%]
-        [% END %]
-      [% END %]
-      <span class="edit_list_request_help">
-      [% IF p.type == 'scenario' %]
-        [% IF is_listmaster %]
-          &nbsp;<a class="input" href="[% 'dump_scenario' | url_rel([list,p.name]) %]" title="[%|loc%]scenario source[%END%]">[%|loc%]scenario source[%END%]</a>
-        [% END %]
-      [% END %]
-      <a  href="[% 'nomenu/help/editlist' | url_rel %]#[% p.name %]" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=800,height=400')" target="wws_help"><i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i></a>
-      </span>
-      </h4>
+  [% FOREACH pS = config_schema ~%]
+    [% SET pV = config_values.${pS.name} ~%]
 
-      <div class="edit_list_request_enum">
-      [% IF p.occurrence == 'multiple' %]
+    [% IF pS.changed ~%]
+      <div class="CurrentBlock">
+    [%~ ELSE ~%]
+      <div class="block">
+    [%~ END ~%]
+    <h4>
+    [% IF pS.title ~%]
+      [% pS.title %]
+      [%~ IF is_listmaster %] ([% pS.name %])[% END %]
+    [%~ ELSE ~%]
+      [% pS.name %]
+    [%~ END %]
+    [%~ IF is_listmaster && pS.default_value %] [%|loc%](default)[%END%][% END %]
+    <span class="edit_list_request_help">
+    [% IF pS.type == 'scenario' ~%]
+      [% IF is_listmaster ~%]
+        &nbsp;<a class="input"
+         href="[% 'dump_scenario' | url_rel([list,pS.name]) %]"
+         title="[%|loc%]scenario source[%END%]">[%|loc%]scenario source[%END~%]
+        </a>
+      [%~ END %]
+    [%~ END %]
+    <a href="[% 'nomenu/help/editlist' | url_rel %]#[% pS.name %]"
+     title="[%|loc%]Open in a new window[%END%]"
+     onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=800,height=400')"
+     target="wws_help">
+    <i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i>
+    </a>
+    </span>
+    </h4>
 
-        <!-- Multiple params -->
-        [% IF p.type == 'enum' %]
-          [% PROCESS EditListSet 
-             ppaths=[p.name]
-             pitem=p
-             val=p.value
-          %]
-        [% ELSE %]
-          [% o_INDEX = 0 %]
-        [% FOREACH o = p.value %]
+    <div class="edit_list_request_enum">
 
-          <!-- Foreach occurrence -->
-            [% IF p.type == 'paragraph' %]
+    [% IF pS.type == 'set' ~%]
+      [% PROCESS EditListSet 
+         ppaths=[pS.name]
+         pitem=pS
+         val=pV
+      %]
+    [%~ ELSIF pS.occurrence.match('n$') ~%]
 
-              <!-- ParagrapH -->
-              <span class="divider"></span>
-              [% FOREACH key = o.value %]
-                [% IF key.may_edit != 'hidden' %] 
-                  <label for="param.[% p.name %].[% o_INDEX %].[% key.name %]">
-                  [% IF key.title %]
-                    [% key.title %][% IF is_listmaster %] ([% key.name %])[% END %][%|loc%]:[%END%]
-                  [% ELSE %]
-                    [% key.name %][%|loc%]:[%END%]
-                  [% END %]
-                  </label>
+      <!-- array -->
+      [% oI = 0 ~%]
 
-                  [% IF key.type == 'enum' %]
-                    [% PROCESS EditListEnum 
-                       ppaths=[p.name,o_INDEX,key.name]
-                       pitem=key
-                       val=key.value
-                    %]
-                  [% ELSIF key.type == 'datasource' %]
-                    [% PROCESS EditListDatasource 
-                       ppaths=[p.name,o_INDEX,key.name]
-                       pitem=key
-                       val=key.value
-                    %]
-                  [% ELSE %]
-                    [% PROCESS EditListScalar 
-                       ppaths=[p.name,o_INDEX,key.name]
-                       pitem=key
-                       val=key.value
-                    %]
-                  [% END %]
-                [% END %]
-              [% END %]
-            [% ELSE %]
-              [% PROCESS EditListScalar 
-                 ppaths=[p.name,o_INDEX]
-                 pitem=p
-                 val=o.value
+      [% FOREACH oV = pV ~%]
+        [% IF pS.type == 'paragraph' ~%]
+          <span class="divider"></span>
+
+          <!-- paragraph -->
+          [% FOREACH kS = pS.format ~%]
+            [% SET kV = oV.${kS.name} ~%]
+
+            <label for="param.[% pS.name %].[% oI %].[% kS.name %]">
+            [% IF kS.title ~%]
+              [% kS.title %]
+              [%~ IF is_listmaster %] ([% kS.name %])[% END %][%|loc%]:[%END%]
+            [%~ ELSE ~%]
+              [% kS.name %][%|loc%]:[%END%]
+            [%~ END %]
+            </label>
+
+            [% IF kS.type == 'set' ~%]
+              [% PROCESS EditListSet
+                 ppaths=[pS.name,oI,kS.name]
+                 pitem=kS
+                 val=kV
               %]
-            [% END %]
-            [% o_INDEX = o_INDEX + 1 %]
+            [%~ ELSIF kS.type == 'leaf' ~%]
+              [% PROCESS EditListLeaf
+                 ppaths=[pS.name,oI,kS.name]
+                 pitem=kS
+                 val=kV
+              %]
+            [%~ END %]
           [% END %]
-          <!-- END Foreach occurrence -->
-        [%END%]
-        <!-- ENDIF Enum -->
-      [% ELSE %]
-
-        <!-- Single params -->
-        [% IF p.type == 'scenario' %]
-          [% PROCESS EditListScenario 
-             ppaths=[p.name]
-             pitem=p
-             val=p.value
+          <!-- end paragraph -->
+        [%~ ELSE ~%]
+          [% PROCESS EditListLeaf
+             ppaths=[pS.name,oI]
+             pitem=pS
+             val=oV
           %]
-        [% ELSIF p.type == 'task' %]
-          [% PROCESS EditListTask 
-             ppaths=[p.name]
-             pitem=p
-             val=p.value
-          %]
-        [% ELSIF p.type == 'datasource' %]
-          [% PROCESS EditListDatasource 
-             ppaths=[p.name]
-             pitem=p
-             val=p.value
-          %]
-        [% ELSIF p.type == 'paragraph' %]
+        [%~ END %]
+        [%~ oI = oI + 1 %]
+      [% END %]
 
-          <!-- Paragraph -->
-          [% FOREACH key = p.value %]
-            [% IF key.may_edit != 'hidden' %] 
-              <label for="param.[% p.name %].[% key.name %]">
-              [% IF key.title %]
-                [% key.title %][% IF is_listmaster %] ([% key.name %])[% END %][%|loc%]:[%END%]
-              [% ELSE %]
-                [% key.name %][%|loc%]:[%END%]
-              [% END %]
-              </label>
+      [%# Additional empty section. ~%]
+      [% IF pS.privilege == 'write' ~%]
+        [% IF pS.type == 'paragraph' ~%]
+          <span class="divider"></span>
 
-              [% IF key.type == 'scenario' %]
-                [% PROCESS EditListScenario 
-                   ppaths=[p.name,key.name]
-                   pitem=key
-                   val=key.value
-                %]
-              [% ELSIF key.type == 'task' %]
-                [% PROCESS EditListTask 
-                   ppaths=[p.name,key.name]
-                   pitem=key
-                   val=key.value
-                %]
-              [% ELSIF key.type == 'datasource' %]
-                [% PROCESS EditListDatasource 
-                   ppaths=[p.name,key.name]
-                   pitem=key
-                   val=key.value
-                %]
-              [% ELSIF key.type == 'enum' %]
-                [% IF key.occurrence == 'multiple' %]
-                  [% PROCESS EditListSet 
-                     ppaths=[p.name,key.name]
-                     pitem=key
-                     val=key.value
-                  %]
-                [% ELSE %]
-                  [% PROCESS EditListEnum 
-                     ppaths=[p.name,key.name]
-                     pitem=key
-                     val=key.value
-                  %]
-                [% END %]
-              [% ELSE %]
-                [% PROCESS EditListScalar 
-                   ppaths=[p.name,key.name]
-                   pitem=key
-                   val=key.value
-                %]
-              [% END %]
-            [% END %]
+          <!-- paragraph -->
+          [% FOREACH kS = pS.format ~%]
+            [% SET kV = kS.default # Default value. ~%]
+
+            <label for="param.[% pS.name %].[% oI %].[% kS.name %]">
+            [% IF kS.title ~%]
+              [% kS.title %]
+              [%~ IF is_listmaster %] ([% kS.name %])[% END %][%|loc%]:[%END%]
+            [%~ ELSE ~%]
+              [% kS.name %][%|loc%]:[%END%]
+            [%~ END %]
+            </label>
+
+            [% IF kS.type == 'set' ~%]
+              [% PROCESS EditListSet
+                 ppaths=[pS.name,oI,kS.name]
+                 pitem=kS
+                 val=kV
+              %]
+            [%~ ELSIF kS.type == 'leaf' ~%]
+              [% PROCESS EditListLeaf
+                 ppaths=[pS.name,oI,kS.name]
+                 pitem=kS
+                 val=kV
+              %]
+            [%~ END %]
           [% END %]
-        [% ELSIF p.type == 'enum' %]
-          [% PROCESS EditListEnum 
-             ppaths=[p.name]
-             pitem=p
-             val=p.value
+          <!-- end paragraph -->
+        [%~ ELSE ~%]
+          [% PROCESS EditListLeaf
+             ppaths=[pS.name,oI]
+             pitem=pS
+             val=UNDEF # Empty value.
           %]
-        [% ELSE %]
-          [% PROCESS EditListScalar 
-             ppaths=[p.name]
-             pitem=p
-             val=p.value
-          %]
+        [%~ END %]
+      [%~ END %]
+
+      <!-- end array -->
+    [%~ ELSE ~%]
+      [% IF pS.type == 'paragraph' ~%]
+
+        <!-- paragraph -->
+        [% FOREACH kS = pS.format ~%]
+          [% SET kV = pV.${kS.name} ~%]
+
+          <label for="param.[% pS.name %].[% kS.name %]">
+          [% IF kS.title ~%]
+            [% kS.title %]
+            [%~ IF is_listmaster %] ([% kS.name %])[% END %][%|loc%]:[%END%]
+          [%~ ELSE ~%]
+            [% kS.name %][%|loc%]:[%END%]
+          [%~ END %]
+          </label>
+
+          [% IF kS.type == 'set' ~%]
+            [% PROCESS EditListSet 
+               ppaths=[pS.name,kS.name]
+               pitem=kS
+               val=kV
+            %]
+          [%~ ELSIF kS.type == 'leaf' ~%]
+            [% PROCESS EditListLeaf
+               ppaths=[pS.name,kS.name]
+               pitem=kS
+               val=kV
+            %]
+          [%~ END %]
         [% END %]
-      [% END %]
-      </div>[%# class="edit_list_request_enum" #%]
-
-      [% IF p.default == '1' %]
-        <div class="default" style="clear: both;"><span>[%|loc%]default[%END%]</span></div>
-      [% END %]
-      </div>
+        <!-- end paragraph -->
+      [%~ ELSIF pS.type == 'leaf' ~%]
+        [% PROCESS EditListLeaf
+           ppaths=[pS.name]
+           pitem=pS
+           val=pV
+        %]
+      [%~ END %]
     [% END %]
+
+    </div>
+
+    [% IF pS.default_value ~%]
+      <div class="default" style="clear: both;">
+      <span>[%|loc%]default[%END%]</span>
+      </div>
+    [%~ END %]
+    </div>
   [% END %]
 
   <input type="hidden" name="list" value="[% list %]" />
   <input type="hidden" name="group" value="[% group %]" />
   <input type="hidden" name="action" value="edit_list" />
-  [% IF is_form_editable == '1' %]
+  [% IF is_form_editable ~%]
     <input class="MainMenuLinks" type="submit" name="action_edit_list"
      value="[%|loc%]Update[%END%]" />
-  [% END %]
+  [%~ END %]
   </fieldset>
   </form>
 [%~ END %]
@@ -220,135 +220,171 @@
 
 [%# Block definitions ~%]
 
-[%~ BLOCK EditListSet ~%]
-  <!-- set -->[%# ppaths,pitem,val %]
-  [% IF pitem.may_edit == 'write' %]
+[%~ BLOCK EditListSet # (ppaths,pitem,val) ~%]
+  <!-- set -->
+  [% IF pitem.privilege == 'write' ~%]
     <select name="multiple_param.[% ppaths.join('.') %]"
      id="param.[% ppaths.join('.') %]"
-     multiple="multiple" size="[% val.size %]"
+     multiple="multiple" size="[% pitem.format.size() %]"
      [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
-    [% FOREACH enum = val ~%]
-      <option value="[% enum.key %]"
-       [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
-       [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[% END %]>
-      [%~ enum.key | optdesc(pitem.field_type,is_listmaster) ~%]
+    [% FOREACH enum = pitem.format ~%]
+      <option value="[% enum %]"
+       [%~ FOREACH v = val ~%]
+         [%~ IF enum == v %] selected="selected"[% END %]
+       [%~ END %]
+       [%~ IF pitem.field_type == 'lang' %] lang="[% enum %]"
+         xml:lang="[% enum %]"[% END %]>
+      [%~ enum | optdesc(pitem.field_type,is_listmaster) ~%]
       </option>
     [% END %]
     </select>
-  [% ELSIF pitem.may_edit == 'read' %]
-    [% FOREACH enum = val ~%]
-      [% IF enum.value.selected == '1' ~%]
-        [%~ IF pitem.field_type == 'lang' ~%]
-          <span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">
-        [%~ END ~%]
-        [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
-        [%~ IF pitem.field_type == 'lang' ~%]
-          </span>
+  [%~ ELSE ~%]
+    [% FOREACH enum = pitem.format ~%]
+      [% FOREACH v = val ~%]
+        [% IF enum == v ~%]
+          [%~ IF pitem.field_type == 'lang' ~%]
+            <span class="neutral" lang="[% enum %]" xml:lang="[% enum %]">
+          [%~ END ~%]
+          [% enum | optdesc(pitem.field_type,is_listmaster) %]
+          [%~ IF pitem.field_type == 'lang' ~%]
+            </span>
+          [%~ END %]
+
+          [%~ LAST %]
         [%~ END %]
-      [%~ END %]
+      [% END %]
     [%~ END %]
-  [% END %]
+  [%~ END %]
   <!-- end set -->
 [%~ END ~%]
 
-[%~ BLOCK EditListEnum ~%]
-  <!-- enum -->[%# ppaths, pitem, val %]
-  [% IF pitem.may_edit == 'write' %]
+[%~ BLOCK EditListLeaf # (ppaths,pitem,val) ~%]
+  [% IF pitem.enum ~%]
+    [% PROCESS EditListEnum %]
+  [%~ ELSIF pitem.scenario ~%]
+    [% PROCESS EditListScenario %]
+  [%~ ELSIF pitem.task ~%]
+    [% PROCESS EditListTask %]
+  [%~ ELSIF pitem.datasource ~%]
+    [% PROCESS EditListDatasource %]
+  [%~ ELSE ~%]
+    [% PROCESS EditListScalar %]
+  [%~ END %]
+[%~ END ~%]
+
+[%~ BLOCK EditListEnum # (ppaths,pitem,val) ~%]
+  <!-- enum -->
+  [% IF pitem.privilege == 'write' ~%]
     <select name="single_param.[% ppaths.join('.') %]"
      id="param.[% ppaths.join('.') %]"
      [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
-    [% FOREACH enum = val ~%]
-      <option value="[% enum.key %]"
-       [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
-       [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
-      [%~ enum.key | optdesc(pitem.field_type,is_listmaster) ~%]
+    [% FOREACH enum = pitem.format ~%]
+      <option value="[% enum %]"
+       [%~ IF enum == val %] selected="selected"[% END %]
+       [%~ IF pitem.field_type == 'lang' %] lang="[% enum %]"
+       xml:lang="[% enum %]"[%END%]>
+      [%~ enum | optdesc(pitem.field_type,is_listmaster) ~%]
       </option>
     [% END %]
     </select>
-  [% ELSIF pitem.may_edit == 'read' %]
-    [% FOREACH enum = val ~%]
-      [% IF enum.value.selected == '1' ~%]
+  [%~ ELSE ~%]
+    [% FOREACH enum = pitem.format ~%]
+      [% IF enum == val ~%]
         [% IF pitem.field_type == 'lang' ~%]
-          <span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">
+          <span class="neutral" lang="[% enum %]" xml:lang="[% enum %]">
         [%~ END ~%]
-        [% enum.key | optdesc(pitem.field_type,is_listmaster) %]
+        [% enum | optdesc(pitem.field_type,is_listmaster) %]
         [%~ IF pitem.field_type == 'lang' ~%]
           </span>
         [%~ END %]
+
+        [%~ LAST %]
       [%~ END %]
     [%~ END %]
-  [% END %]
+  [%~ END %]
   <!-- end enum -->
 [%~ END ~%]
 
-[%~ BLOCK EditListScenario ~%]
-  <!-- scenario -->[%# ppaths, pitem, val %]
-  [% IF pitem.may_edit == 'write' %]
+[%~ BLOCK EditListScenario # (ppaths,pitem,val) ~%]
+  <!-- scenario -->
+  [% IF pitem.privilege == 'write' ~%]
     <select name="single_param.[% ppaths.join('.') %].name"
      id="param.[% ppaths.join('.') %]">
-    [% FOREACH scenario = val ~%]
+    [% FOREACH scenario = pitem.format ~%]
       [% UNLESS scenario.value.name == 'default' ~%]
         <option value="[% scenario.value.name %]"
-         [%~ IF scenario.value.selected == '1' %] selected="selected"[% END %]>
-        [%~ scenario.value.web_title %] ([% scenario.value.name %])</option>
+         [%~ IF scenario.value.name == val.name %] selected="selected"[% END %]>
+        [%~ scenario.value.title %]
+        [%~ IF is_listmaster %] ([% scenario.value.name %])[% END ~%]
+        </option>
       [%~ END %]
     [% END %]
     </select>
-  [% ELSIF pitem.may_edit == 'read' %]
-    [% FOREACH scenario = val ~%]
-      [% IF scenario.value.selected == '1' ~%]
-        [% scenario.value.web_title %] ([% scenario.value.name %])
+  [%~ ELSE ~%]
+    [% FOREACH scenario = pitem.format ~%]
+      [% IF scenario.value.name == val.name ~%]
+        [% scenario.value.title %]
+        [%~ IF is_listmaster %] ([% scenario.value.name %])[% END %]
       [%~ END %]
     [%~ END %]
-  [% END %]
+  [%~ END %]
   <!-- end scenario -->
 [%~ END ~%]
 
-[%~ BLOCK EditListTask ~%]
-  <!-- task -->[%# ppaths, pitem, val %]
-  [% IF pitem.may_edit == 'write' %]
+[%~ BLOCK EditListTask # (ppaths,pitem,val) ~%]
+  <!-- task -->
+  [% IF pitem.privilege == 'write' ~%]
     <select name="single_param.[% ppaths.join('.') %].name"
      id="param.[% ppaths.join('.') %]">
-    [% FOREACH task = val ~%]
+    [% IF pitem.occurrence.match('^0') ~%]
+      <option value=""></option>
+    [%~ END %]
+    [% FOREACH task = pitem.format ~%]
       <option value="[% task.value.name %]"
-       [%~ IF task.value.selected == '1' %] selected="selected"[% END %]>
-      [%~ task.value.title %] ([% task.value.name %])</option>
+       [%~ IF task.value.name == val.name %] selected="selected"[% END %]>
+      [%~ task.value.title %]
+      [%~ IF is_listmaster %] ([% task.value.name %])[% END ~%]
+      </option>
     [% END %]
     </select>
-  [% ELSIF pitem.may_edit == 'read' %]
-    [% FOREACH task = val ~%]
-      [% IF task.value.selected == '1' ~%]
-        [% task.value.title %] ([% task.value.name %])
+  [%~ ELSE ~%]
+    [% FOREACH task = pitem.format ~%]
+      [% IF task.value.name == val.name ~%]
+        [% task.value.title %]
+        [%~ IF is_listmaster %] ([% task.value.name %])[% END %]
       [%~ END %]
     [%~ END %]
-  [% END %]
+  [%~ END %]
   <!-- end task -->
 [%~ END ~%]
 
-[%~ BLOCK EditListDatasource ~%]
-  <!-- datasource -->[%# ppaths, pitem, val %]
-  [% IF pitem.may_edit == 'write' %]
+[%~ BLOCK EditListDatasource # (ppaths,pitem,val) ~%]
+  <!-- datasource -->
+  [% IF pitem.privilege == 'write' ~%]
     <select name="single_param.[% ppaths.join('.') %]"
      id="param.[% ppaths.join('.') %]">
-    [% FOREACH source = val ~%]
+    [% FOREACH source = pitem.format ~%]
       <option value="[% source.value.name %]"
-       [%~ IF source.value.selected == '1' %] selected="selected"[% END %]>
-      [%~ source.value.title %] ([% source.value.name %])</option>
+       [%~ IF source.value.name == val %] selected="selected"[% END %]>
+      [%~ source.value.title %]
+      [%~ IF is_listmaster %] ([% source.value.name %])[% END ~%]
+      </option>
     [% END %]
     </select>
-  [% ELSIF pitem.may_edit == 'read' %]
-    [% FOREACH source = val ~%]
-      [% IF source.value.selected == '1' ~%]
-        [% source.value.title %] ([% source.value.name %])
+  [%~ ELSE ~%]
+    [% FOREACH source = pitem.format ~%]
+      [% IF source.value.name == val ~%]
+        [% source.value.title %]
+        [%~ IF is_listmaster %] ([% source.value.name %])[% END %]
       [%~ END %]
     [%~ END %]
-  [% END %]
+  [%~ END %]
   <!-- end datasource -->
 [%~ END ~%]
 
-[%~ BLOCK EditListScalar ~%]
-  <!-- scalar -->[%# ppaths, pitem, val %]
-  [% IF pitem.may_edit == 'write' %]
+[%~ BLOCK EditListScalar # (ppaths,pitem,val) ~%]
+  <!-- scalar -->
+  [% IF pitem.privilege == 'write' ~%]
     <input name="single_param.[% ppaths.join('.') %]"
      id="param.[% ppaths.join('.') %]"
      value="[% val %]" size="[% pitem.length %]"
@@ -356,7 +392,7 @@
      [%~ ELSE %] type="text"
      [%~ END %]
      [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %] />
-  [% ELSIF pitem.may_edit == 'read' %]
+  [%~ ELSE ~%]
     [% IF pitem.field_type == 'lang' ~%]
       <span class="neutral" lang="[% val %]" xml:lang="[% val %]">
     [%~ END ~%]
@@ -368,8 +404,7 @@
     [%~ IF pitem.field_type == 'lang' ~%]
       </span>
     [%~ END %]
-  [% END %]
-  [% pitem.unit %]
+  [%~ END %] [% pitem.unit %]
   <!-- end scalar -->
 [%~ END ~%]
 

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -50,33 +50,36 @@
                       <!-- Multiple params -->
 
                       [% IF p.type == 'enum' %]
-                        <!-- Multiple Enum -->
-
+                          <!-- set -->
                           [% IF p.may_edit == 'write' %]
-                            <select name="multiple_param.[% p.name %]" id="param.[% p.name %]" multiple="multiple" size="[% p.value.size %]">
+                            <select name="multiple_param.[% p.name %]" id="param.[% p.name %]" multiple="multiple" size="[% p.value.size %]"
+                             [%~ IF p.field_type == 'lang' %] class="neutral"[% END %]>
                               [% FOREACH enum = p.value %]
                                 <option value="[% enum.key %]"
-                                [% IF enum.value.selected == '1' %]
-                                  selected="selected"
-                                [% END %]
-                                [% IF enum.value.title %]
-                                  >[% enum.value.title %]</option>
-                                [% ELSE %]
-                                  >[%|optdesc('',is_listmaster)%][% enum.key %][%END%]</option>
-                                [% END %]
+                                 [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
+                                 [%~ IF p.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[% END %]>
+                                [%~ IF enum.value.title ~%]
+                                  [% enum.value.title %]
+                                [%~ ELSE ~%]
+                                  [% enum.key | optdesc(p.field_type,is_listmaster) %]
+                                [%~ END ~%]
+                                </option>
                               [% END %]
                             </select>
                           [% ELSIF p.may_edit == 'read' %]
                             [% FOREACH enum = p.value %]
-                              [% IF enum.value.selected == '1' %]
-                                [% IF enum.value.title %]
+                              [% IF enum.value.selected == '1' ~%]
+                                [%~ IF p.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
+                                [% IF enum.value.title ~%]
                                   [% enum.value.title %]
-                                [% ELSE %]
-                                  [%|optdesc('',is_listmaster)%][% enum.key %][%END%]
-                                [% END %]
-                              [% END %]
+                                [%~ ELSE ~%]
+                                  [% enum.key | optdesc(p.field_type,is_listmaster) %]
+                                [%~ END %]
+                                [%~ IF p.field_type == 'lang' %]</span>[% END %]
+                              [%~ END %]
                             [% END %]
                           [% END %]
+                          <!-- end set -->
                       [% ELSE %]
                         [% o_INDEX = 0 %]
                         [% FOREACH o = p.value %]
@@ -99,41 +102,46 @@
                                       </label>
 
                                       [% IF key.type == 'enum' %]
-                                        <!-- Enum -->
-                                        
+                                        <!-- enum -->
                                         [% IF key.may_edit == 'write' %]
-                                          <select name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]">
-                                            [% FOREACH enum = key.value %]
-                                              <option value="[% enum.key %]"
-                                              [%- IF enum.value.selected == '1' -%]
-                                                selected="selected"
-                                              [%- END -%]
-                                              >[% IF enum.value.title %][% enum.value.title %][% ELSE %][%|optdesc('',is_listmaster)%][% enum.key %][%END%][% END %]
-                                              </option>
-                                            [% END %]
+                                          <select name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]"
+                                           [%~ IF key.field_type == 'lang' %] class="neutral"[% END %]>
+                                          [% FOREACH enum = key.value %]
+                                            <option value="[% enum.key %]"
+                                             [%~ IF enum.value.selected == '1' %] selected="selected"[% END ~%]
+                                             [%~ IF pitem.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
+                                            [%~ IF enum.value.title ~%]
+                                              [% enum.value.title %]
+                                            [%~ ELSE ~%]
+                                              [% enum.key | optdesc(key.field_type,is_listmaster) %]
+                                            [%~ END %]
+                                            </option>
+                                          [% END %]
                                           </select>
                                         [% ELSIF key.may_edit == 'read' %]
                                           [% FOREACH enum = key.value %]
-                                            [% IF enum.value.selected == '1' %]
-                                              [% IF enum.value.title %][% enum.value.title %][% ELSE %][%|optdesc('',is_listmaster)%][% enum.key %][%END%][% END %]
-                                            [% END %]
+                                            [% IF enum.value.selected == '1' ~%]
+                                              [%~ IF key.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
+                                              [% IF enum.value.title ~%]
+                                                [% enum.value.title %]
+                                              [%~ ELSE ~%]
+                                                [% enum.key | optdesc(key.field_type,is_listmaster) %]
+                                              [%~ END %]
+                                              [%~ IF key.field_type == 'lang' %]</span>[% END ~%]
+                                            [%~ END %]
                                           [% END %]
                                         [% END %]
-
-                                        
+                                        <!-- end enum -->
                                       [% ELSIF key.type == 'datasource' %]
-                                        <!-- Datasource -->
+                                        <!-- datasource -->
                                         [% IF key.may_edit == 'write' %]
                                           <select name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]">
-                                            [% FOREACH source = key.value %]
-                                              <option value="[% source.value.name %]"
-                                              [% IF source.value.selected == '1' %]
-                                                selected="selected"
-                                              [% END %]
-                                              >[% source.value.title %] ([% source.value.name %])</option>
-                                            [% END %]
+                                          [% FOREACH source = key.value %]
+                                            <option value="[% source.value.name %]"
+                                             [%~ IF source.value.selected == '1' %] selected="selected"[% END %]>
+                                            [%~ source.value.title %] ([% source.value.name %])</option>
+                                          [% END %]
                                           </select>
-
                                         [% ELSIF key.may_edit == 'read' %]
                                           [% FOREACH source = key.value %]
                                             [% IF source.value.selected == '1' %]
@@ -141,42 +149,51 @@
                                             [% END %]
                                           [% END %]
                                         [% END %]
+                                        <!-- end datasource -->
                                       [% ELSE %]
-                                        <!-- Scalar -->
+                                        <!-- scalar -->
                                         [% IF key.may_edit == 'write' %]
                                           <input
                                            [%~ IF key.field_type == 'password' %] type="password"
                                            [%~ ELSE %] type="text"
                                            [%~ END %]
-                                           name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]" value="[% key.value %]" size="[% key.length %]" />
-                                        [% ELSIF key.may_edit == 'read' %]
-                                          [% IF key.field_type == 'password' ~%]
-                                            [% x = '*'; x.repeat(key.value.length()) %]
+                                           name="single_param.[% p.name %].[% o_INDEX %].[% key.name %]" id="param.[% p.name %].[% o_INDEX %].[% key.name %]" value="[% key.value %]" size="[% key.length %]"
+                                           [%~ IF key.field_type == 'lang' %] class="neutral"[% END %] />
+                                        [% ELSIF key.may_edit == 'read' ~%]
+                                          [% IF key.field_type == 'lang' %]<span class="neutral" lang="[%key.value%]" xml:lang="[%key.value%]">[% END ~%]
+                                          [% IF key.field_type ~%]
+                                            [% key.value | optdesc(key.field_type,is_listmaster) %]
                                           [%~ ELSE ~%]
                                             [% key.value %]
                                           [%~ END %]
-                                        [% END %]
+                                          [%~ IF key.field_type == 'lang' %]</span>[% END %]
+                                        [%~ END %]
                                         [% key.unit %]
+                                        <!-- end scalar -->
                                       [% END %]
                                   
                                 [% END %]
                               [% END %]
                             [% ELSE %]
-                              <!-- Scalar -->
+                                  <!-- scalar -->
                                   [% IF p.may_edit == 'write' %]
                                     <input
                                      [%~ IF p.field_type == 'password' %] type="password"
                                      [%~ ELSE %] type="text"
                                      [%~ END %]
-                                     name="single_param.[% p.name %].[% o_INDEX %]" id="param.[% p.name %].[% o_INDEX %]" value="[% o.value %]" size="[% o.length %]" />
-                                  [% ELSIF p.may_edit == 'read' %]
-                                    [% IF p.field_type == 'password' ~%]
-                                      [% x = '*'; x.repeat(o.value.length()) %]
+                                     name="single_param.[% p.name %].[% o_INDEX %]" id="param.[% p.name %].[% o_INDEX %]" value="[% o.value %]" size="[% p.length %]"
+                                     [%~ IF p.field_type == 'lang' %] class="neutral"[% END %] />
+                                  [% ELSIF p.may_edit == 'read' ~%]
+                                    [% IF p.field_type == 'lang' %]<span class="neutral" lang="[%o.value%]" xml:lang="[%o.value%]">[% END ~%]
+                                    [% IF p.field_type ~%]
+                                      [% o.value | optdesc(p.field_type,is_listmaster) %]
                                     [%~ ELSE ~%]
                                       [% o.value %]
                                     [%~ END %]
-                                  [% END %]
-                                  [% o.unit %]
+                                    [%~ IF p.field_type == 'lang' %]</span>[% END %]
+                                  [%~ END %]
+                                  [% p.unit %]
+                                  <!-- end scalar -->
                             [% END %]
                             [% o_INDEX = o_INDEX + 1 %]
                           [% END %]
@@ -188,20 +205,18 @@
                       [% ELSE %]
                         <!-- Single params -->
                           [% IF p.type == 'scenario' %]
-                            <!-- Scenario -->
+                            <!-- scenario -->
                             [% IF p.may_edit == 'write' %]
                               <select name="single_param.[% p.name %].name" id="param.[% p.name %]">
                                 [% FOREACH scenario = p.value %]
-                                  [% UNLESS scenario.value.name.match('(default)\s*$') %]
+                                  [% UNLESS scenario.value.name == 'default' ~%]
                                     <option value="[% scenario.value.name %]"
-                                    [% IF scenario.value.selected == '1' %]
-                                      selected="selected"
-                                    [% END %]
-                                    >[% scenario.value.web_title %] ([% scenario.value.name %])</option>
-                                  [% END %]
+                                     [%~ IF scenario.value.selected == '1' %] selected="selected"[% END %]>
+                                    [% scenario.value.web_title %] ([% scenario.value.name %])
+                                    </option>
+                                  [%~ END %]
                                 [% END %]
                               </select>
-
                             [% ELSIF p.may_edit == 'read' %]
                               [% FOREACH scenario = p.value %]
                                 [% IF scenario.value.selected == '1' %]
@@ -209,9 +224,9 @@
                                 [% END %]
                               [% END %]
                             [% END %]
-
+                            <!-- end scenario -->
                           [% ELSIF p.type == 'task' %]
-                            <!-- Task -->
+                            <!-- task -->
                             [% IF p.may_edit == 'write' %]
                               <select name="single_param.[% p.name %].name" id="param.[% p.name %]">
                                 [% FOREACH task = p.value %]
@@ -229,8 +244,9 @@
                                 [% END %]
                               [% END %]
                             [% END %]
+                            <!-- end task -->
                           [% ELSIF p.type == 'datasource' %]
-                            <!-- Datasource -->
+                            <!-- datasource -->
                             [% IF p.may_edit == 'write' %]
                               <select name="single_param.[% p.name %]" id="param.[% p.name %]">
                                 [% FOREACH source = p.value %]
@@ -248,6 +264,7 @@
                                 [% END %]
                               [% END %]
                             [% END %]
+                            <!-- end datasource -->
                           [% ELSIF p.type == 'paragraph' %]
                               <!-- Paragraph -->
                               [% FOREACH key = p.value %]
@@ -261,18 +278,18 @@
                                       </label>
 
                                       [% IF key.type == 'scenario' %]
-                                        <!-- Scenario -->
+                                        <!-- scenario -->
                                         [% IF key.may_edit == 'write' %]
                                           <select name="single_param.[% p.name %].[% key.name %].name" id="param.[% p.name %].[% key.name %]">
                                             [% FOREACH scenario = key.value %]
-                                              <option value="[% scenario.value.name %]"
-                                              [% IF scenario.value.selected == '1' %]
-                                                selected="selected"
-                                              [% END %]
-                                              >[% scenario.value.web_title %] ([% scenario.value.name %])</option>
+                                              [% UNLESS scenario.value.name == 'default' ~%]
+                                                <option value="[% scenario.value.name %]"
+                                                 [% IF scenario.value.selected == '1' %] selected="selected"[% END %]>
+                                                [% scenario.value.web_title %] ([% scenario.value.name %])
+                                                </option>
+                                              [%~ END %]
                                             [% END %]
                                           </select>
-
                                         [% ELSIF key.may_edit == 'read' %]
                                           [% FOREACH scenario = key.value %]
                                             [% IF scenario.value.selected == '1' %]
@@ -280,12 +297,13 @@
                                             [% END %]
                                           [% END %]
                                         [% END %]
+                                        <!-- end scenario -->
                                       [% ELSIF key.type == 'task' %]
-                                        <!-- Task -->
+                                        <!-- task -->
                                         [% IF key.may_edit == 'write' %]
                                           <select name="single_param.[% p.name %].[% key.name %].name" id="param.[% p.name %].[% key.name %]">
                                             [% FOREACH task = key.value %]
-                                              <option value="[% task.name %]"
+                                              <option value="[% task.value.name %]"
                                               [% IF task.value.selected == '1' %]
                                                 selected="selected"
                                               [% END %]
@@ -299,16 +317,15 @@
                                             [% END %]
                                           [% END %]
                                         [% END %]
+                                        <!-- end task -->
                                       [% ELSIF key.type == 'datasource' %]
-                                        <!-- Datasource -->
+                                        <!-- datasource -->
                                         [% IF key.may_edit == 'write' %]
                                           <select name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]">
                                             [% FOREACH source = key.value %]
                                               <option value="[% source.value.name %]"
-                                              [% IF source.value.selected == '1' %]
-                                                selected="selected"
-                                              [% END %]
-                                              >[% source.value.title %] ([% source.value.name %])</option>
+                                               [%~ IF source.value.selected == '1' %] selected="selected"[% END %]>
+                                              [%~ source.value.title %] ([% source.value.name %])</option>
                                             [% END %]
                                           </select>
                                         [% ELSIF key.may_edit == 'read' %]
@@ -318,125 +335,145 @@
                                             [% END %]
                                           [% END %]
                                         [% END %]
-
+                                        <!-- end datasource -->
                                       [% ELSIF key.type == 'enum' %]
-                                        <!-- Enum -->
-                                        [% IF key.may_edit == 'write' %]
-                                          [% IF key.occurrence == 'multiple' %]
-                                            <select name="multiple_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" multiple="multiple" size="[% key.value.size %]">
-                                          [% ELSE %]
-                                            <select name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" class="neutral">
-                                          [% END %]
-                                          [% FOREACH enum = key.value %]
-                                            <option value="[% enum.key %]"
-                                              [% IF enum.value.selected == '1' %]
-                                                selected="selected"
-                                              [% END %]
-                                              [% IF p.name == 'lang' %]
-                                                lang="[%enum.key%]"
-                                                xml:lang="[%enum.key%]"
-                                              [%END%]
-                                              [% IF enum.value.title %]
-                                                >[% enum.value.title %]</option>
-                                              [% ELSE %]
-                                                >[%|optdesc('',is_listmaster)%][% enum.key %][%END%]</option>
-                                              [% END %]
-                                          [% END %]
-                                          </select>
-
-                                        [% ELSIF key.may_edit == 'read' %]
-                                          [% FOREACH enum = key.value %]
-                                            [% IF enum.value.selected == '1' %]
-                                              [% IF enum.value.title %]
-                                                [% IF p.name == 'lang' %]
-                                                  <span class="neutral"
-                                                  lang="[%enum.key%]"
-                                                  xml:lang="[%enum.key%]"
-                                                  >[% enum.value.title %]</span>
-                                                [% ELSE %]
+                                        [% IF key.occurrence == 'multiple' %]
+                                          <!-- set -->
+                                          [% IF key.may_edit == 'write' %]
+                                            <select name="multiple_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" multiple="multiple" size="[% key.value.size %]"
+                                             [%~ IF key.field_type == 'lang' %] class="neutral"[% END %]>
+                                            [% FOREACH enum = key.value %]
+                                              <option value="[% enum.key %]"
+                                              [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
+                                              [%~ IF key.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
+                                              [%~ IF enum.value.title ~%]
+                                                [% enum.value.title %]
+                                              [%~ ELSE ~%]
+                                                [% enum.key | optdesc(key.field_type,is_listmaster) %]
+                                              [%~ END ~%]
+                                              </option>
+                                            [% END %]
+                                            </select>
+                                          [% ELSIF key.may_edit == 'read' %]
+                                            [% FOREACH enum = key.value %]
+                                              [% IF enum.value.selected == '1' ~%]
+                                                [% IF key.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
+                                                [%~ IF enum.value.title ~%]
                                                   [% enum.value.title %]
-                                                [% END %]
-                                              [% ELSE %]
-                                                [%|optdesc('',is_listmaster)%][% enum.key %][%END%]
+                                                [%~ ELSE ~%]
+                                                  [% enum.key | optdesc(key.field_type,is_listmaster) %]
+                                                [%~ END ~%]
+                                                [% IF key.field_type == 'lang' %]</span>[% END %]
                                               [% END %]
                                             [% END %]
                                           [% END %]
+                                          <!-- end set -->
+                                        [% ELSE %]
+                                          <!-- enum -->
+                                          [% IF key.may_edit == 'write' %]
+                                            <select name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]"
+                                             [%~ IF key.field_type == 'lang' %] class="neutral"[% END %]>
+                                            [% FOREACH enum = key.value %]
+                                              <option value="[% enum.key %]"
+                                               [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
+                                               [%~ IF key.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
+                                              [%~ IF enum.value.title ~%]
+                                                [% enum.value.title %]
+                                              [%~ ELSE ~%]
+                                                [% enum.key | optdesc(key.field_type,is_listmaster) %]
+                                              [%~ END ~%]
+                                              </option>
+                                            [% END %]
+                                            </select>
+                                          [% ELSIF key.may_edit == 'read' %]
+                                            [% FOREACH enum = key.value %]
+                                              [% IF enum.value.selected == '1' ~%]
+                                                [% IF key.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END ~%]
+                                                [%~ IF enum.value.title ~%]
+                                                  [% enum.value.title %]
+                                                [%~ ELSE ~%]
+                                                  [% enum.key | optdesc(key.field_type,is_listmaster) %]
+                                                [%~ END ~%]
+                                                [% IF key.field_type == 'lang' %]</span>[% END %]
+                                              [% END %]
+                                            [% END %]
+                                          [% END %]
+                                          <!-- end enum -->
                                         [% END %]
-
                                       [% ELSE %]
-                                        <!-- Scalar -->
+                                        <!-- scalar -->
                                         [% IF key.may_edit == 'write' %]
                                           <input
                                            [%~ IF key.field_type == 'password' %] type="password"
                                            [%~ ELSE %] type="text"
                                            [%~ END %]
-                                           name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" value="[% key.value %]" size="[% key.length %]" />
-                                        [% ELSIF key.may_edit == 'read' %]
-                                          [% IF key.field_type == 'password' ~%]
-                                            [% x = '*'; x.repeat(key.value.length()) %]
+                                           name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]" value="[% key.value %]" size="[% key.length %]"
+                                           [%~ IF key.field_type == 'lang' %] class="neutral"[% END %] />
+                                        [% ELSIF key.may_edit == 'read' ~%]
+                                          [%~ IF key.field_type == 'lang' %]<span class="neutral" lang="[%key.value%]" xml:lang="[%key.value%]">[%END%]
+                                          [% IF key.field_type ~%]
+                                            [% key.value | optdesc(key.field_type,is_listmaster) %]
                                           [%~ ELSE ~%]
                                             [% key.value %]
                                           [%~ END %]
-                                        [% END %]
+                                          [%~ IF key.field_type == 'lang' %]</span>[% END %]
+                                        [%~ END %]
                                         [% key.unit %]
-
+                                        <!-- end scalar -->
                                       [% END %]
                               [% END %]
                             [% END %]
                           [% ELSIF p.type == 'enum' %]
-                          <!-- Enum -->
+                            <!-- enum -->
                             [% IF p.may_edit == 'write' %]
-                              <select name="single_param.[% p.name %]" id="param.[% p.name %]" class="neutral">
+                              <select name="single_param.[% p.name %]" id="param.[% p.name %]"
+                               [%~ IF p.field_type == 'lang' %] class="neutral"[% END %]>
                                 [% FOREACH enum = p.value %]
                                   <option value="[% enum.key %]"
-                                  [% IF enum.value.selected == '1' %]
-                                    selected="selected"
-                                  [% END %]
-                                  [% IF p.name == 'lang' %]
-                                    lang="[%enum.key%]"
-                                    xml:lang="[%enum.key%]"
-                                  [%END%]
-                                  [% IF enum.value.title %]
-                                    >[% enum.value.title %]</option>
-                                  [% ELSE %]
-                                    >[%|optdesc('',is_listmaster)%][% enum.key %][%END%]</option>
-                                  [% END %]
+                                   [%~ IF enum.value.selected == '1' %] selected="selected"[% END %]
+                                   [%~ IF p.field_type == 'lang' %] lang="[%enum.key%]" xml:lang="[%enum.key%]"[%END%]>
+                                  [% IF enum.value.title ~%]
+                                    [% enum.value.title %]
+                                  [%~ ELSE ~%]
+                                    [% enum.key | optdesc(p.field_type,is_listmaster) %]
+                                  [%~ END %]
+                                  </option>
                                 [% END %]
                               </select>
                             [% ELSIF p.may_edit == 'read' %]
                               [% FOREACH enum = p.value %]
                                 [% IF enum.value.selected == '1' %]
-                                  [% IF enum.value.title %]
-                                    [% IF p.name == 'lang' %]
-                                      <span class="neutral"
-                                      lang="[%enum.key%]"
-                                      xml:lang="[%enum.key%]"
-                                      >[% enum.value.title %]</span>
-                                    [% ELSE %]
-                                      [% enum.value.title %]
-                                    [% END %]
-                                  [% ELSE %]
-                                    [%|optdesc('',is_listmaster)%][% enum.key %][%END%]
-                                  [% END %]
+                                  [%~ IF p.field_type == 'lang' %]<span class="neutral" lang="[%enum.key%]" xml:lang="[%enum.key%]">[% END %]
+                                  [%~ IF enum.value.title ~%]
+                                    [% enum.value.title %]
+                                  [%~ ELSE ~%]
+                                    [% enum.key | optdesc(p.field_type,is_listmaster) %]
+                                  [%~ END %]
+                                  [%~ IF p.field_type == 'lang' %]</span>[% END %]
                                 [% END %]
                               [% END %]
                             [% END %]
+                            <!-- end enum -->
                           [% ELSE %]
-                            <!-- Scalar -->
-                            [% IF p.may_edit == 'write' %]
+                            <!-- scalar -->
+                            [% IF p.may_edit == 'write' ~%]
                               <input
                                [%~ IF p.field_type == 'password' %] type="password"
                                [%~ ELSE %] type="text"
                                [%~ END %]
-                               name="single_param.[% p.name %]" id="param.[% p.name %]" value="[% p.value %]" size="[% p.length %]" />
-                            [% ELSIF p.may_edit == 'read' %]
-                              [% IF p.field_type == 'password' ~%]
-                                [% x = '*'; x.repeat(p.value.length()) %]
+                               name="single_param.[% p.name %]" id="param.[% p.name %]" value="[% p.value %]" size="[% p.length %]"
+                               [%~ IF p.field_type == 'lang' %] class="neutral"[% END %] />
+                            [%~ ELSIF p.may_edit == 'read' ~%]
+                              [%~ IF p.field_type == 'lang' %]<span class="neutral" lang="[% p.value %]" xml:lang="[% p.value %]">[% END ~%]
+                              [% IF p.field_type ~%]
+                                [% p.value | optdesc(p.field_type,is_listmaster) %]
                               [%~ ELSE ~%]
                                 [% p.value %]
                               [%~ END %]
+                              [%~ IF p.field_type == 'lang' %]</span>[% END %]
                             [% END %]
                             [% p.unit %]
+                            <!-- end scalar -->
                           [% END %]
 
                       [% END %]

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -130,7 +130,7 @@
                                               [% IF source.value.selected == '1' %]
                                                 selected="selected"
                                               [% END %]
-                                              >[% source.value.title %]</option>
+                                              >[% source.value.title %] ([% source.value.name %])</option>
                                             [% END %]
                                           </select>
 
@@ -304,7 +304,7 @@
                                         [% IF key.may_edit == 'write' %]
                                           <select name="single_param.[% p.name %].[% key.name %]" id="param.[% p.name %].[% key.name %]">
                                             [% FOREACH source = key.value %]
-                                              <option value="[% source.name %]"
+                                              <option value="[% source.value.name %]"
                                               [% IF source.value.selected == '1' %]
                                                 selected="selected"
                                               [% END %]

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -111,11 +111,13 @@
           <!-- end paragraph -->
           </div>
 
-          <div class="small-3 large-2 columns">
-          [% PROCESS EditListArrayDel
-             ppaths=[pS.name,oI]
-          %]
-          </div>
+          [% UNLESS pS.occurrence.match('^1') && pV.size() == 1 ~%] 
+            <div class="small-3 large-2 columns">
+            [% PROCESS EditListArrayDel
+               ppaths=[pS.name,oI]
+            %]
+            </div>
+          [%~ END %]
 
           </div>
           <span class="divider"></span>
@@ -131,11 +133,13 @@
           %]
           </div>
  
-          <div class="small-3 large-2 columns">
-          [% PROCESS EditListArrayDel
-             ppaths=[pS.name,oI]
-          %]
-          </div>
+          [% UNLESS pS.occurrence.match('^1') && pV.size() == 1 ~%] 
+            <div class="small-3 large-2 columns">
+            [% PROCESS EditListArrayDel
+               ppaths=[pS.name,oI]
+            %]
+            </div>
+          [%~ END %]
 
           </div>
         [%~ END %]
@@ -341,7 +345,7 @@
     <select name="single_param.[% ppaths.join('.') %]"
      id="param.[% ppaths.join('.') %]"
      [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
-    [% IF pitem.occurrence.match('^0') ~%]
+    [% IF pitem.occurrence.match('^0') || val.length() == 0 %][%# FIXME ~%]
       <option value=""></option>
     [%~ END %]
     [% FOREACH enum = pitem.format ~%]
@@ -402,7 +406,7 @@
   [% IF pitem.privilege == 'write' ~%]
     <select name="single_param.[% ppaths.join('.') %].name"
      id="param.[% ppaths.join('.') %]">
-    [% IF pitem.occurrence.match('^0') ~%]
+    [% IF pitem.occurrence.match('^0') || val.length() == 0 %][%# FIXME ~%]
       <option value=""></option>
     [%~ END %]
     [% FOREACH task = pitem.format ~%]
@@ -429,7 +433,7 @@
   [% IF pitem.privilege == 'write' ~%]
     <select name="single_param.[% ppaths.join('.') %]"
      id="param.[% ppaths.join('.') %]">
-    [% IF pitem.occurrence.match('^0') ~%]
+    [% IF pitem.occurrence.match('^0') || val.length() == 0 %][%# FIXME ~%]
       <option value=""></option>
     [%~ END %]
     [% FOREACH source = pitem.format ~%]

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -40,7 +40,7 @@
     [%~ END %]
     [%~ IF is_listmaster && pS.default_value %] [%|loc%](default)[%END%][% END %]
     <span class="edit_list_request_help">
-    [% IF pS.type == 'scenario' ~%]
+    [% IF pS.scenario ~%]
       [% IF is_listmaster ~%]
         &nbsp;<a class="input"
          href="[% 'dump_scenario' | url_rel([list,pS.name]) %]"

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -57,14 +57,19 @@
     </span>
     </h4>
 
-    <div class="edit_list_request_enum">
-
     [% IF pS.type == 'set' ~%]
+      <div class="row">
+
+      <div id="item.[% pS.name %]"
+       class="small-9 large-10 columns">
       [% PROCESS EditListSet 
          ppaths=[pS.name]
          pitem=pS
          val=pV
       %]
+      </div>
+
+      </div>
     [%~ ELSIF pS.occurrence.match('n$') ~%]
 
       <!-- array -->
@@ -72,8 +77,10 @@
 
       [% FOREACH oV = pV ~%]
         [% IF pS.type == 'paragraph' ~%]
-          <span class="divider"></span>
+          <div class="row">
 
+          <div id="item.[% pS.name %].[% oI %]"
+           class="small-9 large-10 columns">
           <!-- paragraph -->
           [% FOREACH kS = pS.format ~%]
             [% SET kV = oV.${kS.name} ~%]
@@ -102,12 +109,35 @@
             [%~ END %]
           [% END %]
           <!-- end paragraph -->
+          </div>
+
+          <div class="small-3 large-2 columns">
+          [% PROCESS EditListArrayDel
+             ppaths=[pS.name,oI]
+          %]
+          </div>
+
+          </div>
+          <span class="divider"></span>
         [%~ ELSE ~%]
+          <div class="row">
+
+          <div id="item.[% pS.name %].[% oI %]"
+           class="small-9 large-10 columns">
           [% PROCESS EditListLeaf
              ppaths=[pS.name,oI]
              pitem=pS
              val=oV
           %]
+          </div>
+ 
+          <div class="small-3 large-2 columns">
+          [% PROCESS EditListArrayDel
+             ppaths=[pS.name,oI]
+          %]
+          </div>
+
+          </div>
         [%~ END %]
         [%~ oI = oI + 1 %]
       [% END %]
@@ -115,8 +145,10 @@
       [%# Additional empty section. ~%]
       [% IF pS.privilege == 'write' ~%]
         [% IF pS.type == 'paragraph' ~%]
-          <span class="divider"></span>
+          <div class="row">
 
+          <div id="item.[% pS.name %].[% oI %]"
+           class="small-9 large-10 columns">
           <!-- paragraph -->
           [% FOREACH kS = pS.format ~%]
             [% SET kV = kS.default # Default value. ~%]
@@ -145,19 +177,32 @@
             [%~ END %]
           [% END %]
           <!-- end paragraph -->
+          </div>
+
+          </div>
         [%~ ELSE ~%]
+          <div class="row">
+
+          <div id="item.[% pS.name %].[% oI %]"
+           class="small-9 large-10 columns">
           [% PROCESS EditListLeaf
              ppaths=[pS.name,oI]
              pitem=pS
              val=UNDEF # Empty value.
           %]
+          </div>
+
+          </div>
         [%~ END %]
       [%~ END %]
 
       <!-- end array -->
     [%~ ELSE ~%]
       [% IF pS.type == 'paragraph' ~%]
+        <div class="row">
 
+        <div id="item.[% pS.name %]"
+         class="small-9 large-10 columns">
         <!-- paragraph -->
         [% FOREACH kS = pS.format ~%]
           [% SET kV = pV.${kS.name} ~%]
@@ -186,20 +231,28 @@
           [%~ END %]
         [% END %]
         <!-- end paragraph -->
+        </div>
+
+        </div>
       [%~ ELSIF pS.type == 'leaf' ~%]
+        <div class="row">
+
+        <div id="item.[% pS.name %]"
+         class="small-9 large-10 columns">
         [% PROCESS EditListLeaf
            ppaths=[pS.name]
            pitem=pS
            val=pV
         %]
+        </div>
+
+        </div>
       [%~ END %]
     [% END %]
 
-    </div>
-
     [% IF pS.default_value ~%]
-      <div class="default" style="clear: both;">
-      <span>[%|loc%]default[%END%]</span>
+      <div class="row">
+      <div class="columns">[%|loc%]default[%END%]</div>
       </div>
     [%~ END %]
     </div>
@@ -256,6 +309,16 @@
     [%~ END %]
   [%~ END %]
   <!-- end set -->
+[%~ END ~%]
+
+[%~ BLOCK EditListArrayDel # (ppaths) ~%]
+  <!-- del -->
+  <input type="checkbox" name="deleted_param.[% ppaths.join('.') %]"
+   id="del.[% ppaths.join('.') %]"
+   class="fadeIfChecked" data-selector="#item\.[% ppaths.join('\\.') %]"
+   value="del" />
+  <label for="del.[% ppaths.join('.') %]">[%|loc%]Delete[%END%]</label>
+  <!-- end del -->
 [%~ END ~%]
 
 [%~ BLOCK EditListLeaf # (ppaths,pitem,val) ~%]

--- a/default/web_tt2/edit_template.tt2
+++ b/default/web_tt2/edit_template.tt2
@@ -26,8 +26,9 @@
 [%|loc%](This template is the default for all languages unless it is redefined for a specific language)[%END%]
 [%- ELSE -%]
 <strong class="neutral"
-lang="[%tpl_lang_lang%]" xml:lang="[%tpl_lang_lang%]"
-> [% tpl_lang_title %] </strong>
+ lang="[%tpl_lang_lang%]" xml:lang="[%tpl_lang_lang%]">
+[%~ tpl_lang | optdesc('lang',1) ~%]
+</strong>
 [%- END %]</li>
 </ul>
 </p><br />

--- a/default/web_tt2/editsubscriber.tt2
+++ b/default/web_tt2/editsubscriber.tt2
@@ -28,20 +28,26 @@
 
   <label for="reception">[%|loc%]Receiving:[%END%]  </label>
   <select name="reception" id="reception">
-  [% FOREACH r = reception %]
-    <option value="[% r.key %]" [% r.value.selected %]>[% r.value.description %]</option>
+  [% FOREACH r = reception ~%]
+    <option value="[% r.key %]"
+     [%~ IF r.value.selected %] selected="selected"[% END %]>
+    [%~ r.key | optdesc('reception') ~%]
+    </option>
   [% END %]
   </select>
 
   <label for="visibility">[%|loc%]Visibility:[%END%]  </label>
   <select id="visibility" name="visibility">
-  [% FOREACH r = visibility %]
-    <option value="[% r.key %]" [% r.value.selected %]>[% r.value.description %]</option>
+  [% FOREACH r = visibility ~%]
+    <option value="[% r.key %]"
+     [%~ IF r.value.selected %] selected="selected"[% END %]>
+    [%~ r.key | optdesc('visibility') ~%]
+    </option>
   [% END %]
   </select>
 
-  <label>[%|loc%]Language:[%END%]  </label>[% current_subscriber.lang %]
-
+  <label>[%|loc%]Language:[%END%]  </label>
+  [% current_subscriber.lang | optdesc('lang') %]
 
   [% IF pictures_display ~%]
     [% IF current_subscriber.pictures_url || current_subscriber.email == user.email ~%]

--- a/default/web_tt2/error.tt2
+++ b/default/web_tt2/error.tt2
@@ -95,6 +95,7 @@
   [% ELSIF u_err.msg == 'config_changed' %][%|loc(u_err.email)%]Config file has been modified by %1. Cannot apply your changes[%END%]
   [% ELSIF u_err.msg == 'topic_other' %][%|loc%]Topic "other" is a reserved word[%END%]
   [% ELSIF u_err.msg == 'mandatory_parameter' %][%|loc(u_err.p_name)%]Parameter '%1' is mandatory. Ignoring deletion.[%END%]
+  [% ELSIF u_err.msg == 'unique_paragraph_key' %][%|loc(u_err.value,u_err.p_name)%]Duplicate value '%1' for parameter '%2'. Ignoring change.[%END%]
   [% ELSIF u_err.msg == 'p_family_controlled' %][%|loc(u_err.param)%]Parameter '%1' must have values[%END%]
   [% ELSIF u_err.msg == 'p_family_wrong' %][%|loc(u_err.param,u_err.val)%]Parameter '%1' has got wrong value: '%2'[%END%]
   [% ELSIF u_err.msg == 'already_closed' %][%|loc(u_err.listname)%]The list '%1' is already closed[%END%]

--- a/default/web_tt2/get_biggest_lists.tt2
+++ b/default/web_tt2/get_biggest_lists.tt2
@@ -15,7 +15,7 @@
 [% ELSE %]
   <tr class="color0">[% SET dark = 1 %]
 [% END %]
-<td>[% list.creation_date %]</td>
+<td>[% list.creation_date_epoch | optdesc('unixtime') %]</td>
 <td><a href="[% 'admin' | url_rel([list.name]) %]">[% list.name %]</a></td>
 <td>[% list.subject %]</td>
 <td>[% list.subscribers %]</td>

--- a/default/web_tt2/get_inactive_lists.tt2
+++ b/default/web_tt2/get_inactive_lists.tt2
@@ -23,8 +23,8 @@
   <tr class="color0">[% SET dark = 1 %]
 [% END %]
 
-<td>[% list.creation_date %]</td>
-<td>[% IF list.last_message_epoch > 0 %]
+<td>[% list.creation_date_epoch | optdesc('unixtime') %]</td>
+<td>[% IF list.last_message_epoch %]
       [% list.last_message_date %]
     [% ELSE %]
       <em>[%|loc%]none so far[%END%]</em>

--- a/default/web_tt2/get_latest_lists.tt2
+++ b/default/web_tt2/get_latest_lists.tt2
@@ -16,7 +16,7 @@
 [% ELSE %]
   <tr class="color0">[% SET dark = 1 %]
 [% END %]
-<td>[% list.creation_date %]</td>
+<td>[% list.creation_date_epoch | optdesc('unixtime') %]</td>
 <td><a href="[% 'admin' | url_rel([list.name]) %]">[% list.name %]</a></td>
 <td>[% list.subject %]</td>
 </tr>

--- a/default/web_tt2/get_pending_lists.tt2
+++ b/default/web_tt2/get_pending_lists.tt2
@@ -24,7 +24,7 @@
 <td><a href="[% 'set_pending_list_request' | url_rel([list.key]) %]">[% list.key %]</a></td>
 <td>[% list.value.subject %]</td>
 <td>[% list.value.by %]</td>
-<td>[% list.value.date %]</td>
+<td>[% list.value.date_epoch | optdesc('unixtime') %]</td>
 </tr>
 [% END %]
 </table>

--- a/default/web_tt2/lists.tt2
+++ b/default/web_tt2/lists.tt2
@@ -1,6 +1,10 @@
 <!-- $Id$ -->
 
-[%- IF subtitle %]<h3>[% subtitle %]</h3>[% END -%]
+[% IF topic ~%]
+  <h3>[% topic | optdesc('listtopic') %]</h3>
+[%~ ELSIF subtitle ~%]
+  <h3>[% subtitle %]</h3>
+[%~ END %]
 
 [% letters = ['a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','others' ] %]
 [% all_letters = [] %]

--- a/default/web_tt2/ls_templates.tt2
+++ b/default/web_tt2/ls_templates.tt2
@@ -53,8 +53,8 @@
 <th>&nbsp;</th>
 [%- ELSE -%]
 <th class="neutral"
-lang="[%lang.value.lang%]" xml:lang="[%lang.value.lang%]"
->[%lang.value.title%] ([%lang.key%])</th>
+ lang="[%lang.value.lang%]" xml:lang="[%lang.value.lang%]">
+[%~ lang.value.lang | optdesc('lang',1) %]</th>
 [%- END %]
 [% END %]
 
@@ -63,8 +63,8 @@ lang="[%lang.value.lang%]" xml:lang="[%lang.value.lang%]"
 <th>&nbsp;</th>
 [%- ELSE -%]
 <th class="neutral"
-lang="[%lang.value.lang%]" xml:lang="[%lang.value.lang%]"
->[%lang.value.title%] ([%lang.key%])</th>
+ lang="[%lang.value.lang%]" xml:lang="[%lang.value.lang%]">
+[%~ lang.key | optdesc('lang',1) %]</th>
 [%- END %]
 [% END %]
 
@@ -73,8 +73,8 @@ lang="[%lang.value.lang%]" xml:lang="[%lang.value.lang%]"
 <th>&nbsp;</th>
 [%- ELSE -%]
 <th class="neutral"
-lang="[%lang.value.lang%]" xml:lang="[%lang.value.lang%]"
->[%lang.value.title%] ([%lang.key%])</th>
+ lang="[%lang.value.lang%]" xml:lang="[%lang.value.lang%]">
+[%~ lang.key | optdesc('lang',1) %]</th>
 [%- END %]
 [% END %]
 
@@ -83,8 +83,8 @@ lang="[%lang.value.lang%]" xml:lang="[%lang.value.lang%]"
 <th>&nbsp;</th>
 [%- ELSE -%]
 <th class="neutral"
-lang="[%lang.value.lang%]" xml:lang="[%lang.value.lang%]"
->[%lang.value.title%] ([%lang.key%])</th>
+ lang="[%lang.value.lang%]" xml:lang="[%lang.value.lang%]">
+[%~ lang.key | optdesc('lang',1) %]</th>
 [%- END %]
 [% END %]
 

--- a/default/web_tt2/pref.tt2
+++ b/default/web_tt2/pref.tt2
@@ -10,7 +10,9 @@
   <div>
   <select id="lang" name="lang" class="neutral">
     [% FOREACH l = languages %]
-      <option value="[% l.key %]" lang="[% l.key %]" xml:lang="[% l.key %]" [% l.value.selected %]>[% l.value.complete %]</option>
+      <option value="[% l.key %]" lang="[% l.key %]" xml:lang="[% l.key %]"
+       [%~ IF l.value.selected %] selected="selected"[% END %]>
+      [%~ l.key | optdesc('lang') %]</option>
     [% END %]
   </select>
   </div>
@@ -18,7 +20,9 @@
   <div>
   <select name="cookie_delay" id="cookie_delay">
     [% FOREACH period = cookie_periods %]
-      <option value="[% period.value %]" [% period.selected %]>[% period.desc %]</option>
+      <option value="[% period.value %]"
+       [%~ IF period.selected %] selected="selected"[% END %]>
+      [%~ period.desc %]</option>
     [% END %]
   </select>
   </div>

--- a/default/web_tt2/review_family.tt2
+++ b/default/web_tt2/review_family.tt2
@@ -11,9 +11,9 @@
 
 [% FOREACH list = family_lists %]
 <tr>
-<td>[%|optdesc('status')%][% list.status %][%END%]</td>
+<td>[% list.status | optdesc('status')%]</td>
 <td><a href="[% 'admin' | url_rel([list.name]) %]">[% list.name %]</a></td>
-<td>[% list.instantiation_date %]</td>
+<td>[% list.instantiation_date_epoch | optdesc('unixtime') %]</td>
 <td>[% list.subject %]</td>
 </tr>
 [% END %]

--- a/default/web_tt2/set_pending_list_request.tt2
+++ b/default/web_tt2/set_pending_list_request.tt2
@@ -5,7 +5,10 @@
    [%|loc%]Listname:[%END%] [% list %]<br />
    [%|loc%]Subject:[%END%] [% list_subject %]<br />
   </strong>
-   [%|loc%]List requested by[%END%] [% list_request_by %] [%|loc(list_request_date)%] on %1[%END%]<br />
+  [% list_request_date = BLOCK ~%]
+    [% list_request_date_epoch | optdesc('unixtime') %]
+  [%~ END ~%]
+  [%|loc(list_request_by,list_request_date)%]List requested by %1 on %2[%END%]<br />
  </div>
 
 [% IF is_listmaster %]

--- a/default/web_tt2/setlang.tt2
+++ b/default/web_tt2/setlang.tt2
@@ -10,7 +10,11 @@
     <select id="language_selection" name="lang" class="neutral submitOnChange">
 
      [% FOREACH lang = languages %]
-     <option lang="[% lang.key %]" xml:lang="[% lang.key %]" value="[% lang.key %]" [% lang.value.selected %]>[% lang.value.complete %]</option>
+       <option lang="[% lang.key %]" xml:lang="[% lang.key %]"
+        value="[% lang.key %]"
+        [%~ IF lang.value.selected %] selected="selected"[% END %]>
+       [%~ lang.key | optdesc('lang') ~%]
+       </option>
      [% END %]
      </select>
      <noscript>

--- a/default/web_tt2/suboptions.tt2
+++ b/default/web_tt2/suboptions.tt2
@@ -10,8 +10,11 @@
   <label for="reception"> [%|loc%]Receiving mode:[%END%] </label>
   <div>
   <select name="reception" id="reception">
-  [% FOREACH r = reception %]
-    <option value="[% r.key %]" [% r.value.selected %]>[% r.value.description %]</option>
+  [% FOREACH r = reception ~%]
+    <option value="[% r.key %]"
+     [%~ IF r.value.selected %] selected="selected"[% END %]>
+    [%~ r.key | optdesc('reception') ~%]
+    </option>
   [% END %]
   </select>
   <a href="[% 'nomenu/help/user_options' | url_rel %]" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=800,height=400')" target="wws_help">
@@ -54,8 +57,11 @@
   <label for="visibility"> [%|loc%]Visibility:[%END%] </label>
   <div>
   <select id="visibility" name="visibility">
-  [% FOREACH r = visibility %]
-    <option value="[% r.key %]" [% r.value.selected %]>[% r.value.description %]</option>
+  [% FOREACH r = visibility ~%]
+    <option value="[% r.key %]"
+     [%~ IF r.value.selected %] selected="selected"[% END %]>
+    [%~ r.key | optdesc('visibility') ~%]
+    </option>
   [% END %]
   </select>
   </div>

--- a/default/web_tt2/view_template.tt2
+++ b/default/web_tt2/view_template.tt2
@@ -29,8 +29,9 @@
 [%|loc%](This template is the default for all languages unless it is redefined for a specific language)[%END%]
 [%- ELSE -%]
 <strong class="neutral"
-lang="[%tpl_lang_lang%]" xml:lang="[%tpl_lang_lang%]"
-> [%tpl_lang_title%] ([%tpl_lang%]) </strong>
+ lang="[%tpl_lang_lang%]" xml:lang="[%tpl_lang_lang%]">
+[%~ tpl_lang | optdesc('lang',1) ~%]
+</strong>
 [%- END %]</li>
 </ul>
 </p><br />

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -982,7 +982,7 @@ my %filtering = (
     #XXX'editsubscriber' => {'email' => 'fix_escape_uri'},
     ## Required because outgoing parameters have been html-escaped in
     ## edit_list_request
-    'edit_list' => {'*param*' => 'unescape_html'},
+    #'edit_list' => {'*param*' => 'unescape_html'},
     ## Remove leading/trailing white spaces and lowercase
     'change_email' => {'*email' => 'normalize'},
 );
@@ -2430,15 +2430,14 @@ sub get_parameters {
             #            Sympa::Tools::Text::qencode_filename($tokens[$i]);
             #    }
             #    $in{$p} = join '/', @tokens;
-            #}
-            if ($filtering_action eq 'unescape_html') {
-                $in{$p} = Sympa::Tools::Text::unescape_chars($in{$p});
-                #} elsif ($filtering_action eq 'fix_escape_uri') {
-                #    # Sympa::Tools::Text::escape_chars() replaces '/' with
-                #    # %A5 ('¥' character).  This should be transformed into a
-                #    # '/' again.
-                #    $in{$p} =~ s{/}{\xa5}g;
-            } elsif ($filtering_action eq 'normalize') {
+            #} elsif ($filtering_action eq 'unescape_html') {
+            #    $in{$p} = Sympa::Tools::Text::unescape_chars($in{$p});
+            #} elsif ($filtering_action eq 'fix_escape_uri') {
+            #    # Sympa::Tools::Text::escape_chars() replaces '/' with
+            #    # %A5 ('¥' character).  This should be transformed into a
+            #    # '/' again.
+            #    $in{$p} =~ s{/}{\xa5}g;
+            if ($filtering_action eq 'normalize') {
                 $in{$p} =~ s/^\$+//;    ## remove leading \s
                 $in{$p} =~ s/\$+$//;    ## remove trailing \s
                 $in{$p} = lc($in{$p});  ## lowercase

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1847,20 +1847,12 @@ while ($query = new_loop()) {
 
     ## Available languages
     $param->{'languages'} = {};
-    $language->push_lang();
+    $language->push_lang;
     foreach my $lang (Sympa::get_supported_languages($robot)) {
         next unless $lang = $language->set_lang($lang);
-        $param->{'languages'}{$lang}{'complete'} = $language->native_name
-            || $lang;
-        # compatibility: 6.1.
-        $param->{'languages'}{$lang}{'lang_tag'} = $lang;
+        $param->{'languages'}{$lang} = {};
     }
     if (my $lang = $language->set_lang($param->{'lang'})) {    #current lang
-        $param->{'languages'}{$lang}{'complete'} = $language->native_name
-            || $lang;
-        # compatibility: 6.1.
-        $param->{'languages'}{$lang}{'lang_tag'} = $lang;
-
         $param->{'languages'}{$lang}{'selected'} = 'selected="selected"';
     }
     $language->pop_lang;
@@ -6005,8 +5997,6 @@ sub do_suboptions {
         localtime($s->{'update_date'}));
 
     foreach $m ($list->available_reception_mode) {
-        $param->{'reception'}{$m}{'description'} =
-            Sympa::ListOpt::get_title($m, 'reception');
         if ($s->{'reception'} eq $m) {
             $param->{'reception'}{$m}{'selected'} = ' selected';
             if ($m =~ /^(mail|notice|not_me|txt|html|urlize)$/i) {
@@ -6018,8 +6008,6 @@ sub do_suboptions {
     }
 
     foreach $m (qw(conceal noconceal)) {
-        $param->{'visibility'}{$m}{'description'} =
-            Sympa::ListOpt::get_title($m, 'visibility');
         if ($s->{'visibility'} eq $m) {
             $param->{'visibility'}{$m}{'selected'} = ' selected';
         } else {
@@ -6861,16 +6849,13 @@ sub do_ls_templates {
 
     foreach my $file (keys %{$param->{'templates'}}) {
         foreach my $level (keys %{$param->{'templates'}{$file}}) {
-            $language->push_lang;
             foreach my $subdir (keys %{$param->{'templates'}{$file}{$level}})
             {
-                my $lang = $language->set_lang($subdir); # allow unknown lang.
-                $param->{'lang_per_level'}{$level}{$subdir} = {
-                    'title' => ($lang ? $language->native_name : ''),
-                    'lang' => $lang,
-                };
+                # Allow unknown lang.
+                my $lang = Sympa::Language::canonic_lang($subdir);
+                $param->{'lang_per_level'}{$level}{$subdir} =
+                    {lang => ($lang || $subdir)};
             }
-            $language->pop_lang;
         }
     }
 
@@ -7005,18 +6990,8 @@ sub do_view_template {
     my $tpl_lang = $in{'tpl_lang'} || 'default';
     $param->{'tpl_lang'} = $tpl_lang;
     unless ($tpl_lang eq 'default') {
-        $language->push_lang;
-
-        if (my $lang = $language->set_lang($tpl_lang)) { # allow unknown lang.
-            $param->{'tpl_lang_title'} = $language->native_name || $tpl_lang;
-            $param->{'tpl_lang_lang'} = $lang;
-        } else {
-            $param->{'tpl_lang_title'} = $tpl_lang;
-            $param->{'tpl_lang_lang'} =
-                Sympa::Language::canonic_lang($tpl_lang);
-        }
-
-        $language->pop_lang;
+        # Allow unknown lang.
+        $param->{'tpl_lang_lang'} = Sympa::Language::canonic_lang($tpl_lang);
     }
 
     return 1;
@@ -7136,18 +7111,8 @@ sub do_copy_template {
     my $tpl_lang = $in{'tpl_lang_out'} || 'default';
     $param->{'tpl_lang'} = $in{'tpl_lang'} = $tpl_lang;
     unless ($tpl_lang eq 'default') {
-        $language->push_lang;
-
-        if (my $lang = $language->set_lang($tpl_lang)) { # allow unknown lang.
-            $param->{'tpl_lang_title'} = $language->native_name || $tpl_lang;
-            $param->{'tpl_lang_lang'} = $lang;
-        } else {
-            $param->{'tpl_lang_title'} = $tpl_lang;
-            $param->{'tpl_lang_lang'} =
-                Sympa::Language::caonic_lang($tpl_lang);
-        }
-
-        $language->pop_lang;
+        # Allow unknown lang.
+        $param->{'tpl_lang_lang'} = Sympa::Language::caonic_lang($tpl_lang);
     }
 
     $param->{'scope'} = $in{'scope'} = $in{'scope_out'};
@@ -11066,13 +11031,9 @@ sub do_editsubscriber {
 
     ## Get language from user_table
     my $user = Sympa::User::get_global_user($in{'email'});
-    $language->push_lang($user->{'lang'});
-    $param->{'current_subscriber'}{'lang'} = $language->native_name;
-    $language->pop_lang;
+    $param->{'current_subscriber'}{'lang'} = $user->{'lang'};
 
     foreach my $m ($list->available_reception_mode) {
-        $param->{'reception'}{$m}{'description'} =
-            Sympa::ListOpt::get_title($m, 'reception');
         if ($param->{'current_subscriber'}{'reception'} eq $m) {
             $param->{'reception'}{$m}{'selected'} = ' selected';
         } else {
@@ -11081,8 +11042,6 @@ sub do_editsubscriber {
     }
 
     foreach my $m (qw(conceal noconceal)) {
-        $param->{'visibility'}{$m}{'description'} =
-            Sympa::ListOpt::get_title($m, 'visibility');
         if ($param->{'current_subscriber'}{'visibility'} eq $m) {
             $param->{'visibility'}{$m}{'selected'} = ' selected';
         } else {
@@ -15964,8 +15923,6 @@ sub _set_my_lists_info {
             $member_info->{'reception'}  ||= 'mail';
             $member_info->{'visibility'} ||= 'noconceal';
             foreach my $mode ($list->available_reception_mode) {
-                $param->{'reception'}{$list->{'name'}}{$mode}{'description'}
-                    = Sympa::ListOpt::get_title($mode, 'reception');
                 if ($member_info->{'reception'} eq $mode) {
                     $param->{'reception'}{$list->{'name'}}{$mode}{'selected'}
                         = ' selected';

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -12431,8 +12431,6 @@ sub _prepare_data {
                 $p->{'value'}      = $d;
                 $p->{'length'}     = $struct->{'length'};
                 $p->{'field_type'} = $struct->{'field_type'};
-                my $l = length($p->{'value'});
-                $p->{'hidden_field'} = '*' x $l;
                 $p->{'unit'} = $language->gettext($struct->{'gettext_unit'});
                 if ($restrict) {    # for topics
                     $p_glob->{'constraint'} = $constraint;

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -11859,443 +11859,131 @@ sub _notify_added_admin {
     }
 }
 
-#=head2 sub do_edit_list_request
-#
-#Sends back the list config edition form.
-#
-#=head3 Arguments
-#
-#=over
-#
-#=item * I<None>
-#
-#=back
-#
-#=head3 Return
-#
-#=over
-#
-#=item * I<1>, if no problem is encountered
-#
-#=item * I<undef>, if anything goes wrong
-#
-#=item * I<'loginrequest'> if no user is logged in at the time the function is called.
-#
-#=back
-#
-#=cut
-
-## Send back the list config edition form
+# Sends back the list config edition form.
 sub do_edit_list_request {
     wwslog('info', '(%s)', $in{'group'});
 
-    if ($in{'group'}) {
-        $param->{'group'} = $in{'group'};
-        _prepare_edit_form($list);
-    }
+    return 1 unless $in{'group'};
 
-    #    print "Content-type: text/plain\n\n";
-    #    Sympa::Tools::Data::dump_var(\%pinfo,0);
-    #    Sympa::Tools::Data::dump_var($list->{'admin'},0);
-    #    Sympa::Tools::Data::dump_var($param->{'param'},0);
+    my $config = Sympa::List::Config->new($list, config => $list->{'admin'});
+    my $schema = $config->get_schema($param->{'user'}{'email'});
 
-    $param->{'serial'} = $list->{'admin'}{'serial'};
+    my @schema = map {
+        # Skip comments and default values.
+        # Skip parameters belonging to another group.
+        if (   $_ eq 'comment'
+            or $_ eq 'defaults'
+            or $schema->{$_}->{group} ne $in{'group'}) {
+            ();
+        } else {
+            my @p = _do_edit_list_request($config, $schema->{$_}, [$_]);
+            if (@p) {
+                # Store if the parameter is still at its default value or not.
+                # Store the change state of this parameter.
+                # FIXME:Multiple levels of keys should be possible.
+                $p[0]->{'default_value'} = $config->get('defaults')->{$_};
+                $p[0]->{'changed'}       = $::changed_params{$_};
+            }
+            @p;
+        }
+    } $config->keys;
+
+    # If at least one param was editable, make the update button appear in
+    # the form.
+    $param->{'is_form_editable'} =
+        grep { $_->{privilege} eq 'write' } @schema;
+    $param->{'config_schema'} = [@schema];
+    $param->{'config_values'} = {
+        map {
+            my @value = $config->get($_->{name});
+            @value ? ($_->{name} => $value[0]) : ();
+            } @schema
+    };
+
+    $param->{'group'}  = $in{'group'};
+    $param->{'serial'} = $config->get('serial');
 
     return 1;
+}
+
+sub _do_edit_list_request {
+    my $config = shift;
+    my $pitem  = shift;
+    my $pnames = shift;
+
+    # Skip obsolete parameters and alias names.
+    # Skip hidden parameters.
+    return () if $pitem->{obsolete};
+    return () if $pitem->{privilege} eq 'hidden';
+
+    $pitem->{name}  = $pnames->[-1];
+    $pitem->{title} = $language->gettext($pitem->{gettext_id})
+        if exists $pitem->{gettext_id};
+    $pitem->{comment} = $language->gettext($pitem->{gettext_comment})
+        if exists $pitem->{gettext_comment};
+    $pitem->{unit} = $language->gettext($pitem->{gettext_unit})
+        if exists $pitem->{gettext_unit};
+
+    if (ref $pitem->{format} eq 'ARRAY' and $pitem->{occurrence} =~ /n$/) {
+        $pitem->{type} = 'set';
+    } elsif (ref $pitem->{format} eq 'HASH') {
+        $pitem->{type} = 'paragraph';
+
+        my @format = map {
+            _do_edit_list_request(
+                $config,
+                $pitem->{format}->{$_},
+                [@$pnames, $_]
+            );
+        } $config->keys(join '.', @$pnames);
+
+        if (@format) {
+            $pitem->{format} = [@format];
+        } else {
+            return ();
+        }
+    } else {
+        $pitem->{type} = 'leaf';
+
+        $pitem->{enum} = 1
+            if ref $pitem->{format} eq 'ARRAY';
+
+        if ($pitem->{scenario}) {
+            my $scenarios =
+                $list->load_scenario_list($pitem->{scenario}, $robot);
+            my $list_of_scenario = {};
+            # Only get required scenario attributes.
+            foreach my $scenario (keys %{$scenarios}) {
+                $list_of_scenario->{$scenario} = {
+                    name  => $scenarios->{$scenario}{name},
+                    title => $scenarios->{$scenario}->get_current_title()
+                };
+            }
+            $pitem->{format} = $list_of_scenario;
+        } elsif ($pitem->{task}) {
+            my $list_of_task =
+                $list->load_task_list($pitem->{task}, $robot);
+            $pitem->{format} = $list_of_task;
+        } elsif ($pitem->{datasource}) {
+            my $list_of_data_sources = $list->load_data_sources_list($robot);
+            $pitem->{format} = $list_of_data_sources;
+        }
+    }
+
+    return ($pitem);
 }
 
 # No longer used.
 #sub _check_new_values;
 
-#=head2 sub _prepare_edit_form(LIST)
-#
-#Prepares config data to be sent in the edition form. Adds to the parameters array a hash for each parameter to be edited.
-#
-#=head3 Arguments
-#
-#=over
-#
-#=item * I<$list>, a List object
-#
-#=back
-#
-#=head3 Return
-#
-#=over
-#
-#=item * I<1>, if no problem is encountered
-#
-#=item * I<undef>, if anything goes wrong
-#
-#=back
-#
-#=cut
+# DEPRECATED.
+#sub _prepare_edit_form;
 
-## Prepare config data to be sent in the
-## edition form
-sub _prepare_edit_form {
-    my $list        = shift;
-    my $list_config = Sympa::Tools::Data::dup_var($list->{'admin'});
-    my $family;
-    my $is_form_editable = '0';
+# DEPRECATED.
+#sub _prepare_data;
 
-    ## If the list belongs to a family, check if the said family can be
-    ## retrieved.
-    if (defined $list_config->{'family_name'}) {
-        unless ($family = $list->get_family()) {
-            Sympa::Report::reject_report_web('intern', 'unable_get_family',
-                {}, $param->{'action'}, $list, $param->{'user'}{'email'},
-                $robot);
-            wwslog('info', 'Impossible to get list %s\'s family',
-                $list->{'name'});
-            return undef;
-        }
-    }
-
-    my $config = Sympa::List::Config->new($list, config => $list->{'admin'});
-    my $pinfo = $config->get_schema($param->{'user'}{'email'});
-
-    ## For each parameter defined in List.pm, retrieve and prepare for editing
-    foreach my $pname ($config->keys) {
-        # Skip comments and default values.
-        next if grep { $pname eq $_ } qw(comment defaults);
-
-        # Skip parameters belonging to another group.
-        next if $in{'group'} and $pinfo->{$pname}{'group'} ne $in{'group'};
-
-        # Skip obsolete parameters and alias names.
-        next if $pinfo->{$pname}{'obsolete'};
-
-        ## Check whether the parameter can be edited by the logged user.
-        my $may_edit = $list->may_edit($pname, $param->{'user'}{'email'});
-
-        ## Valid form global edit status as soon as at least one editable
-        ## parameter is found.
-        if ($may_edit eq 'write') {
-            $is_form_editable = '1';
-        }
-
-        # Store in $p a reference to the hash containing the information
-        # relative to the parameter editing.
-        my $p =
-            _prepare_data($pname, $pinfo->{$pname}, $list_config->{$pname},
-            $may_edit, $family);
-        next unless defined $p;
-
-        ## Store if the parameter is still at its default value or not.
-        $p->{'default'} = $list_config->{'defaults'}{$pname};
-
-        ## Store the change state of this parameter, taken from the global
-        ## variable %changed_params.
-        $p->{'changed'} = $::changed_params{$pname};
-
-        # Exception.
-        if ($pname eq 'digest') {
-            foreach my $v (@{$p->{'value'}}) {
-                next unless ($v->{'name'} eq 'days');
-                if (ref($v->{'value'}) eq 'ARRAY') {
-                    # Empty digest parameter. Putting a dummy value.
-                    $v->{'value'} = undef;
-                    $v->{'type'}  = 'enum';
-                }
-            }
-        }
-
-        push @{$param->{'param'}}, $p;
-    }
-
-    ## If at least one param was editable, make the update button appear in
-    ## the form.
-    $param->{'is_form_editable'} = $is_form_editable;
-    return 1;
-}
-
-#=head2 sub _prepare_data(STRING $name, HASH_Ref $struct, SCALAR $data, STRING $may_edit, FAMILY $family, STRING $main_p)
-#
-#Returns a reference to a hash containing the data used to edit the parameter (of name $name, corresponding to the structure $struct in pinfo, with the $may_edit editing status) containing the data in the Sympa web interface.
-#
-#=head3 Arguments
-#
-#=over
-#
-#=item * I<$name> (STRING), the name of the parameter processed
-#
-#=item * I<$struct> (HASH_Ref), a ref to the hash describing this parameter in %Sympa::ListDef::pinfo
-#
-#=item * I<$data> (), the value(s) taken by this parameter in the current list. Can be a reference to a list or the value of a single parameter.
-#
-#=item * I<$may_edit> (STRING), the editing status of this parameter in the current context.
-#
-#=item * I<$family> (FAMILY), the family the list belongs to.
-#
-#=item * I<$main_p> (STRING), the prefix composing the complete name of the parameter.
-#
-#=back
-#
-#=head3 Return
-#
-#=over
-#
-#=item * I<$p_glob>, a reference to a hash containing the data used to edit the parameter.
-#
-#=back
-#
-#=cut
-
-sub _prepare_data {
-    my ($name, $struct, $data, $may_edit, $family, $main_p) = @_;
-    #    wwslog('debug2', '(%s, %s)', $name, $data);
-    # $family and $main_p (recursive call) are optionnal
-    # if $main_p is needed, $family also
-    return undef if $struct->{'obsolete'};
-
-    ## Prepare data structure for the parser
-    my $p_glob = {'name' => $name};
-
-    ## Check if some family constraint modify the editing rights.
-    my $restrict = 0;
-    my $constraint;
-    if ((ref($family) eq 'Sympa::Family') && ($may_edit eq 'write')) {
-
-        if ($main_p && defined $pinfo->{$main_p}) {
-            if (ref($pinfo->{$main_p}{'format'}) eq 'HASH') {
-                # composed parameter
-                $constraint = $family->get_param_constraint(
-                    "$main_p.$p_glob->{'name'}");
-            }
-        } else {    # simple parameter
-            if (ref($pinfo->{$p_glob->{'name'}}{'format'}) ne 'HASH') {
-                # simple parameter
-                $constraint =
-                    $family->get_param_constraint($p_glob->{'name'});
-            }
-        }
-        if ($constraint eq '0') {    # free parameter
-            $p_glob->{'may_edit'} = 'write';
-
-        } elsif (ref($constraint) eq 'HASH') {    # controlled parameter
-            $p_glob->{'may_edit'} = 'write';
-            $restrict = 1;
-
-        } else {                                  # fixed parameter
-            $p_glob->{'may_edit'} = 'read';
-        }
-
-    } else {
-        $p_glob->{'may_edit'} = $may_edit;
-    }
-
-    ## Naming the parameter.
-    if ($struct->{'gettext_id'}) {
-        $p_glob->{'title'} = $language->gettext($struct->{'gettext_id'});
-    } else {
-        $p_glob->{'title'} = $name;
-    }
-    if ($struct->{'gettext_comment'}) {
-        $p_glob->{'comment'} =
-            $language->gettext($struct->{'gettext_comment'});
-    }
-
-    ## Occurrences : if the parameter can have multiple occurrences,
-    ## its values are transfered into the array pointed by $data2
-    ## if they were given in arguments (if not, an empty array is created).
-    ## if it is a single occurrence parameter, an array is created with
-    ## its single value.
-
-    my $data2;
-    if ($struct->{'occurrence'} =~ /n$/) {
-        $p_glob->{'occurrence'} = 'multiple';
-        $data2 = $data || [];
-
-        if ($may_edit eq 'write') {
-            # Add an empty entry.
-            unless (grep { $name eq $_ }
-                qw(days reception rfc2369_header_fields topics)) {
-                my $empty_entry;
-                if (ref($struct->{'format'}) eq 'HASH') {
-                    # Structured parameter.
-                    foreach my $sub_parameter (keys %{$struct->{'format'}}) {
-                        # Use default value if defined.
-                        if ($struct->{'format'}{$sub_parameter}{'default'}) {
-                            $empty_entry->{$sub_parameter} =
-                                $struct->{'format'}{$sub_parameter}
-                                {'default'};
-                        }
-                    }
-                    $empty_entry->{is_empty} = 1;
-                } else {
-                    # Simple parameter.
-                    $empty_entry = undef;
-                }
-
-                push @{$data2}, $empty_entry;
-            }
-        }
-    } else {
-        $data2 = [$data];
-    }
-
-    # filed_type
-    $p_glob->{field_type} = $struct->{field_type};
-
-    my @all_p;
-
-    ## Foreach occurrence of param
-    foreach my $d (@{$data2}) {
-        my $p = {};
-
-        ## Type of data
-        if ($struct->{'scenario'}) {
-            $p_glob->{'type'} = 'scenario';
-            my $list_of_scenario;
-
-            my $tmp_list_of_scenario =
-                $list->load_scenario_list($struct->{'scenario'}, $robot);
-
-            ## Only get required scenario attributes
-            foreach my $scenario (keys %{$tmp_list_of_scenario}) {
-                $list_of_scenario->{$scenario} = {
-                    'name'      => $tmp_list_of_scenario->{$scenario}{'name'},
-                    'web_title' => $tmp_list_of_scenario->{$scenario}
-                        ->get_current_title()
-                };
-            }
-
-            $list_of_scenario->{$d->{'name'}}{'selected'} = 1;
-
-            $p->{'value'} = $list_of_scenario;
-
-            if ($restrict) {
-                _restrict_values($p->{'value'}, $constraint);
-            }
-
-        } elsif ($struct->{'task'}) {
-            $p_glob->{'type'} = 'task';
-            my $list_of_task =
-                $list->load_task_list($struct->{'task'}, $robot);
-
-            $list_of_task->{$d->{'name'}}{'selected'} = 1;
-
-            $p->{'value'} = $list_of_task;
-
-            if ($restrict) {
-                _restrict_values($p->{'value'}, $constraint);
-            }
-
-        } elsif ($struct->{'datasource'}) {
-            $p_glob->{'type'} = 'datasource';
-            my $list_of_data_sources = $list->load_data_sources_list($robot);
-
-            $list_of_data_sources->{$d}{'selected'} = 1;
-
-            $p->{'value'} = $list_of_data_sources;
-
-            if ($restrict) {
-                _restrict_values($p->{'value'}, $constraint);
-            }
-
-        } elsif (ref($struct->{'format'}) eq 'HASH') {
-            $p_glob->{'type'} = 'paragraph';
-            unless (ref($d) eq 'HASH') {
-                $d = {};
-            }
-
-            $p->{is_empty} = delete $d->{is_empty};
-            foreach my $k (
-                sort {
-                    $struct->{'format'}{$a}{'order'}
-                        <=> $struct->{'format'}{$b}{'order'}
-                }
-                keys %{$struct->{'format'}}
-                ) {
-                ## Prepare data recursively
-                my $m_e =
-                    $list->may_edit("$name.$k", $param->{'user'}{'email'});
-                my $v = _prepare_data($k, $struct->{'format'}{$k},
-                    $d->{$k}, $m_e, $family, $name);
-                next unless defined $v;
-                push @{$p->{'value'}}, $v;
-            }
-
-        } elsif ((ref($struct->{'format'}) eq 'ARRAY')
-            || ($restrict && ($main_p eq 'msg_topic' && $name eq 'keywords')))
-        {
-            $p_glob->{'type'} = 'enum';
-
-            unless (defined $p_glob->{'value'}) {
-                ## Initialize
-                foreach my $elt (@{$struct->{'format'}}) {
-                    $p_glob->{'value'}{$elt}{'selected'} = 0;
-                }
-            }
-            if (ref($d)) {
-                next unless (ref($d) eq 'ARRAY');
-                foreach my $v (@{$d}) {
-                    $p_glob->{'value'}{$v}{'selected'} = 1;
-                }
-            } else {
-                $p_glob->{'value'}{$d}{'selected'} = 1 if (defined $d);
-            }
-
-            if ($restrict) {
-                _restrict_values($p_glob->{'value'}, $constraint);
-            }
-
-        } else {
-            if ($restrict) {
-                $p_glob->{'type'} = 'enum';
-
-                foreach my $elt (keys %{$constraint}) {
-                    $elt =~ s/"/&quot;/;
-                    $p->{'value'}{$elt}{'selected'} = 0;
-                }
-
-                $d =~ s/"/&quot;/;
-                $p->{'value'}{$d}{'selected'} = 1;
-                $p->{'length'} = $struct->{'length'};
-                $p->{'unit'} = $language->gettext($struct->{'gettext_unit'});
-
-            } else {
-
-                $d =~ s/"/&quot;/;
-                $p_glob->{'type'}  = 'scalar';
-                $p->{'value'}      = $d;
-                $p->{'length'}     = $struct->{'length'};
-                $p->{'field_type'} = $struct->{'field_type'};
-                $p->{'unit'} = $language->gettext($struct->{'gettext_unit'});
-                if ($restrict) {    # for topics
-                    $p_glob->{'constraint'} = $constraint;
-                }
-            }
-        }
-
-        push @all_p, $p;
-    }
-
-    if (   ($p_glob->{'occurrence'} eq 'multiple')
-        && ($p_glob->{'type'} ne 'enum')) {
-        $p_glob->{'value'} = \@all_p;
-    } else {
-        foreach my $k (keys %{$all_p[0]}) {
-            $p_glob->{$k} = $all_p[0]->{$k};
-        }
-    }
-
-    return $p_glob;
-}
-
-## Restrict allowed values in the hash
-sub _restrict_values {
-    my $values  = shift;    #ref on hash of values
-    my $allowed = shift;    #ref on hash of allowed values
-    wwslog('debug3', '');
-
-    foreach my $v (keys %{$values}) {
-        unless (defined $allowed->{$v}) {
-            delete $values->{$v};
-        }
-    }
-}
+# No longer used.
+#sub _restrict_values;
 
 ## NOT USED anymore (expect chinese)
 sub do_close_list_request {

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -12109,67 +12109,10 @@ sub _prepare_edit_form {
             foreach my $v (@{$p->{'value'}}) {
                 next unless ($v->{'name'} eq 'days');
                 if (ref($v->{'value'}) eq 'ARRAY') {
-                    $log->syslog('debug2',
-                        'Empty digest parameter. Putting a dummy value');
+                    # Empty digest parameter. Putting a dummy value.
                     $v->{'value'} = undef;
                     $v->{'type'}  = 'enum';
-                } else {
-                    foreach my $day (keys %{$v->{'value'}}) {
-                        my $t =
-                            $language->gettext_strftime("%A",
-                            gmtime(0 + ($day + 3) * (3600 * 24)));
-                        $t = sprintf '%s (%s)', $t,
-                            $day
-                            if Sympa::is_listmaster($list,
-                            $param->{'user'}{'email'});
-                        $v->{'value'}{$day}{'title'} = $t;
-                    }
                 }
-            }
-        } elsif ($pname eq 'lang') {
-            $language->push_lang;
-            foreach my $lang (keys %{$p->{'value'}}) {
-                $language->set_lang($lang);
-                my $t = $language->native_name || $lang;
-                $t = sprintf '%s (%s)', $t, $lang
-                    if Sympa::is_listmaster($list, $param->{'user'}{'email'});
-                $p->{'value'}{$lang}{'title'} = $t;
-                # compatibility: 6.1.
-                $p->{'value'}{$lang}{'lang_tag'} = $lang;
-            }
-            $language->pop_lang;
-        } elsif ($pname eq 'available_user_options'
-            or $pname eq 'default_user_options') {
-            foreach my $v (@{$p->{'value'}}) {
-                if ($v->{'name'} eq 'reception') {
-                    foreach my $x (keys %{$v->{'value'}}) {
-                        $v->{'value'}{$x}{'title'} =
-                            Sympa::ListOpt::get_title(
-                            $x,
-                            'reception',
-                            Sympa::is_listmaster(
-                                $list, $param->{'user'}{'email'}
-                            )
-                            );
-                    }
-                } elsif ($v->{'name'} eq 'visibility') {
-                    foreach my $x (keys %{$v->{'value'}}) {
-                        $v->{'value'}{$x}{'title'} =
-                            Sympa::ListOpt::get_title(
-                            $x,
-                            'visibility',
-                            Sympa::is_listmaster(
-                                $list, $param->{'user'}{'email'}
-                            )
-                            );
-                    }
-                }
-            }
-        } elsif ($pname eq 'status') {
-            foreach my $x (keys %{$p->{'value'}}) {
-                $p->{'value'}{$x}{'title'} =
-                    Sympa::ListOpt::get_title($x, 'status',
-                    Sympa::is_listmaster($list, $param->{'user'}{'email'}));
             }
         }
 
@@ -12306,6 +12249,9 @@ sub _prepare_data {
     } else {
         $data2 = [$data];
     }
+
+    # filed_type
+    $p_glob->{field_type} = $struct->{field_type};
 
     my @all_p;
 

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -11640,7 +11640,7 @@ sub do_edit_list {
     my $data_source_updated = 1
         if grep { $config->get_change($_) }
             grep { $_ =~ /\Ainclude_/ or $_ eq 'ttl' }
-            keys %$pinfo;
+            $config->keys;
 
     # Update config in memory.
     $config->commit;

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -11753,6 +11753,31 @@ sub _deserialize_changes {
         eval sprintf '$new_admin->%s = $value', join('->', @subscripts);
     }
 
+    # Deleted parameters or paragraphs.
+    foreach my $key (sort keys %in) {
+        next unless $key =~ /\Adeleted_param[.](\S+)\z/;
+        my $name = $1;
+        next unless defined $in{$key} and $in{$key} =~ /\S/;
+
+        my @subscripts = map {
+            if (/\A\d+\z/) {
+                sprintf '[%s]', $_;
+            } elsif (/\A[-\w]+\z/) {
+                sprintf "{'%s'}", $_;
+            } else {
+                "{''}";
+            }
+        } split /[.]/, $name;
+        my $var = sprintf '$new_admin->%s', join('->', @subscripts);
+
+        if (eval "exists $var and ref $var eq 'HASH'") {
+            my %hash = map {($_ => undef)} keys %{eval $var};
+            eval "$var = {%hash}";
+        } else {
+            eval "$var = undef";
+        }
+    }
+
     return $new_admin;
 }
 

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -4595,7 +4595,6 @@ sub do_lists {
         $list_info->{'host'}    = $list->{'admin'}{'host'};
         $list_info->{'date_epoch'} =
             $list->{'admin'}{'creation'}{'date_epoch'};
-        $list_info->{'date'}   = $list->{'admin'}{'creation'}{'date'};
         $list_info->{'topics'} = $list->{'admin'}{'topics'};
 
         if (    $param->{'user'}{'email'}
@@ -10320,9 +10319,8 @@ sub do_get_pending_lists {
             $list->{'admin'}{'subject'};
         $param->{'pending'}{$list->{'name'}}{'by'} =
             $list->{'admin'}{'creation'}{'email'};
-        $param->{'pending'}{$list->{'name'}}{'date'} =
-            $language->gettext_strftime("%d %b %y  %H:%M",
-            localtime($list->{'admin'}{'creation'}{'date_epoch'}));
+        $param->{'pending'}{$list->{'name'}}{'date_epoch'} =
+            $list->{'admin'}{'creation'}{'date_epoch'};
     }
 
     return 1;
@@ -10365,16 +10363,15 @@ sub do_get_latest_lists {
             {
             'name'          => $list->{'name'},
             'subject'       => $list->{'admin'}{'subject'},
-            'creation_date' => $list->{'admin'}{'creation'}{'date_epoch'}
+            'creation_date_epoch' =>
+                $list->{'admin'}{'creation'}{'date_epoch'}
             };
     }
 
-    foreach my $l (sort { $b->{'creation_date'} <=> $a->{'creation_date'} }
-        @unordered_lists) {
+    foreach my $l (sort {
+        $b->{'creation_date_epoch'} <=> $a->{'creation_date_epoch'}
+        } @unordered_lists) {
         push @{$param->{'latest_lists'}}, $l;
-        $l->{'creation_date'} =
-            $language->gettext_strftime("%d %b %Y",
-            localtime($l->{'creation_date'}));
     }
 
     return 1;
@@ -10427,10 +10424,6 @@ sub do_get_inactive_lists {
             ),
             'creation_date_epoch' =>
                 $list->{'admin'}{'creation'}{'date_epoch'},
-            'creation_date' => $language->gettext_strftime(
-                "%d %b %Y",
-                localtime($list->{'admin'}{'creation'}{'date_epoch'})
-            ),
             };
     }
 
@@ -10457,16 +10450,14 @@ sub do_get_biggest_lists {
             {
             'name'          => $list->{'name'},
             'subject'       => $list->{'admin'}{'subject'},
-            'creation_date' => $list->{'admin'}{'creation'}{'date_epoch'},
-            'subscribers'   => $list->get_total
+            'creation_date_epoch' =>
+                $list->{'admin'}{'creation'}{'date_epoch'},
+            'subscribers' => $list->get_total
             };
     }
 
     foreach my $l (sort { $b->{'subscribers'} <=> $a->{'subscribers'} }
         @unordered_lists) {
-        $l->{'creation_date'} =
-            $language->gettext_strftime("%d %b %Y",
-            localtime($l->{'creation_date'}));
         push @{$param->{'biggest_lists'}}, $l;
     }
 
@@ -10499,7 +10490,8 @@ sub do_set_pending_list_request {
     $param->{'list_info'}         = $list_dir . '/info';
     $param->{'list_subject'}      = $list->{'admin'}{'subject'};
     $param->{'list_request_by'}   = $list->{'admin'}{'creation'}{'email'};
-    $param->{'list_request_date'} = $list->{'admin'}{'creation'}{'date'};
+    $param->{'list_request_date_epoch'} =
+        $list->{'admin'}{'creation'}{'date_epoch'};
     $param->{'list_serial'}       = $list->{'admin'}{'serial'};
     $param->{'list_status'}       = $list->{'admin'}{'status'};
 
@@ -18326,13 +18318,10 @@ sub do_review_family {
 
         push @{$param->{'family_lists'}},
             {
-            'name'               => $flist->{'name'},
-            'status'             => $flist->{'admin'}{'status'},
-            'instantiation_date' => $language->gettext_strftime(
-                "%d %b %Y at %H:%M:%S",
-                localtime $flist->{'admin'}{'latest_instantiation'}
-                    {'date_epoch'}
-            ),
+            'name'                     => $flist->{'name'},
+            'status'                   => $flist->{'admin'}{'status'},
+            'instantiation_date_epoch' =>
+                $flist->{'admin'}{'latest_instantiation'}{'date_epoch'},
             'subject' => $flist->{'admin'}{'subject'},
             };
     }

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -4527,36 +4527,16 @@ sub do_lists {
         $all_lists = [map { $lists{$_} } sort keys %lists];
         $param->{'subtitle'} = $language->gettext('Your lists');
     } elsif ($in{'topic'}) {
-        my %topics = Sympa::Robot::load_topics($robot);
-        $param->{'topic'} = $in{'topic'};
-        if ($in{'subtopic'}) {
-            $param->{'subtopic'} = $in{'subtopic'};
-            $param->{'subtitle'} = $language->gettext_sprintf(
-                '%s / %s',
-                $topics{$in{'topic'}}{'current_title'},
-                $topics{$in{'topic'}}{'sub'}{$in{'subtopic'}}{'current_title'}
-                    || $in{'subtopic'}
-            );
-        } elsif ($topics{$in{'topic'}}{'current_title'}) {
-            $param->{'subtitle'} = $topics{$in{'topic'}}{'current_title'};
-        } elsif ($in{'topic'} eq 'others' or $in{'topic'} eq 'topicsless') {
-            $param->{'subtitle'} = $language->gettext('Others');
-        } else {
-            $param->{'subtitle'} = $in{'topic'};
-        }
+        my $topic = join '/', grep {$_} ($in{'topic'}, $in{'subtopic'});
+        $param->{'topic'} = $topic;
 
-        ## Filter lists by topic.
-        ## topic argument 'topicsless' or 'other' means 'lists with topic
-        ## "other" or without topics'.
-        ## no topic argument; List all lists
+        # Filter lists by topic.
+        # topic argument 'topicsless' or 'other' means 'lists with topic
+        # "other" or without topics'.
+        # no topic argument; List all lists
         my $options = {};
-        if ($in{'topic'}) {
-            if ($in{'subtopic'}) {
-                $options->{'filter'} =
-                    ['topics' => "$in{'topic'}/$in{'subtopic'}"];
-            } else {
-                $options->{'filter'} = ['topics' => $in{'topic'}];
-            }
+        if ($topic) {
+            $options->{'filter'} = ['topics' => $topic];
         }
         $all_lists = Sympa::List::get_lists($robot, %$options);
     } else {
@@ -10889,23 +10869,11 @@ sub do_create_list_request {
         || [];
     #XXX}
 
-    my %topics;
-    unless (%topics = Sympa::Robot::load_topics($robot)) {
-        Sympa::Report::reject_report_web('intern',
-            'unable_to_load_list_of_topics',
-            {}, $param->{'action'}, '', $param->{'user'}{'email'}, $robot);
+    my %topics = map { ($_ => {}) } Sympa::Robot::topic_keys($robot);
+    if ($in{'topics'} and exists $topics{$in{'topics'}}) {
+        $topics{$in{'topics'}}->{selected} = 1;
     }
-    $param->{'list_of_topics'} = \%topics;
-
-    if ($in{'topics'}) {
-        my ($topic, $subtopic) = split('/', $in{'topics'});
-        if ($subtopic) {
-            $param->{'list_of_topics'}{$topic}{'sub'}{$subtopic}{'selected'}
-                = 1;
-        } else {
-            $param->{'list_of_topics'}{$topic}{'selected'} = 1;
-        }
-    }
+    $param->{'list_of_topics'} = {%topics};
 
     unless ($param->{'list_list_tpl'} =
         Sympa::Tools::WWW::get_list_list_tpl($robot)) {
@@ -11984,8 +11952,11 @@ sub _prepare_edit_form {
         }
     }
 
+    my $config = Sympa::List::Config->new($list, config => $list->{'admin'});
+    my $pinfo = $config->get_schema($param->{'user'}{'email'});
+
     ## For each parameter defined in List.pm, retrieve and prepare for editing
-    foreach my $pname (sort Sympa::List::by_order keys %{$pinfo}) {
+    foreach my $pname ($config->keys) {
         # Skip comments and default values.
         next if grep { $pname eq $_ } qw(comment defaults);
 
@@ -12018,45 +11989,8 @@ sub _prepare_edit_form {
         ## variable %changed_params.
         $p->{'changed'} = $::changed_params{$pname};
 
-        ## Exceptions...too many
-        if ($pname eq 'topics') {
-            $p->{'type'} = 'enum';
-
-            my @topics;
-            foreach my $topic (sort keys %{$p->{'value'}}) {
-                push @topics, $topic if $p->{'value'}{$topic}{'selected'};
-            }
-            delete $p->{'value'};
-            my %list_of_topics = Sympa::Robot::load_topics($robot);
-
-            if (defined $p->{'constraint'}) {
-                _restrict_values(\%list_of_topics, $p->{'constraint'});
-            }
-
-            foreach my $topic (keys %list_of_topics) {
-                $p->{'value'}{$topic}{'selected'} = 0;
-                $p->{'value'}{$topic}{'title'} =
-                    $list_of_topics{$topic}{'current_title'};
-
-                if ($list_of_topics{$topic}{'sub'}) {
-                    foreach
-                        my $subtopic (keys %{$list_of_topics{$topic}{'sub'}})
-                    {
-                        $p->{'value'}{"$topic/$subtopic"}{'selected'} = 0;
-                        $p->{'value'}{"$topic/$subtopic"}{'title'} =
-                            "$list_of_topics{$topic}{'current_title'}/$list_of_topics{$topic}{'sub'}{$subtopic}{'current_title'}";
-                    }
-                }
-            }
-            foreach my $selected_topic (@topics) {
-                next unless (defined $selected_topic);
-                $p->{'value'}{$selected_topic}{'selected'} = 1;
-                $p->{'value'}{$selected_topic}{'title'} =
-                    $language->gettext_sprintf("Unknown (%s)",
-                    $selected_topic)
-                    unless (defined $p->{'value'}{$selected_topic}{'title'});
-            }
-        } elsif ($pname eq 'digest') {
+        # Exception.
+        if ($pname eq 'digest') {
             foreach my $v (@{$p->{'value'}}) {
                 next unless ($v->{'name'} eq 'days');
                 if (ref($v->{'value'}) eq 'ARRAY') {
@@ -12308,7 +12242,7 @@ sub _prepare_data {
             }
 
         } else {
-            if ($restrict && ($name ne 'topics')) {
+            if ($restrict) {
                 $p_glob->{'type'} = 'enum';
 
                 foreach my $elt (keys %{$constraint}) {

--- a/src/lib/Sympa/Admin.pm
+++ b/src/lib/Sympa/Admin.pm
@@ -262,9 +262,6 @@ sub create_list_old {
     }
 
     # Creation of the config file.
-    #FIXME:should be unneccessary
-    $param->{'creation'}{'date'} =
-        $language->gettext_strftime("%d %b %Y at %H:%M:%S", localtime time);
     $param->{'creation'}{'date_epoch'} = time;
     $param->{'creation_email'} ||= Sympa::get_address($robot, 'listmaster');
     $param->{'status'} ||= 'open';
@@ -579,9 +576,6 @@ sub create_list {
     #    $list->create_shared();
     #}
 
-    ##FIXME:should be unneccessary
-    $list->{'admin'}{'creation'}{'date'} =
-        $language->gettext_strftime("%d %b %Y at %H:%M:%S", localtime time);
     $list->{'admin'}{'creation'}{'date_epoch'} = time;
     $list->{'admin'}{'creation'}{'email'}      = $param->{'creation_email'}
         || Sympa::get_address($robot, 'listmaster');
@@ -679,9 +673,6 @@ sub update_list {
         return undef;
     }
 
-    ##FIXME:should be unneccessary
-    $list->{'admin'}{'creation'}{'date'} =
-        $language->gettext_strftime("%d %b %Y at %H:%M:%S", localtime time);
     $list->{'admin'}{'creation'}{'date_epoch'} = time;
     $list->{'admin'}{'creation'}{'email'}      = $param->{'creation_email'}
         || Sympa::get_address($robot, 'listmaster');
@@ -1243,9 +1234,6 @@ sub clone_list_as_empty {
     $new_list->{'admin'}{'serial'} = 0;
     $new_list->{'admin'}{'creation'}{'email'} = $email if ($email);
     $new_list->{'admin'}{'creation'}{'date_epoch'} = time;
-    ##FIXME:should be unneccessary
-    $new_list->{'admin'}{'creation'}{'date'} =
-        $language->gettext_strftime("%d %b %y at %H:%M:%S", localtime time);
     $new_list->save_config($email);
     return $new_list;
 }

--- a/src/lib/Sympa/Family.pm
+++ b/src/lib/Sympa/Family.pm
@@ -393,9 +393,6 @@ sub add_list {
     # info parameters
     $list->{'admin'}{'latest_instantiation'}{'email'} =
         Sympa::get_address($self, 'listmaster');
-    ##FIXME:should be unneccessary
-    $list->{'admin'}{'latest_instantiation'}{'date'} =
-        $language->gettext_strftime("%d %b %Y at %H:%M:%S", localtime time);
     $list->{'admin'}{'latest_instantiation'}{'date_epoch'} = time;
     $list->save_config(Sympa::get_address($self, 'listmaster'));
     $list->{'family'} = $self;
@@ -665,9 +662,6 @@ sub modify_list {
 
     $list->{'admin'}{'latest_instantiation'}{'email'} =
         Sympa::get_address($self, 'listmaster');
-    ##FIXME:should be unneccessary
-    $list->{'admin'}{'latest_instantiation'}{'date'} =
-        $language->gettext_strftime("%d %b %Y at %H:%M:%S", localtime time);
     $list->{'admin'}{'latest_instantiation'}{'date_epoch'} = time;
     $list->save_config(Sympa::get_address($self, 'listmaster'));
     $list->{'family'} = $self;
@@ -2493,9 +2487,6 @@ sub _end_update_list {
 
     $list->{'admin'}{'latest_instantiation'}{'email'} =
         Sympa::get_address($self, 'listmaster');
-    ##FIXME:should be unneccessary
-    $list->{'admin'}{'latest_instantiation'}{'date'} =
-        $language->gettext_strftime("%d %b %Y at %H:%M:%S", localtime time);
     $list->{'admin'}{'latest_instantiation'}{'date_epoch'} = time;
     $list->save_config(Sympa::get_address($self, 'listmaster'));
     $list->{'family'} = $self;

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -673,10 +673,6 @@ sub save_config {
     $self->{'admin'}{'update'} = {
         'email'      => $email,
         'date_epoch' => time,
-        'date'       => $language->gettext_strftime(
-            "%d %b %Y at %H:%M:%S",
-            localtime time
-        ),
     };
 
     unless (

--- a/src/lib/Sympa/List/Config.pm
+++ b/src/lib/Sympa/List/Config.pm
@@ -348,9 +348,13 @@ sub _get_schema_apply_privilege {
     my $list = $self->{context};
 
     # Choose most restrictive privilege.
-    # Trick:
-    # "hidden", "read" and "write" precede others in reverse dictionary order.
+    # - Trick: "hidden", "read" and "write" precede others in reverse
+    #   dictionary order.
+    # - Internal parameters are not editable anyway.
     my $priv = $list->may_edit(_pfullname($pnames), $user);
+    $priv = 'read'
+        if $pitem->{internal}
+            and (not $priv or 'read' lt $priv);
     $priv = $priv_p
         if not $priv
             or ($priv_p and $priv_p lt $priv);

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -391,8 +391,8 @@ our %pinfo = (
                 'order'      => 1,
                 'gettext_id' => "reception mode",
                 'format'     => [
-                    'digest',  'digestplain', 'mail', 'nomail',
-                    'summary', 'notice',      'txt',  'html',
+                    'mail',    'notice', 'digest', 'digestplain',
+                    'summary', 'nomail', 'txt',    'html',
                     'urlize',  'not_me'
                 ],
                 'field_type' => 'reception',
@@ -2009,15 +2009,16 @@ our %pinfo = (
                 'default'    => {'conf' => 'dkim_selector'}
             },
             'header_list' => {
-                'order' => 4,
+                'obsolete' => 1,        # Not yet implemented
+                'order'    => 4,
                 'gettext_id' =>
-                    'List of headers to be included ito the message for signature',
+                    'List of headers to be included into the message for signature',
                 'gettext_comment' =>
                     'You should probably use the default value which is the value recommended by RFC4871',
                 'format'     => '\S+',
-                'occurrence' => '0-1',
+                'occurrence' => '1-n',
+                'split_char' => ':',    #FIXME
                 #'default'    => {'conf' => 'dkim_header_list'},
-                'obsolete' => 1,
             },
             'signer_domain' => {
                 'order' => 5,

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -77,7 +77,8 @@ our %pinfo = (
                 'format'     => Sympa::Regexps::email(),
                 'occurrence' => '1',
                 'length'     => 30,
-                validations  => ['list_special_addresses'],
+                validations =>
+                    [qw(list_special_addresses unique_paragraph_key)],
             },
             'gecos' => {
                 'order'      => 2,
@@ -163,7 +164,8 @@ our %pinfo = (
                 'format'     => Sympa::Regexps::email(),
                 'occurrence' => '1',
                 'length'     => 30,
-                validations  => ['list_editor_address'],
+                validations =>
+                    [qw(list_editor_address unique_paragraph_key)],
             },
             'reception' => {
                 'order'      => 4,

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2599,6 +2599,16 @@ Visibility mode of list memeber.
 
 TBD.
 
+Introduced on Sympa 6.2.17.
+
+=item privilege
+
+I<Dynamically assigned>.
+Privilege for specified user:
+C<'write'>, C<'read'> or C<'hidden'>.
+
+Introduced on Sympa 6.2.17.
+
 =back
 
 =back

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2137,7 +2137,8 @@ our %pinfo = (
                 'occurrence' => '0-1'
             },
             'date' => {
-                'order'      => 2,
+                #'order'      => 2,
+                'obsolete'   => 1,
                 'gettext_id' => 'date',
                 'format'     => '.+'
             },
@@ -2203,7 +2204,8 @@ our %pinfo = (
                 'length'     => 10,
             },
             'date' => {
-                'order'      => 2,
+                #'order'      => 2,
+                'obsolete'   => 1,
                 'gettext_id' => "human readable",
                 'format'     => '.+'
             },
@@ -2232,7 +2234,8 @@ our %pinfo = (
                 'length'     => 30
             },
             'date' => {
-                'order'      => 2,
+                #'order'      => 2,
+                'obsolete'   => 1,
                 'gettext_id' => 'date',
                 'format'     => '.+',
                 'length'     => 30

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -250,6 +250,7 @@ our %pinfo = (
         'gettext_id' => "Language of the list",
         'format' => [],    ## Sympa::get_supported_languages() called later
         'file_format' => '\w+(\-\w+)*',
+        'field_type'  => 'lang',
         'default'     => {'conf' => 'lang'}
     },
 
@@ -310,6 +311,7 @@ our %pinfo = (
                 'gettext_id'  => "days",
                 'format'      => [0 .. 6],
                 'file_format' => '1|2|3|4|5|6|7',
+                'field_type'  => 'dayofweek',
                 'occurrence'  => '1-n'
             },
             'hour' => {
@@ -351,6 +353,7 @@ our %pinfo = (
                     'summary', 'nomail', 'txt',    'html',
                     'urlize',  'not_me'
                 ],
+                'field_type' => 'reception',
                 'occurrence' => '1-n',
                 'split_char' => ',',
                 'default' =>
@@ -372,12 +375,14 @@ our %pinfo = (
                     'summary', 'notice',      'txt',  'html',
                     'urlize',  'not_me'
                 ],
+                'field_type' => 'reception',
                 'default' => 'mail'
             },
             'visibility' => {
                 'order'      => 2,
                 'gettext_id' => "visibility",
                 'format'     => ['conceal', 'noconceal'],
+                'field_type' => 'visibility',
                 'default'    => 'noconceal'
             }
         },
@@ -2138,9 +2143,11 @@ our %pinfo = (
             },
             'date_epoch' => {
                 'order'      => 3,
-                'gettext_id' => 'epoch date',
+                'gettext_id' => 'date',
                 'format'     => '\d+',
-                'occurrence' => '1'
+                'field_type' => 'unixtime',
+                'occurrence' => '1',
+                'length'     => 10,
             }
         },
         'internal' => 1
@@ -2189,9 +2196,11 @@ our %pinfo = (
         'format'     => {
             'date_epoch' => {
                 'order'      => 3,
-                'gettext_id' => "epoch date",
+                'gettext_id' => "date",
                 'format'     => '\d+',
-                'occurrence' => '1'
+                'field_type' => 'unixtime',
+                'occurrence' => '1',
+                'length'     => 10,
             },
             'date' => {
                 'order'      => 2,
@@ -2230,10 +2239,11 @@ our %pinfo = (
             },
             'date_epoch' => {
                 'order'      => 3,
-                'gettext_id' => 'epoch date',
+                'gettext_id' => 'date',
                 'format'     => '\d+',
+                'field_type' => 'unixtime',
                 'occurrence' => '1',
-                'length'     => 8
+                'length'     => 10,
             }
         },
         'internal' => 1,
@@ -2245,6 +2255,7 @@ our %pinfo = (
         'gettext_id' => "Status of the list",
         'format' =>
             ['open', 'closed', 'pending', 'error_config', 'family_closed'],
+        'field_type' => 'status',
         'default'  => 'open',
         'internal' => 1
     },
@@ -2547,7 +2558,39 @@ that should always be saved in the config file.
 
 =item field_type
 
-Used to select passwords web input type.
+Used to special treatment of parameter value to show it.
+
+=over
+
+=item C<'dayofweek'>
+
+Day of week, C<0> - C<6>.
+
+=item C<'lang'>
+
+Language tag.
+
+=item C<'password'>
+
+The value to be concealed.
+
+=item C<'reception'>
+
+Reception mode of list member.
+
+=item C<'status'>
+
+Status of list.
+
+=item C<'unixtime'>
+
+The time in second from Unix epoch.
+
+=item C<'visibility'>
+
+Visibility mode of list memeber.
+
+=back
 
 =item validations
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2614,6 +2614,13 @@ C<'write'>, C<'read'> or C<'hidden'>.
 
 Introduced on Sympa 6.2.17.
 
+=item enum
+
+I<Automatically assigned>.
+TBD.
+
+Introdueced on Sympa 6.2.17.
+
 =back
 
 =back

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2474,6 +2474,9 @@ sub cleanup {
                 keys %{$v->{'format'}{$k}{synonym} || {}};
         }
 
+        next if $v->{format}{$k}{'obsolete'};
+
+        #FIXME
         if (($v->{'file_format'}{$k}{'occurrence'} =~ /n$/)
             && $v->{'file_format'}{$k}{'split_char'}) {
             my $format = $v->{'file_format'}{$k}{'file_format'};

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -230,7 +230,8 @@ our %pinfo = (
         order        => 10.07,
         'group'      => 'description',
         'gettext_id' => "Topics for the list",
-        'format'     => [],     # Sympa::Robot::load_topics() called later
+        'format'     => [],     # Sympa::Robot::topic_keys() called later
+        'field_type' => 'listtopic',
         'split_char' => ',',
         'occurrence' => '0-n'
     },
@@ -2584,6 +2585,10 @@ Reception mode of list member.
 =item C<'status'>
 
 Status of list.
+
+=item C<'listtopic'>
+
+List topic.
 
 =item C<'unixtime'>
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -96,18 +96,21 @@ our %pinfo = (
                 'order'      => 4,
                 'gettext_id' => "profile",
                 'format'     => ['privileged', 'normal'],
+                'occurrence' => '1',
                 'default'    => 'normal'
             },
             'reception' => {
                 'order'      => 5,
                 'gettext_id' => "reception mode",
                 'format'     => ['mail', 'nomail'],
+                'occurrence' => '1',
                 'default'    => 'mail'
             },
             'visibility' => {
                 'order'      => 6,
                 'gettext_id' => "visibility",
                 'format'     => ['conceal', 'noconceal'],
+                'occurrence' => '1',
                 'default'    => 'noconceal'
             }
         },
@@ -135,18 +138,21 @@ our %pinfo = (
                 'order'      => 4,
                 'gettext_id' => 'reception mode',
                 'format'     => ['mail', 'nomail'],
+                'occurrence' => '1',
                 'default'    => 'mail'
             },
             'visibility' => {
                 'order'      => 5,
                 'gettext_id' => "visibility",
                 'format'     => ['conceal', 'noconceal'],
+                'occurrence' => '1',
                 'default'    => 'noconceal'
             },
             'profile' => {
                 'order'      => 3,
                 'gettext_id' => 'profile',
                 'format'     => ['privileged', 'normal'],
+                'occurrence' => '1',
                 'default'    => 'normal'
             }
         },
@@ -171,12 +177,14 @@ our %pinfo = (
                 'order'      => 4,
                 'gettext_id' => "reception mode",
                 'format'     => ['mail', 'nomail'],
+                'occurrence' => '1',
                 'default'    => 'mail'
             },
             'visibility' => {
                 'order'      => 5,
                 'gettext_id' => "visibility",
                 'format'     => ['conceal', 'noconceal'],
+                'occurrence' => '1',
                 'default'    => 'noconceal'
             },
             'gecos' => {
@@ -216,12 +224,14 @@ our %pinfo = (
                 'order'      => 3,
                 'gettext_id' => 'reception mode',
                 'format'     => ['mail', 'nomail'],
+                'occurrence' => '1',
                 'default'    => 'mail'
             },
             'visibility' => {
                 'order'      => 5,
                 'gettext_id' => "visibility",
                 'format'     => ['conceal', 'noconceal'],
+                'occurrence' => '1',
                 'default'    => 'noconceal'
             }
         },
@@ -254,6 +264,7 @@ our %pinfo = (
         'format' => [],    ## Sympa::get_supported_languages() called later
         'file_format' => '\w+(\-\w+)*',
         'field_type'  => 'lang',
+        'occurrence'  => '1',
         'default'     => {'conf' => 'lang'}
     },
 
@@ -282,6 +293,7 @@ our %pinfo = (
         'gettext_id' => "Priority",
         'format'     => [0 .. 9, 'z'],
         'length'     => 1,
+        'occurrence' => '1',
         'default'    => {'conf' => 'default_list_priority'}
     },
 
@@ -379,13 +391,15 @@ our %pinfo = (
                     'urlize',  'not_me'
                 ],
                 'field_type' => 'reception',
-                'default' => 'mail'
+                'occurrence' => '1',
+                'default'    => 'mail'
             },
             'visibility' => {
                 'order'      => 2,
                 'gettext_id' => "visibility",
                 'format'     => ['conceal', 'noconceal'],
                 'field_type' => 'visibility',
+                'occurrence' => '1',
                 'default'    => 'noconceal'
             }
         },
@@ -436,7 +450,7 @@ our %pinfo = (
         'group'      => 'sending',
         'gettext_id' => "Message tagging",
         'format'     => ['required_sender', 'required_moderator', 'optional'],
-        'occurrence' => '0-1',
+        'occurrence' => '1',
         'default'    => 'optional'
     },
 
@@ -535,7 +549,7 @@ our %pinfo = (
         'group'      => 'sending',
         'gettext_id' => "Allow message personalization",
         'format'     => ['on', 'off'],
-        'occurrence' => '0-1',
+        'occurrence' => '1',
         'default'    => {'conf' => 'merge_feature'}
     },
 
@@ -544,7 +558,7 @@ our %pinfo = (
         'group'      => 'sending',
         'gettext_id' => "Reject mail from automates (crontab, etc)?",
         'format'     => ['on', 'off'],
-        'occurrence' => '0-1',
+        'occurrence' => '1',
         'default'    => {'conf' => 'reject_mail_from_automates_feature'}
     },
 
@@ -691,6 +705,7 @@ our %pinfo = (
         'group'      => 'archives',
         'gettext_id' => "Store distributed messages into archive",
         'format'     => ['on', 'off'],
+        'occurrence' => '1',
         'default'    => {'conf' => 'process_archive'},
     },
     'web_archive' => {
@@ -775,6 +790,7 @@ our %pinfo = (
         'group'      => 'archives',
         'gettext_id' => "Archive encrypted mails as cleartext",
         'format'     => ['original', 'decrypted'],
+        'occurrence' => '1',
         'default'    => 'original'
     },
 
@@ -783,6 +799,7 @@ our %pinfo = (
         'group'      => 'archives',
         'gettext_id' => "email address protection method",
         'format'     => ['cookie', 'javascript', 'at', 'none'],
+        'occurrence' => '1',
         'default' => {'conf' => 'web_archive_spam_protection'}
     },
 
@@ -829,13 +846,15 @@ our %pinfo = (
             'action' => {
                 'order'      => 2,
                 'gettext_id' => "action for this population",
-                'format'  => ['remove_bouncers', 'notify_bouncers', 'none'],
-                'default' => 'notify_bouncers'
+                'format' => ['remove_bouncers', 'notify_bouncers', 'none'],
+                'occurrence' => '1',
+                'default'    => 'notify_bouncers'
             },
             'notification' => {
                 'order'      => 3,
                 'gettext_id' => "notification",
                 'format'     => ['none', 'owner', 'listmaster'],
+                'occurrence' => '1',
                 'default'    => 'owner'
             }
         }
@@ -858,12 +877,14 @@ our %pinfo = (
                 'order'      => 2,
                 'gettext_id' => "action for this population",
                 'format'  => ['remove_bouncers', 'notify_bouncers', 'none'],
-                'default' => 'remove_bouncers'
+                'occurrence' => '1',
+                'default'    => 'remove_bouncers'
             },
             'notification' => {
                 'order'      => 3,
                 'gettext_id' => "notification",
                 'format'     => ['none', 'owner', 'listmaster'],
+                'occurrence' => '1',
                 'default'    => 'owner'
             }
         }
@@ -875,7 +896,8 @@ our %pinfo = (
         'gettext_id' => "percentage of list members in VERP mode",
         'format' =>
             ['100%', '50%', '33%', '25%', '20%', '10%', '5%', '2%', '0%'],
-        'default' => {'conf' => 'verp_rate'}
+        'occurrence' => '1',
+        'default'    => {'conf' => 'verp_rate'}
     },
 
     'tracking' => {
@@ -888,6 +910,7 @@ our %pinfo = (
                 'gettext_id' =>
                     "tracking message by delivery status notification",
                 'format' => ['on', 'off'],
+                'occurrence' => '1',
                 'default' =>
                     {'conf' => 'tracking_delivery_status_notification'}
             },
@@ -896,6 +919,7 @@ our %pinfo = (
                 'gettext_id' =>
                     "tracking message by message disposition notification",
                 'format' => ['on', 'on_demand', 'off'],
+                'occurrence' => '1',
                 'default' =>
                     {'conf' => 'tracking_message_disposition_notification'}
             },
@@ -940,7 +964,7 @@ our %pinfo = (
         'gettext_id' =>
             "Notify subscribers when they are included from a data source?",
         'format'     => ['on', 'off'],
-        'occurrence' => '0-1',
+        'occurrence' => '1',
         'default'    => 'off',
     },
 
@@ -1135,8 +1159,9 @@ our %pinfo = (
                 'order'      => 2.4,
                 'gettext_id' => 'use TLS (formerly SSL)',
                 'format'     => ['starttls', 'ldaps', 'none'],
-                'default'    => 'none',
                 'synonym'    => {'yes' => 'ldaps', 'no' => 'none'},
+                'occurrence' => '1',
+                'default'    => 'none',
             },
             'use_ssl' => {
                 #'order'      => 2.5,
@@ -1150,6 +1175,7 @@ our %pinfo = (
                 'gettext_id' => 'SSL version',
                 'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
                 'synonym' => {'tls' => 'tlsv1'},
+                'occurrence' => '1',
                 'default' => 'tlsv1'
             },
             'ssl_ciphers' => {
@@ -1163,8 +1189,8 @@ our %pinfo = (
                 'gettext_id' => 'Certificate verification',
                 'format'     => ['none', 'optional', 'required'],
                 'synonym'    => {'require' => 'required'},
+                'occurrence' => '1',
                 'default'    => 'required',
-                'occurrence' => '0-1'
             },
             'user' => {
                 'order'      => 3,
@@ -1187,6 +1213,7 @@ our %pinfo = (
                 'order'      => 5,
                 'gettext_id' => "search scope",
                 'format'     => ['base', 'one', 'sub'],
+                'occurrence' => '1',
                 'default'    => 'sub'
             },
             'timeout' => {
@@ -1214,6 +1241,7 @@ our %pinfo = (
                 'order'      => 9,
                 'gettext_id' => "selection (if multiple)",
                 'format'     => ['all', 'first'],
+                'occurrence' => '1',
                 'default'    => 'first'
             },
             'nosync_time_ranges' => {
@@ -1254,8 +1282,9 @@ our %pinfo = (
                 'order'      => 2.4,
                 'gettext_id' => 'use TLS (formerly SSL)',
                 'format'     => ['starttls', 'ldaps', 'none'],
-                'default'    => 'none',
                 'synonym'    => {'yes' => 'ldaps', 'no' => 'none'},
+                'occurrence' => '1',
+                'default'    => 'none',
             },
             'use_ssl' => {
                 #'order'      => 2.5,
@@ -1269,6 +1298,7 @@ our %pinfo = (
                 'gettext_id' => 'SSL version',
                 'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
                 'synonym' => {'tls' => 'tlsv1'},
+                'occurrence' => '1',
                 'default' => 'tlsv1'
             },
             'ssl_ciphers' => {
@@ -1282,8 +1312,8 @@ our %pinfo = (
                 'gettext_id' => 'Certificate verification',
                 'format'     => ['none', 'optional', 'required'],
                 'synonym'    => {'require' => 'required'},
+                'occurrence' => '1',
                 'default'    => 'required',
-                'occurrence' => '0-1'
             },
             'user' => {
                 'order'      => 3,
@@ -1332,6 +1362,7 @@ our %pinfo = (
                 'order'      => 9,
                 'gettext_id' => "first-level selection",
                 'format'     => ['all', 'first', 'regex'],
+                'occurrence' => '1',
                 'default'    => 'first'
             },
             'regex1' => {
@@ -1350,6 +1381,7 @@ our %pinfo = (
                 'order'      => 12,
                 'gettext_id' => "second-level search scope",
                 'format'     => ['base', 'one', 'sub'],
+                'occurrence' => '1',
                 'default'    => 'sub'
             },
             'timeout2' => {
@@ -1377,6 +1409,7 @@ our %pinfo = (
                 'order'      => 16,
                 'gettext_id' => "second-level selection",
                 'format'     => ['all', 'first', 'regex'],
+                'occurrence' => '1',
                 'default'    => 'first'
             },
             'regex2' => {
@@ -1557,8 +1590,9 @@ our %pinfo = (
                 'order'      => 2.4,
                 'gettext_id' => 'use TLS (formerly SSL)',
                 'format'     => ['starttls', 'ldaps', 'none'],
-                'default'    => 'none',
                 'synonym'    => {'yes' => 'ldaps', 'no' => 'none'},
+                'occurrence' => '1',
+                'default'    => 'none',
             },
             'use_ssl' => {
                 #'order'      => 2.5,
@@ -1572,6 +1606,7 @@ our %pinfo = (
                 'gettext_id' => 'SSL version',
                 'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
                 'synonym' => {'tls' => 'tlsv1'},
+                'occurrence' => '1',
                 'default' => 'tlsv1'
             },
             'ssl_ciphers' => {
@@ -1585,8 +1620,8 @@ our %pinfo = (
                 'gettext_id' => 'Certificate verification',
                 'format'     => ['none', 'optional', 'required'],
                 'synonym'    => {'require' => 'required'},
+                'occurrence' => '1',
                 'default'    => 'required',
-                'occurrence' => '0-1'
             },
             'user' => {
                 'order'      => 3,
@@ -1609,6 +1644,7 @@ our %pinfo = (
                 'order'      => 5,
                 'gettext_id' => "search scope",
                 'format'     => ['base', 'one', 'sub'],
+                'occurrence' => '1',
                 'default'    => 'sub'
             },
             'timeout' => {
@@ -1642,6 +1678,7 @@ our %pinfo = (
                 'order'      => 10,
                 'gettext_id' => "selection (if multiple)",
                 'format'     => ['all', 'first'],
+                'occurrence' => '1',
                 'default'    => 'first'
             },
             'nosync_time_ranges' => {
@@ -1682,8 +1719,9 @@ our %pinfo = (
                 'order'      => 2.4,
                 'gettext_id' => 'use TLS (formerly SSL)',
                 'format'     => ['starttls', 'ldaps', 'none'],
-                'default'    => 'none',
                 'synonym'    => {'yes' => 'ldaps', 'no' => 'none'},
+                'occurrence' => '1',
+                'default'    => 'none',
             },
             'use_ssl' => {
                 #'order'      => 2.5,
@@ -1697,6 +1735,7 @@ our %pinfo = (
                 'gettext_id' => 'SSL version',
                 'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
                 'synonym' => {'tls' => 'tlsv1'},
+                'occurrence' => '1',
                 'default' => 'tlsv1'
             },
             'ssl_ciphers' => {
@@ -1710,8 +1749,8 @@ our %pinfo = (
                 'gettext_id' => 'Certificate verification',
                 'format'     => ['none', 'optional', 'required'],
                 'synonym'    => {'require' => 'required'},
+                'occurrence' => '1',
                 'default'    => 'required',
-                'occurrence' => '0-1'
             },
             'user' => {
                 'order'      => 3,
@@ -1734,6 +1773,7 @@ our %pinfo = (
                 'order'      => 5,
                 'gettext_id' => "first-level search scope",
                 'format'     => ['base', 'one', 'sub'],
+                'occurrence' => '1',
                 'default'    => 'sub'
             },
             'timeout1' => {
@@ -1760,6 +1800,7 @@ our %pinfo = (
                 'order'      => 9,
                 'gettext_id' => "first-level selection",
                 'format'     => ['all', 'first', 'regex'],
+                'occurrence' => '1',
                 'default'    => 'first'
             },
             'regex1' => {
@@ -1778,6 +1819,7 @@ our %pinfo = (
                 'order'      => 12,
                 'gettext_id' => "second-level search scope",
                 'format'     => ['base', 'one', 'sub'],
+                'occurrence' => '1',
                 'default'    => 'sub'
             },
             'timeout2' => {
@@ -1805,6 +1847,7 @@ our %pinfo = (
                 'order'      => 16,
                 'gettext_id' => "second-level selection",
                 'format'     => ['all', 'first', 'regex'],
+                'occurrence' => '1',
                 'default'    => 'first'
             },
             'regex2' => {
@@ -1925,7 +1968,7 @@ our %pinfo = (
         'gettext_comment' =>
             "Enable/Disable DKIM. This feature require Mail::DKIM to installed and may be some custom scenario to be updated",
         'format'     => ['on', 'off'],
-        'occurrence' => '0-1',
+        'occurrence' => '1',
         'default' => {'conf' => 'dkim_feature'}
     },
 
@@ -2173,7 +2216,7 @@ our %pinfo = (
         'gettext_id' =>
             "Allow picture display? (must be enabled for the current robot)",
         'format'     => ['on', 'off'],
-        'occurrence' => '0-1',
+        'occurrence' => '1',
         'default' => {'conf' => 'pictures_feature'}
     },
 
@@ -2190,6 +2233,7 @@ our %pinfo = (
         'group'      => 'other',
         'gettext_id' => "email address protection method",
         'format'     => ['at', 'javascript', 'none'],
+        'occurrence' => '1',
         'default'    => 'javascript'
     },
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2532,7 +2532,7 @@ Or arrayref containing all possible values of parameter.
 If the parameter is paragraph, value of this item is a hashref containing
 definitions of sub-parameters.
 
-See also L</"Node types">.
+See also L<Sympa::List::Config/"Node types">.
 
 =item file_format
 
@@ -2578,7 +2578,7 @@ Occurrence of the parameter in the config file
 possible values: C<0-1>, C<1>, C<0-n> and C<1-n>.
 Example: A list may have multiple owner.
 
-See also L</"Node types">.
+See also L<Sympa::List::Config/"Node types">.
 
 =item gettext_id
 
@@ -2657,15 +2657,17 @@ Visibility mode of list memeber.
 
 =back
 
+Most of field types were introduced on Sympa 6.2.17.
+
 =item filters
 
-TBD.
+See L<Sympa::List::Config/"Filters">.
 
 Introduced on Sympa 6.2.17.
 
 =item validations
 
-TBD.
+See L<Sympa::List::Config/"Validations">.
 
 Introduced on Sympa 6.2.17.
 
@@ -2688,93 +2690,10 @@ Introdueced on Sympa 6.2.17.
 
 =back
 
-=head2 Node types
-
-Each node of configuration has one of following four types.
-Some of them can include other type of nodes recursively.
-
-=over
-
-=item Set (multiple enumerated values)
-
-=over
-
-=item *
-
-{occurrence}: C<'0-n'> or C<'1-n'>.
-
-=item *
-
-{format}: Arrayref.
-
-=back
-
-List of unique items not considering order.
-Items are scalars, and cannot be special values (scenario or task).
-The set cannot contain paragraphs, sets or arrays.
-
-=item Array (multiple values)
-
-=over
-
-=item *
-
-{occurrence}: C<'0-n'> or C<'1-n'>.
-
-=item *
-
-{format}: Regexp or hashref.
-
-=back
-
-List of the same type of nodes in order.
-Type of all nodes can be one of paragraph,
-scalar or special value (scenario or task).
-The array cannot contain sets or arrays.
-
-=item Paragraph (structured value)
-
-=over
-
-=item *
-
-{occurrence}: If the node is an item of array, C<'0-n'> or C<'1-n'>.
-Otherwise, C<'0-1'> or C<'1'>.
-
-=item *
-
-{format}: Hashref.
-
-=back
-
-Compound node of one or more named nodes.
-Paragraph can contain any type of nodes, and each of their names and types
-are defined as member of {format}.
-
-=item Leaf (simple value)
-
-=over
-
-=item *
-
-{occurrence}: If the node is an item of array, C<'0-n'> or C<'1-n'>.
-Otherwise, C<'0-1'> or C<'1'>.
-
-=item *
-
-{format}: If the node is an item of array, regexp.
-Otherwise, regexp or arrayref.
-
-=back
-
-Scalar or special value (scenario or task).
-Leaf cannot contain any other nodes.
-
-=back
-
 =head1 SEE ALSO
 
 L<config(5)>,
+L<Sympa::List::Config>,
 L<Sympa::ListOpt>.
 
 =head1 HISTORY

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -77,6 +77,7 @@ our %pinfo = (
                 'format'     => Sympa::Regexps::email(),
                 'occurrence' => '1',
                 'length'     => 30,
+                filters      => ['canonic_email'],
                 validations =>
                     [qw(list_special_addresses unique_paragraph_key)],
             },
@@ -170,6 +171,7 @@ our %pinfo = (
                 'format'     => Sympa::Regexps::email(),
                 'occurrence' => '1',
                 'length'     => 30,
+                filters      => ['canonic_email'],
                 validations =>
                     [qw(list_editor_address unique_paragraph_key)],
             },
@@ -245,7 +247,8 @@ our %pinfo = (
         'format'     => [],     # Sympa::Robot::topic_keys() called later
         'field_type' => 'listtopic',
         'split_char' => ',',
-        'occurrence' => '0-n'
+        'occurrence' => '0-n',
+        filters      => ['lc'],
     },
 
     'host' => {
@@ -253,6 +256,7 @@ our %pinfo = (
         'group'      => 'description',
         'gettext_id' => "Internet domain",
         'format'     => Sympa::Regexps::host(),
+        filters      => ['canonic_domain'],
         'default'    => {'conf' => 'host'},
         'length'     => 20
     },
@@ -265,6 +269,7 @@ our %pinfo = (
         'file_format' => '\w+(\-\w+)*',
         'field_type'  => 'lang',
         'occurrence'  => '1',
+        filters       => ['canonic_lang'],
         'default'     => {'conf' => 'lang'}
     },
 
@@ -2651,6 +2656,12 @@ The time in second from Unix epoch.
 Visibility mode of list memeber.
 
 =back
+
+=item filters
+
+TBD.
+
+Introduced on Sympa 6.2.17.
 
 =item validations
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2087,6 +2087,7 @@ our %pinfo = (
         'group'      => 'other',
         'gettext_id' => "Secret string for generating unique keys",
         'format'     => '\S+',
+        'field_type' => 'password',
         'length'     => 15,
         'default'    => {'conf' => 'cookie'}
     },

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -1221,6 +1221,7 @@ our %pinfo = (
                 'gettext_id'   => "connection timeout",
                 'gettext_unit' => 'seconds',
                 'format'       => '\w+',
+                'length'       => 6,
                 'default'      => 30
             },
             'filter' => {
@@ -1343,6 +1344,7 @@ our %pinfo = (
                 'gettext_id'   => "first-level connection timeout",
                 'gettext_unit' => 'seconds',
                 'format'       => '\w+',
+                'length'       => 6,
                 'default'      => 30
             },
             'filter1' => {
@@ -1389,6 +1391,7 @@ our %pinfo = (
                 'gettext_id'   => "second-level connection timeout",
                 'gettext_unit' => 'seconds',
                 'format'       => '\w+',
+                'length'       => 6,
                 'default'      => 30
             },
             'filter2' => {
@@ -1652,6 +1655,7 @@ our %pinfo = (
                 'gettext_id'   => "connection timeout",
                 'gettext_unit' => 'seconds',
                 'format'       => '\w+',
+                'length'       => 6,
                 'default'      => 30
             },
             'filter' => {
@@ -1781,6 +1785,7 @@ our %pinfo = (
                 'gettext_id'   => "first-level connection timeout",
                 'gettext_unit' => 'seconds',
                 'format'       => '\w+',
+                'length'       => 6,
                 'default'      => 30
             },
             'filter1' => {
@@ -1827,6 +1832,7 @@ our %pinfo = (
                 'gettext_id'   => "second-level connection timeout",
                 'gettext_unit' => 'seconds',
                 'format'       => '\w+',
+                'length'       => 6,
                 'default'      => 30
             },
             'filter2' => {

--- a/src/lib/Sympa/ListOpt.pm
+++ b/src/lib/Sympa/ListOpt.pm
@@ -256,7 +256,9 @@ my %list_status = (
 );
 
 # Old name: Sympa::List::get_option_title().
-sub get_title {
+# Old name: Sympa::ListOpt::get_title().
+sub get_option_description {
+    my $that    = shift;
     my $option  = shift;
     my $type    = shift || '';
     my $withval = shift || 0;
@@ -278,6 +280,20 @@ sub get_title {
             $title = $language->native_name;
         }
         $language->pop_lang;
+    } elsif ($type eq 'listtopic' or $type eq 'listtopic:leaf') {
+        my $robot_id;
+        if (ref $that eq 'Sympa::List') {
+            $robot_id = $that->{'domain'};
+        } elsif ($that and $that ne '*') {
+            $robot_id = $that;
+        } else {
+            $robot_id = '*';
+        }
+        if ($type eq 'listtopic') {
+            $title = Sympa::Robot::topic_get_title($robot_id, $option);
+        } else {
+            $title = [Sympa::Robot::topic_get_title($robot_id, $option)]->[-1];
+        }
     } elsif ($type eq 'password') {
         return '*' x length($option);    # return
     } elsif ($type eq 'unixtime') {
@@ -323,7 +339,7 @@ configuration.
 
 =over
 
-=item get_title ( $value, [ $type, [ $withval ] ] )
+=item get_option_description ( $that, $value, [ $type, [ $withval ] ] )
 
 I<Function>.
 Gets i18n-ed title of option.
@@ -332,6 +348,10 @@ Language context must be set in advance (See L<Sympa::Language>).
 Parameters:
 
 =over
+
+=item $that
+
+Context, instance of L<Sympa::List>, Robot or Site.
 
 =item $value
 

--- a/src/lib/Sympa/Template.pm
+++ b/src/lib/Sympa/Template.pm
@@ -238,6 +238,7 @@ sub _optdesc_func {
     my $type    = shift;
     my $withval = shift;
 
+    my $that = $self->{context};
     my $encode_html = ($self->{subdir} && $self->{subdir} eq 'web_tt2');
 
     return sub {
@@ -246,7 +247,8 @@ sub _optdesc_func {
         return undef unless $x =~ /\S/;
         $x =~ s/^\s+//;
         $x =~ s/\s+$//;
-        my $title = Sympa::ListOpt::get_title($x, $type, $withval);
+        my $title = Sympa::ListOpt::get_option_description($that, $x, $type,
+            $withval);
         $encode_html ? Sympa::Tools::Text::encode_html($title) : $title;
     };
 }

--- a/t/parse_templates.t
+++ b/t/parse_templates.t
@@ -18,6 +18,8 @@ my $params = {
     rows        => 2,
     reply_to_header         => {value => 'all', other_email => 'xxx@xxx',},
     list_request_date_epoch => 0,
+    tpl_lang                => 'en',
+    current_subscriber => {lang => 'en'},
 };
 
 my @def_tt2 = _templates('default', '*.tt2 sympa.wsdl');

--- a/t/parse_templates.t
+++ b/t/parse_templates.t
@@ -16,7 +16,8 @@ my $params = {
     languages   => {size => 2},
     total_group => 2,
     rows        => 2,
-    reply_to_header => {value => 'all', other_email => 'xxx@xxx',},
+    reply_to_header         => {value => 'all', other_email => 'xxx@xxx',},
+    list_request_date_epoch => 0,
 };
 
 my @def_tt2 = _templates('default', '*.tt2 sympa.wsdl');

--- a/www/js/sympa.js
+++ b/www/js/sympa.js
@@ -575,6 +575,19 @@ $(function() {
     });
 });
 
+/* If checked, fade off item specified by data-selector. */
+$(function() {
+    $('.fadeIfChecked').each(function(){
+        var selector = $(this).data('selector');
+        $(this).on('change', function(){
+            if ($(this).prop('checked'))
+                $(selector).fadeTo('normal', 0.3);
+            else
+                $(selector).fadeTo('normal', 1);
+        });
+    });
+});
+
 /* Top button. */
 $(function() {
     var scrollTopInner = $('<span class="scroll-top-inner">' +


### PR DESCRIPTION
Entirely refactored edit_list_request.tt2. Simpler and consistent logic to compile configuration

Fixed bugs:
* [SourceSup#9741] "percentage of list members in VERP mode" is order by left justified
* Access privilege ("read" etc.) of paragraph did not override that of sub-parameter:
  * e.g. If "archive" gives "read" privilege and "archive.web_access" gives "write", latter is editable on edit_list form but change is ignored.
* [SourceSup#7914] Web interface let define the same email twice as list owner.
* [SourceSup#9972] Existing item in member_include list configuration paragraph cannot be removed.
* Text parameter values including "%xx" are broken: For example "%a5" is altered to "/", "%3a" to ":".
* and several minor flaws.

Changes:
* List parameter "cookie" will be masked, even if it is accessible (normally by listmaster).
* Obsoleted "date" parameter of following paragraphs: last_instantiation, creation and update.
* Internal parameters, e.g. "creation", may not be editable.

Known bug:
* If owner_include, editors or editor_include is empty, then [Update] on edit_list form is clicked without any changes, configuration file will be updated.
This seems to be caused by inconsistency of current code to save/load config file, and may be fixed by another pr.

(6 May update)
(8 May update)