### PR TITLE
Insignificant bugs related to cache

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -11168,7 +11168,10 @@ sub do_close_list {
     if ($mode eq 'install') {
         return 'get_pending_lists';
     } else {
-        return $in{'previous_action'} || 'admin';
+        return
+            (Sympa::is_listmaster($list, $param->{'user'}{'email'})
+            ? ($in{'previous_action'} || 'admin')
+            : Conf::get_robot_conf($robot, 'default_home'));
     }
 }
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -386,7 +386,7 @@ sub new {
     my $pertinent_ttl = $list->{'admin'}{'distribution_ttl'}
         || $list->{'admin'}{'ttl'};
     if ($status
-        and $list->{'admin'}{'status'} eq 'open'
+        and grep {$list->{'admin'}{'status'} eq $_} qw(open pending)
         and (
             (   not $options->{'skip_sync_admin'}
                 and $list->_cache_read_expiry('last_sync_admin_user') <

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -386,6 +386,7 @@ sub new {
     my $pertinent_ttl = $list->{'admin'}{'distribution_ttl'}
         || $list->{'admin'}{'ttl'};
     if ($status
+        and $list->{'admin'}{'status'} eq 'open'
         and (
             (   not $options->{'skip_sync_admin'}
                 and $list->_cache_read_expiry('last_sync_admin_user') <

--- a/src/lib/Sympa/Request/Handler/open_list.pm
+++ b/src/lib/Sympa/Request/Handler/open_list.pm
@@ -87,6 +87,9 @@ sub _twist {
     # Insert users in database.
     $list->add_list_member(@users);
 
+    # Restore admins
+    $list->sync_include_admin;
+
     # Install new aliases.
     my $aliases = Sympa::Admin::install_aliases($list);
     if ($aliases and $aliases == 1) {


### PR DESCRIPTION
- When list is closed, list could be marked error_config. Fixed by checking owner only when list is open or peinding.
- When list is restored, long time could be taken before owners/editors are restored.
