### PR TITLE
Cache list info in Sympa::Scenario::verify to reduce overhead of pinfo…

### DIFF
--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -49,6 +49,9 @@ my $log = Sympa::Log->instance;
 my %all_scenarios;
 my %persistent_cache;
 
+my $picache = {};
+my $picache_refresh = 10;
+
 ## Creates a new object
 ## Supported parameters : function, robot, name, directory, file_path, options
 ## Output object has the following entries : name, file_path, rules, date,
@@ -698,7 +701,16 @@ sub verify {
 
     my $pinfo;
     if ($robot) {
-        $pinfo = Sympa::Robot::list_params($robot);
+        # Generating the lists index creates multiple calls to verify()
+        # per list, and each call triggers a copy of the pinfo hash.
+        # Profiling shows that this scales poorly with thousands of lists.
+        # Briefly cache the list params data to avoid this overhead.
+        if (time > $picache->{$robot}{'expires'}) {
+            $log->syslog('debug', 'robot %s pinfo cache refresh', $robot);
+            $picache->{$robot}{'pinfo'} = Sympa::Robot::list_params($robot);
+            $picache->{$robot}{'expires'} = (time + $picache_refresh);
+        }
+        $pinfo = $picache->{$robot}{'pinfo'};
     } else {
         $pinfo = {};
     }

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -705,7 +705,8 @@ sub verify {
         # per list, and each call triggers a copy of the pinfo hash.
         # Profiling shows that this scales poorly with thousands of lists.
         # Briefly cache the list params data to avoid this overhead.
-        if (time > $picache->{$robot}{'expires'}) {
+        
+        if (time > ($picache->{$robot}{'expires'} || 0)) {
             $log->syslog('debug', 'robot %s pinfo cache refresh', $robot);
             $picache->{$robot}{'pinfo'} = Sympa::Robot::list_params($robot);
             $picache->{$robot}{'expires'} = (time + $picache_refresh);


### PR DESCRIPTION
Our site has approximately 6000 lists and 600,000 subscribers.  In order to do performance testing of our upgrade to Sympa 6.2, we created a demo server and loaded it with that many lists and subscribers. We found that the lists index page could take over a minute to load.

Profiling with NYTProf indicated that copying the `%pinfo` hash in `Sympa::Robot::list_params() ` was the primary source of the time spent inside `do_lists()`, once wwsympa.fcgi was initialized.

Since `Sympa::Scenario::verify()` was the primary caller of `Sympa::Robot::list_params` during the list index, that code seemed to be a likely place for some caching. Robot parameters can change (say when topics are updated), so the cached data is updated every `$picache_refresh` seconds.

With this patch, lists index page performance with our demo Sympa 6.2.22 installation is approximately 3 seconds, instead of over 60. And it is comparable to our existing installation's performance. 

The before and after profiling data is attached as `nytprof-picache.zip`:
* before: `nytprof-6.2.22`
* after: `nytprof-6.2.22-picache`

The profiling data represents 5 successive requests to `/sympa/lists` to a single instance of `wwsympa.fcgi` running on our loaded demo server. We selected 5 requests instead of just 1 in order to reduce the impact of the significant overhead of simply starting wwsympa at all.

While I am not familiar enough with Sympa's design to be sure this is the very best way to approach this performance issue, this is an attempt to avoid breaking things while at the same time making things run acceptably fast.

--mic--

[nytprof-picache.zip](https://github.com/sympa-community/sympa/files/1383927/nytprof-picache.zip)