### PR TITLE
Issue #22: Parameters for LDAP attribute description are too restrictive

### DIFF
--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -38,6 +38,7 @@ use Sympa::DatabaseManager;
 use Sympa::Language;
 use Sympa::LockedFile;
 use Sympa::Log;
+use Sympa::Regexps;
 use Sympa::Tools::Data;
 use Sympa::Tools::File;
 use Sympa::Tools::Text;
@@ -1002,8 +1003,10 @@ sub _load_auth {
             'bind_password'   => '.+',
             'get_dn_by_uid_filter'        => '.+',
             'get_dn_by_email_filter'      => '.+',
-            'email_attribute'             => '\w+',
-            'alternative_email_attribute' => '(\w+)(,\w+)*',
+            'email_attribute'             => Sympa::Regexps::ldap_attrdesc(),
+            'alternative_email_attribute' => Sympa::Regexps::ldap_attrdesc()
+                . '(\s*,\s*'
+                . Sympa::Regexps::ldap_attrdesc() . ')*',
             'scope'                       => 'base|one|sub',
             'authentication_info_url'     => 'http(s)?:/.*',
             'use_tls'                     => 'starttls|ldaps|none',
@@ -1041,7 +1044,7 @@ sub _load_auth {
             'suffix'        => '.+',
             'scope'         => 'base|one|sub',
             'get_email_by_uid_filter' => '.+',
-            'email_attribute'         => '\w+',
+            'email_attribute'         => Sympa::Regexps::ldap_attrdesc(),
             'use_tls'                 => 'starttls|ldaps|none',
             'use_ssl'                 => '1',                     # Obsoleted
             'use_start_tls'           => '1',                     # Obsoleted
@@ -1068,7 +1071,7 @@ sub _load_auth {
             'suffix'        => '.+',
             'scope'         => 'base|one|sub',
             'get_email_by_uid_filter' => '.+',
-            'email_attribute'         => '\w+',
+            'email_attribute'         => Sympa::Regexps::ldap_attrdesc(),
             'use_tls'                 => 'starttls|ldaps|none',
             'use_ssl'                 => '1',                     # Obsoleted
             'use_start_tls'           => '1',                     # Obsoleted

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -1337,7 +1337,9 @@ our %pinfo = (
             'attrs' => {
                 'order'      => 8,
                 'gettext_id' => "extracted attribute",
-                'format'     => '\w+(\s*,\s*\w+)?',
+                'format'     => Sympa::Regexps::ldap_attrdesc()
+                    . '(\s*,\s*'
+                    . Sympa::Regexps::ldap_attrdesc() . ')?',
                 'default'    => 'mail',
                 'length'     => 50
             },
@@ -1462,7 +1464,7 @@ our %pinfo = (
             'attrs1' => {
                 'order'      => 8,
                 'gettext_id' => "first-level extracted attribute",
-                'format'     => '\w+',
+                'format'     => Sympa::Regexps::ldap_attrdesc(),
                 'length'     => 15
             },
             'select1' => {
@@ -1509,7 +1511,9 @@ our %pinfo = (
             'attrs2' => {
                 'order'      => 15,
                 'gettext_id' => "second-level extracted attribute",
-                'format'     => '\w+(\s*,\s*\w+)?',
+                'format'     => Sympa::Regexps::ldap_attrdesc()
+                    . '(\s*,\s*'
+                    . Sympa::Regexps::ldap_attrdesc() . ')?',
                 'default'    => 'mail',
                 'length'     => 50
             },
@@ -1777,7 +1781,7 @@ our %pinfo = (
             'attrs' => {
                 'order'      => 8,
                 'gettext_id' => "extracted attribute",
-                'format'     => '\w+',
+                'format'     => Sympa::Regexps::ldap_attrdesc(),
                 'default'    => 'mail',
                 'length'     => 15
             },
@@ -1907,7 +1911,7 @@ our %pinfo = (
             'attrs1' => {
                 'order'      => 8,
                 'gettext_id' => "first-level extracted attribute",
-                'format'     => '\w+',
+                'format'     => Sympa::Regexps::ldap_attrdesc(),
                 'length'     => 15
             },
             'select1' => {
@@ -1954,7 +1958,7 @@ our %pinfo = (
             'attrs2' => {
                 'order'      => 15,
                 'gettext_id' => "second-level extracted attribute",
-                'format'     => '\w+',
+                'format'     => Sympa::Regexps::ldap_attrdesc(),
                 'default'    => 'mail',
                 'length'     => 15
             },

--- a/src/lib/Sympa/Regexps.pm
+++ b/src/lib/Sympa/Regexps.pm
@@ -50,7 +50,10 @@ use constant multiple_host_with_port =>
 use constant multiple_host_or_url =>
     qr'([-\w]+://.+|[-.\w]+(:\d+)?)(,([-\w]+://.+|[-.\w]+(:\d+)?))*';
 use constant listname    => qr'[a-z0-9][a-z0-9\-\.\+_]*';
-use constant sql_query   => qr'(SELECT|select).*';
+
+use constant ldap_attrdesc => qr'\w[-\w]*(?:;[-\w]+)*'; # RFC2251, 4.1.5
+use constant sql_query     => qr'(SELECT|select).*';
+
 use constant scenario    => qr'[\w,\.\-]+';
 use constant task        => qr'\w+';
 use constant datasource  => qr'[\w-]+';


### PR DESCRIPTION
This PR is intended to be fix to Issue #22.

Parameters for LDAP attribute description such as "include_ldap_query" did not allow those including option(s) like "cn;lang-ja".  Fixed regular expression to check their format according to [RFC2251, 4.1.5](https://tools.ietf.org/html/rfc2251#section-4.1.5).
