### PR TITLE
Activating options in XSS Parser

### DIFF
--- a/src/lib/Sympa/HTMLSanitizer.pm
+++ b/src/lib/Sympa/HTMLSanitizer.pm
@@ -43,6 +43,9 @@ sub new {
     my $self = $class->SUPER::new(
         {   Context  => 'Document',
             AllowSrc => 1,
+            AllowHref       => 1,
+            AllowRelURL     => 1,
+            EscapeFiltered  => 0,
         }
     );
     $self->{_shsURLPrefix} =


### PR DESCRIPTION
It makes sense to use the same options as previous versions. Specially AllowHref to don't strip hrefs of links