### PR TITLE
Fix CSS attributes for un-hovered navigation menu items using color_5

### DIFF
--- a/default/web_tt2/css.tt2
+++ b/default/web_tt2/css.tt2
@@ -1988,6 +1988,10 @@ span.bottom_page, p.bottom_page{
 .top-bar, .top-bar-section ul li, .top-bar-section li:not(.has-form) a:not(.button){
     background-color: [% color_6 %];
 }
+/* properly set active list item color when not hovered */
+.top-bar-section li.active:not(.has-form) a:not(.button){
+    background-color: [% color_5%];
+}
 .top-bar .top-bar-section li:not(.has-form) a:not(.button):hover{
     background-color: [% color_5%];
 }


### PR DESCRIPTION
Our local branding guidelines require a color set that results in fairly dark colors for the top menu items, with a contrasting lighter color for the current item.

We found that when color_5 is set to something other than the default, the current menu item is still rendered as light blue instead of color_5.

![stock-color5-not-hovered](https://user-images.githubusercontent.com/16824077/31563288-019fa600-b024-11e7-9075-5d52ed8488fb.png)

Drawing from the code using color_6 immediately above it, this patch to css.tt2 uses color_5 as the background color for the active menu item when it is *not* being hovered over. 

![fix-color5-not-hovered](https://user-images.githubusercontent.com/16824077/31563381-6f450a74-b024-11e7-9a18-0a1f807d7567.png)

With this update, the colors are as expected and the GUI seems to work correctly when driving under 6.2.22. That is, the current menu item is color_5 (e.g. burnt orange), the rest are color_6 (dark brown), and hovering the mouse over another menu item properly changes the background to color_5 (burnt orange) as well.

--mic--