### PR TITLE
FCGI scripts will not always restart when they are updated

### DIFF
--- a/src/cgi/sympa_soap_server.fcgi.in
+++ b/src/cgi/sympa_soap_server.fcgi.in
@@ -41,7 +41,7 @@ use Sympa::Log;
 use Sympa::SOAP;
 use Sympa::SOAP::Transport;
 
-my $birthday = time;
+my $birthday = [stat $PROGRAM_NAME]->[9];
 
 ## Load sympa config
 unless (Conf::load()) {
@@ -88,7 +88,7 @@ my $server = Sympa::SOAP::Transport->new();
 $server->dispatch_with({'urn:sympasoap' => 'Sympa::SOAP'});
 #$server->dispatch_to('--modulesdir--', 'Sympa::SOAP');
 
-$server->handle($birthday);
+$server->handle($birthday, $PROGRAM_NAME);
 
 __END__
 

--- a/src/cgi/sympa_soap_server.fcgi.in
+++ b/src/cgi/sympa_soap_server.fcgi.in
@@ -41,8 +41,6 @@ use Sympa::Log;
 use Sympa::SOAP;
 use Sympa::SOAP::Transport;
 
-my $birthday = [stat $PROGRAM_NAME]->[9];
-
 ## Load sympa config
 unless (Conf::load()) {
     printf STDERR
@@ -83,12 +81,8 @@ my $all_lists = Sympa::List::get_lists('*');
 #    Soap part
 ##############################################################################
 
-my $server = Sympa::SOAP::Transport->new();
-
-$server->dispatch_with({'urn:sympasoap' => 'Sympa::SOAP'});
-#$server->dispatch_to('--modulesdir--', 'Sympa::SOAP');
-
-$server->handle($birthday, $PROGRAM_NAME);
+Sympa::SOAP::Transport->new(cookie_expire => $Conf::Conf{'cookie_expire'})
+    ->dispatch_with({'urn:sympasoap' => 'Sympa::SOAP'})->handle;
 
 __END__
 

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1008,7 +1008,7 @@ unless (Conf::data_structure_uptodate()) {
 our %in;
 my $query;
 
-my $birthday = time;
+my $birthday = [stat $PROGRAM_NAME]->[9];
 
 my $bulk = Sympa::Bulk->new;
 
@@ -1965,14 +1965,15 @@ while ($query = new_loop()) {
         send_html('main.tt2');
     }
 
-    # exit if wwsympa.fcgi itself has changed
-    if ($ENV{'SCRIPT_FILENAME'}
-        and Sympa::Tools::File::get_mtime($ENV{'SCRIPT_FILENAME'}) >
-        $birthday) {
-        $log->syslog('notice',
-            'Exiting because %s has changed since fastcgi server started',
-            $ENV{'SCRIPT_FILENAME'});
-        exit(0);
+    # Exit if wwsympa.fcgi itself has changed.
+    if (defined $birthday) {
+        my $age = [stat $PROGRAM_NAME]->[9];
+        if (defined $age and $birthday != $age) {
+            $log->syslog('notice',
+                'Exiting because %s has changed since FastCGI server started',
+                $PROGRAM_NAME);
+            exit(0);
+        }
     }
 
 }


### PR DESCRIPTION
FCGI scripts (wwsympa.fcgi and sympa_soap_server.fcgi) will not always restart when they are updated.
- exit(0) occurred only when script file is _updated_: This assumption is not always true. It would be better to occur whenever timestamp is simply _changed_.
- The time of startup was used for origin of change. Timestamp of script would be used instead.
- Non-standard `SCRIPT_FILENAME` CGI environment variable was referred. Instead use `$PROGRAM_NAME` (`$0`).

Note:
- Separate FastCGI server like spawn-fcgi needs restart.  With systemd, `Restart` directive may be useful. With traditional sysVinit script, manual restart may be required.