### PR TITLE
Suppress saving stats file, and solve problem about on-memory cache

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -2782,7 +2782,7 @@ sub check_param_in {
             $param->{'mod_total_shared'} =
                 $shared_doc->count_moderated_descendants;
 
-            if ($param->{'total'} > 0) {
+            if ($param->{'total'}) {
                 $param->{'bounce_total'} = $list->get_total_bouncing();
                 $param->{'bounce_rate'} =
                     $param->{'bounce_total'} * 100 / $param->{'total'};
@@ -10828,9 +10828,6 @@ sub do_edit_list {
         return undef;
     }
 
-    ## Save stats
-    $list->savestats();
-
     Sympa::Report::notice_report_web('list_config_updated', {},
         $param->{'action'});
     web_db_log({'status' => 'success'});
@@ -11412,12 +11409,8 @@ sub do_restore_list {
     }
     my @users = Sympa::List::_load_list_members_file(
         $list->{'dir'} . '/subscribers.closed.dump');
-    ## Insert users in database
-    foreach my $user (@users) {
-        $list->add_list_member($user);
-    }
-
-    $list->savestats();
+    # Insert users in database
+    $list->add_list_member(@users);
 
     my $aliases = Sympa::Admin::install_aliases($list);
     if ($aliases == 1) {

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1041,10 +1041,7 @@ while ($query = new_loop()) {
     $log->{level} = $Conf::Conf{'log_level'};
     $language->set_lang(Sympa::best_language('*'));
 
-    ## Empty cache of the List.pm module
-    Sympa::List::init_list_cache();
-
-    # Process grouped notifications
+    # Process grouped notifications.
     Sympa::Alarm->instance->flush;
 
     ## Check effective ID

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -3038,6 +3038,7 @@ sub _get_admins {
         $sdm and $sth = $sdm->do_prepared_query(
             sprintf(
                 q{SELECT user_admin AS email, comment_admin AS gecos,
+                         role_admin AS "role",
                          reception_admin AS reception,
                          visibility_admin AS visibility,
                          %s AS "date", %s AS update_date,

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -668,7 +668,7 @@ sub _cache_read_expiry {
         return Sympa::Tools::File::get_mtime(
             $self->{'dir'} . '/.last_sync.admin');
     } elsif ($type eq 'edit_list_conf') {
-        return [Sympa::search_fullpath($self, 'edit_list.conf')]->[9];
+        return [stat Sympa::search_fullpath($self, 'edit_list.conf')]->[9];
     } else {
         die 'bug in logic. Ask developer';
     }

--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -214,7 +214,7 @@ sub _move {
     my $sender       = $request->{sender};
     my $pending      = $request->{pending};
 
-    $current_list->savestats();
+    $current_list->savestats;   #FIXME: required?
 
     # Remove aliases and dump subscribers.
     Sympa::Admin::remove_aliases($current_list);

--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -214,8 +214,6 @@ sub _move {
     my $sender       = $request->{sender};
     my $pending      = $request->{pending};
 
-    $current_list->savestats;   #FIXME: required?
-
     # Remove aliases and dump subscribers.
     Sympa::Admin::remove_aliases($current_list);
     $current_list->_save_list_members_file(
@@ -665,6 +663,6 @@ L<Sympa::Spindle::ProcessRequest>.
 
 =head1 HISTORY
 
-L<Sympa::Request::Handler::move_list> appeared on Sympa 6.2.21b.
+L<Sympa::Request::Handler::move_list> appeared on Sympa 6.2.23b.
 
 =cut

--- a/src/lib/Sympa/Request/Handler/stats.pm
+++ b/src/lib/Sympa/Request/Handler/stats.pm
@@ -49,11 +49,12 @@ sub _twist {
     my $robot    = $list->{'domain'};
     my $sender   = $request->{sender};
 
+    my @stats = $list->get_stats;
     my %stats = (
-        'msg_rcv'   => $list->{'stats'}[0],
-        'msg_sent'  => $list->{'stats'}[1],
-        'byte_rcv'  => sprintf('%9.2f', ($list->{'stats'}[2] / 1024 / 1024)),
-        'byte_sent' => sprintf('%9.2f', ($list->{'stats'}[3] / 1024 / 1024))
+        'msg_rcv'   => $stats[0],
+        'msg_sent'  => $stats[1],
+        'byte_rcv'  => sprintf('%9.2f', ($stats[2] / 1024 / 1024)),
+        'byte_sent' => sprintf('%9.2f', ($stats[3] / 1024 / 1024))
     );
 
     unless (

--- a/src/lib/Sympa/SOAP/Transport.pm
+++ b/src/lib/Sympa/SOAP/Transport.pm
@@ -61,9 +61,6 @@ sub request {
         $ENV{'SYMPA_ROBOT'} =
             Sympa::Tools::WWW::get_robot('soap_url_local', 'soap_url');
 
-        ## Empty cache of the List.pm module
-        Sympa::List::init_list_cache();
-
         my $session;
         ## Existing session or new one
         if (Sympa::Session::get_session_cookie($ENV{'HTTP_COOKIE'})) {

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -823,9 +823,12 @@ sub verify {
         elsif ($value =~ /\[list\-\>([\w\-]+)\]/i) {
             my $param = $1;
 
-            if ($param eq 'name' or $param eq 'total') {
-                my $val = $list->{$param};
-                $value =~ s/\[list\-\>$param\]/$val/;
+            if ($param eq 'name') {
+                my $val = $list->{'name'};
+                $value =~ s/\[list\-\>name\]/$val/;
+            } elsif ($param eq 'total') {
+                my $val = $list->get_total;
+                $value =~ s/\[list\-\>total\]/$val/;
             } elsif ($param eq 'address') {
                 my $val = Sympa::get_address($list);
                 $value =~ s/\[list\-\>$param\]/$val/;

--- a/src/lib/Sympa/Spindle/ProcessArchive.pm
+++ b/src/lib/Sympa/Spindle/ProcessArchive.pm
@@ -49,12 +49,8 @@ sub _init {
     my $state = shift;
 
     if ($state == 1) {
-        Sympa::List::init_list_cache();
         # Process grouped notifications.
         Sympa::Alarm->instance->flush;
-    } elsif ($state == 2) {
-        ## Free zombie sendmail process.
-        #Sympa::Process->instance->reap_child;
     }
 
     1;

--- a/src/lib/Sympa/Spindle/ProcessAutomatic.pm
+++ b/src/lib/Sympa/Spindle/ProcessAutomatic.pm
@@ -328,7 +328,7 @@ sub _twist {
             }
             return undef;
         }
-        unless ($list->get_total() > 0) {
+        unless ($list->get_total) {
             $log->syslog('err',
                 'Dynamic list %s from %s family has ZERO subscribers',
                 $list, $dyn_list_family);

--- a/src/lib/Sympa/Spindle/ProcessAutomatic.pm
+++ b/src/lib/Sympa/Spindle/ProcessAutomatic.pm
@@ -51,12 +51,8 @@ sub _init {
     my $state = shift;
 
     if ($state == 1) {
-        Sympa::List::init_list_cache();
         # Process grouped notifications.
         Sympa::Alarm->instance->flush;
-    } elsif ($state == 2) {
-        ## Free zombie sendmail process.
-        #Sympa::Process->instance->reap_child;
     }
 
     1;

--- a/src/lib/Sympa/Spindle/ProcessBounce.pm
+++ b/src/lib/Sympa/Spindle/ProcessBounce.pm
@@ -56,12 +56,8 @@ sub _init {
     my $state = shift;
 
     if ($state == 1) {
-        Sympa::List::init_list_cache();
         # Process grouped notifications.
         Sympa::Alarm->instance->flush;
-    } elsif ($state == 2) {
-        ## Free zombie sendmail process.
-        #Sympa::Process->instance->reap_child;
     }
 
     1;

--- a/src/lib/Sympa/Spindle/ProcessDigest.pm
+++ b/src/lib/Sympa/Spindle/ProcessDigest.pm
@@ -218,8 +218,6 @@ sub _distribute_digest {
         }
     }
 
-    $list->savestats();
-
     return 1;
 }
 

--- a/src/lib/Sympa/Spindle/ProcessIncoming.pm
+++ b/src/lib/Sympa/Spindle/ProcessIncoming.pm
@@ -55,8 +55,7 @@ sub _init {
         $self->{_msgid}         = {};
         $self->{_msgid_cleanup} = time;
     } elsif ($state == 1) {
-        Sympa::List::init_list_cache();
-        # Process grouped notifications
+        # Process grouped notifications.
         Sympa::Alarm->instance->flush;
 
         # Cleanup in-memory msgid table, only in a while.
@@ -65,9 +64,6 @@ sub _init {
             $self->_clean_msgid_table();
             $self->{_msgid_cleanup} = time;
         }
-    } elsif ($state == 2) {
-        ## Free zombie sendmail process.
-        #Sympa::Process->instance->reap_child;
     }
 
     1;

--- a/src/lib/Sympa/Spindle/ProcessOutgoing.pm
+++ b/src/lib/Sympa/Spindle/ProcessOutgoing.pm
@@ -70,11 +70,7 @@ sub _init {
             ? $self->{log_level}
             : $Conf::Conf{'log_level'};
 
-        ## Free zombie sendmail process.
-        #Sympa::Process->instance->reap_child;
-
-        Sympa::List::init_list_cache();
-        # Process grouped notifications
+        # Process grouped notifications.
         Sympa::Alarm->instance->flush;
 
         unless ($process->{detached}) {

--- a/src/lib/Sympa/Spindle/ToList.pm
+++ b/src/lib/Sympa/Spindle/ToList.pm
@@ -312,9 +312,7 @@ sub _send_msg {
             # Add number and size of messages sent to total in stats file.
             my $numsent = scalar @selected_tabrcpt;
             my $bytes   = length $new_message->as_string;
-            $list->{'stats'}->[1] += $numsent;
-            $list->{'stats'}->[2] += $bytes;
-            $list->{'stats'}->[3] += $bytes * $numsent;
+            $list->update_stats(0, $numsent, $bytes, $bytes * $numsent);
         } else {
             $log->syslog(
                 'notice',
@@ -358,9 +356,7 @@ sub _send_msg {
             # Add number and size of messages sent to total in stats file.
             my $numsent = scalar @verp_selected_tabrcpt;
             my $bytes   = length $new_message->as_string;
-            $list->{'stats'}->[1] += $numsent;
-            $list->{'stats'}->[2] += $bytes;
-            $list->{'stats'}->[3] += $bytes * $numsent;
+            $list->update_stats(0, $numsent, $bytes, $bytes * $numsent);
         } else {
             $log->syslog('notice',
                 'No VERP subscribers left to distribute message to list %s',
@@ -382,7 +378,6 @@ sub _send_msg {
             );
         }
     }
-    $list->savestats;
     return $numstored;
 }
 

--- a/src/lib/Sympa/Spindle/ToList.pm
+++ b/src/lib/Sympa/Spindle/ToList.pm
@@ -203,7 +203,6 @@ sub _send_msg {
         my $total = $list->get_total('nocache');
         unless ($total and 0 < $total) {
             $log->syslog('info', 'No subscriber in list %s', $list);
-            $list->savestats;
             return 0;
         }
 
@@ -247,7 +246,6 @@ sub _send_msg {
         unless ($available_recipients) {
             $log->syslog('info', 'No subscriber for sending msg in list %s',
                 $list);
-            $list->savestats;
             return 0;
         }
     } else {

--- a/src/lib/Sympa/Spindle/ToOutgoing.pm
+++ b/src/lib/Sympa/Spindle/ToOutgoing.pm
@@ -45,13 +45,9 @@ sub _twist {
         my $list = $message->{context};
 
         # Add number and size of digests sent to total in stats file.
-        # Note: $list->savestats() should be executed when spindle finished
-        #       (see Sympa::Spindle::ProcessDigest).
         my $numsent = scalar @{$message->{rcpt} || []};
         my $bytes = length $message->as_string;
-        $list->{'stats'}[1] += $numsent;
-        $list->{'stats'}[2] += $bytes;
-        $list->{'stats'}[3] += $bytes * $numsent;
+        $list->update_stats(0, $numsent, $bytes, $bytes * $numsent);
     }
 
     $status ? 1 : undef;

--- a/src/lib/Sympa/Spindle/ToOutgoing.pm
+++ b/src/lib/Sympa/Spindle/ToOutgoing.pm
@@ -45,6 +45,8 @@ sub _twist {
         my $list = $message->{context};
 
         # Add number and size of digests sent to total in stats file.
+        # Note: $list->savestats() should be executed when spindle finished
+        #       (see Sympa::Spindle::ProcessDigest).
         my $numsent = scalar @{$message->{rcpt} || []};
         my $bytes = length $message->as_string;
         $list->{'stats'}[1] += $numsent;

--- a/src/lib/Sympa/Spindle/TransformIncoming.pm
+++ b/src/lib/Sympa/Spindle/TransformIncoming.pm
@@ -56,7 +56,7 @@ sub _twist {
     my $robot = $list->{'domain'};
 
     # Update msg_count, and returns the new X-Sequence, if any.
-    $message->{xsequence} = $list->get_next_sequence;
+    ($message->{xsequence}) = $list->update_stats(1);
 
     ## Loading info msg_topic file if exists, add X-Sympa-Topic
     my $topic;

--- a/src/lib/Sympa/Spool.pm
+++ b/src/lib/Sympa/Spool.pm
@@ -830,7 +830,7 @@ and metadatas indexed by keys in arrayref $marshal_keys.
 If key is uppercase, it means auto-generated value:
 C<'AUTHKEY'>, C<'KEYAUTH'>, C<'PID'>, C<'RAND'>, C<'TIME'>.
 Otherwise it means metadata or property of $message.
-If C<keep_keys> option (added on 6.2.21b) is set, forces using latter.
+If C<keep_keys> option (added on 6.2.23b) is set, forces using latter.
 
 sprintf() is executed under C<C> locale:
 Full stop (C<.>) is always used for decimal point in floating point number.
@@ -1011,6 +1011,6 @@ build_glob_pattern(), size(), _glob_pattern() and _store_key()
 were introduced on Sympa 6.2.8.
 _filter_pre() was introduced on Sympa 6.2.10.
 marshal(), unmarshal() and C<no_filter> option of next()
-were introduced on Sympa 6.2.21b.
+were introduced on Sympa 6.2.22.
 
 =cut

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -754,7 +754,6 @@ sub upgrade {
                     "$list->{'dir'}/subscribers");
 
                 $list->{'admin'}{'user_data_source'} = 'include2';
-                $list->{'total'} = 0;
 
                 ## Add users to the DB
                 $list->add_list_member(@users);

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -142,8 +142,7 @@ sub upgrade {
         Sympa::List::delete_all_list_admin();
 
         foreach my $list (@$all_lists) {
-            delete $list->{_admin_cache};
-            $list->sync_include_admin();
+            $list->sync_include_admin;
         }
     }
     else {

--- a/src/sbin/task_manager.pl.in
+++ b/src/sbin/task_manager.pl.in
@@ -253,10 +253,7 @@ foreach (keys %asgn_commands) {
 while (!$end) {
     my $current_date = time;    # current epoch date
 
-    ## Empty cache of the List.pm module
-    Sympa::List::init_list_cache();
-
-    # Process grouped notifications
+    # Process grouped notifications.
     Sympa::Alarm->instance->flush;
 
     ## List all tasks
@@ -403,9 +400,6 @@ while (!$end) {
     }
 
     sleep 60;
-
-    ## Free zombie sendmail processes
-    #Sympa::Process->instance->reap_child;
 }
 
 # Purge grouped notifications

--- a/src/sbin/task_manager.pl.in
+++ b/src/sbin/task_manager.pl.in
@@ -2066,22 +2066,18 @@ sub sync_include {
 
     my $list = $task->{'list_object'};
 
-    $list->sync_include();
-    $list->sync_include_admin()
-        if (
-        (   defined $list->{'admin'}{'editor_include'}
-            && $#{$list->{'admin'}{'editor_include'}} > -1
-        )
-        || (defined $list->{'admin'}{'owner_include'}
-            && $#{$list->{'admin'}{'owner_include'}} > -1)
-        );
+    $list->sync_include;
+    $list->sync_include_admin
+        if @{$list->{'admin'}{'editor_include'} || []}
+            or @{$list->{'admin'}{'owner_include'} || []};
 
-    if (!$list->has_include_data_sources()
-        && (!$list->{'last_sync'}
-            || ($list->{'last_sync'} > (stat("$list->{'dir'}/config"))[9]))
+    if (not $list->has_include_data_sources
+        and (not -e $list->{'dir'} . '/.last_sync.member'
+            or [stat $list->{'dir'} . '/.last_sync.member']->[9] >
+            [stat $list->{'dir'} . '/config']->[9])
         ) {
         $log->syslog('debug', 'List %s no more require sync_include task',
-            $list->{'name'});
+            $list);
         return -1;
     }
 }


### PR DESCRIPTION
When subscribers are imported, frequent write accesses to *listdir*`/stats` file occur.  This issue was reported by a listmaster.  According to investigation, content of this file must not being cached on memory, but rather be shared among processes.

Changes:
- Changes on subscribers, owners and editors will be "published" by updating timestamps of `.last_change.member` and `.last_change.admin` files in list directory.
- The last time of inclusion of  subscribers, owners and editors will be published by updating timestamps of `.last_sync.member` and `.last_sync.admin` files in list directory.
- 5th to 7th entries in `stats` file (total, last_sync, last_sync_admin) are removed.

Fixed bugs:
- [bug] Issue #7: Editing owners or editors on web UI requires restart to take effect.
- [bug] X-sequence header field in distributed messages will occasionally not be increased.

As a side work, barely effective cache by `%list_cache` and `init_list_cache()` were removed.