### PR TITLE
"%" sign in SQL data source would be escaped

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -5827,9 +5827,11 @@ sub _include_users_sql {
         = @_;
 
     my $sth;
+    my $sourceSqlQuoteTmp = $source->{'sql_query'};
+    $sourceSqlQuoteTmp =~ s/%/%%/g; # Taking '%' into account in queries
     unless ($db
         and $db->connect()
-        and $sth = $db->do_query($source->{'sql_query'})) {
+        and $sth = $db->do_query($sourceSqlQuoteTmp)) {
         $log->syslog(
             'err',
             'Unable to connect to SQL datasource with parameters host: %s, database: %s',


### PR DESCRIPTION
[Submitted by B. Marchal, univ. Lorraine] When using '%' symbol in SQL data sources, said % was ignored because it was interpolated in subsequent sprintf. Fixed by escaping % sign.