### PR TITLE
Add use_tls, ssl, version etc to valid LDAP options in Scenario.pm

### DIFF
--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -1805,7 +1805,9 @@ sub _load_ldap_configuration {
         return;
     }
 
-    my @valid_options    = qw(host suffix filter scope bind_dn bind_password);
+    my @valid_options    = qw(host suffix filter scope bind_dn bind_password
+                              use_tls ssl_version ssl_ciphers ssl_cert ssl_key
+                              ca_verify ca_path ca_file);
     my @required_options = qw(host suffix filter);
 
     my %valid_options    = map { $_ => 1 } @valid_options;


### PR DESCRIPTION
We have an LDAP search filter that requires some SSL connection options that are not accepted as valid options, such as ca_file, use_tls, and ssl_ciphers. 

This patch updates the list of valid LDAP configuration options in Scenario.pm to include

`       use_tls ssl_version ssl_ciphers ssl_cert ssl_key ca_verify ca_path ca_file
`

With this change, Sympa 6.2.22 accepts our search filter options and properly handles the LDAP search filter.
