### PR TITLE
Bugs on subscribe request with custom attributes and/or authorization

### DIFF
--- a/default/web_tt2/confirm_action.tt2
+++ b/default/web_tt2/confirm_action.tt2
@@ -289,7 +289,7 @@
   <input type="hidden" name="gecos" value="[% gecos %]" />
   [% FOREACH i = custom_attribute ~%]
     <input type="hidden" name="custom_attribute.[% i.key %]"
-     value="[% i.value %]" />
+     value="[% i.value.value.replace('\n', '&#10;') %]" />
   [%~ END %]
 [%~ END %]
   <input type="hidden" name="action" value="[% confirm_action %]" />

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -5537,6 +5537,11 @@ sub do_subscribe {
     @{$param}{qw(email gecos custom_attribute)} =
         ($email, $gecos, $in{'custom_attribute'});
 
+    # Initial access. show empty form.
+    unless ($in{'email'}) {
+        return 1;
+    }
+
     if ($list->{'admin'}{'custom_attribute'}
         and not _check_custom_attribute(
             $list, $param->{'action'}, $in{'custom_attribute'}

--- a/src/lib/Sympa/Request.pm
+++ b/src/lib/Sympa/Request.pm
@@ -222,8 +222,10 @@ sub get_id {
 
     join ';', map {
         my $val = $self->{$_};
-        if (ref $val) {
+        if (Scalar::Util::blessed($val) and $val->can('get_id')) {
             sprintf '%s=%s', $_, $val->get_id;
+        } elsif (ref $val) {
+            sprintf '%s=%s', $_, ref $val;
         } else {
             sprintf '%s=%s', $_, $val;
         }

--- a/src/lib/Sympa/Request.pm
+++ b/src/lib/Sympa/Request.pm
@@ -224,6 +224,8 @@ sub get_id {
         my $val = $self->{$_};
         if (Scalar::Util::blessed($val) and $val->can('get_id')) {
             sprintf '%s=%s', $_, $val->get_id;
+        } elsif (ref $val eq 'HASH' and $_ eq 'request') {  #FIXME
+            sprintf '%s=<%s>', $_, get_id($val);
         } elsif (ref $val) {
             sprintf '%s=%s', $_, ref $val;
         } else {

--- a/src/lib/Sympa/Request/Handler/add.pm
+++ b/src/lib/Sympa/Request/Handler/add.pm
@@ -58,6 +58,7 @@ sub _twist {
     my $sender  = $request->{sender};
     my $email   = $request->{email};
     my $comment = $request->{gecos};
+    my $ca      = $request->{custom_attribute};
 
     $language->set_lang($list->{'admin'}{'lang'});
 
@@ -98,6 +99,7 @@ sub _twist {
     $u->{'email'} = $email;
     $u->{'gecos'} = $comment;
     $u->{'date'}  = $u->{'update_date'} = time;
+    $u->{custom_attribute} = $ca if $ca;
 
     $list->add_list_member($u);
     if (defined $list->{'add_outcome'}{'errors'}) {


### PR DESCRIPTION
- [bug] Confirming subscription on web UI, custom attributes are broken.
- [bug] Authorizing subscription by owner may crash WWSympa.
- [bug] When subscription is authorized by owner, custom attributes submitted by user are omitted.
