### PR TITLE
When fallback language "en" is used, use "en_US" translation catalog

### DIFF
--- a/src/lib/Sympa/Language.pm
+++ b/src/lib/Sympa/Language.pm
@@ -577,14 +577,18 @@ sub dgettext {
         return '8bit';
     }
 
-    return $msgid unless $self->{lang} and $self->{lang} ne 'en';
+    my $gettext_locale;
+    unless ($self->{lang} and $self->{lang} ne 'en') {
+        $gettext_locale = 'en_US';
+    } else {
+        $gettext_locale = $self->{locale};
 
-    ## Workaround for nb/nn.
-    my $locale = $self->{locale};
-    $locale =~ s/^(nb|nn)\b/${1}_NO/;
+        # Workaround for nb/nn.
+        $gettext_locale =~ s/^(nb|nn)\b/${1}_NO/;
+    }
 
     local %ENV;
-    $ENV{'LANGUAGE'} = $locale;
+    $ENV{'LANGUAGE'} = $gettext_locale;
     return Locale::Messages::dgettext($textdomain, $msgid);
 }
 


### PR DESCRIPTION
This change is related to issue #80 (and probably #52, #54).

When language context is not known, fallback setting `en` is used. Currently, it does not use translation catalog and there seems no easy way to correct artless messages.  This PR may solve the problem by trying to use `en_US` translation catalog for `en-US` also in `en` context: Corrections (at least minor ones) can be done modifying the translation.
