### PR TITLE
Changes on POD format for transition to Markdown

### DIFF
--- a/src/libexec/alias_manager.pl.in
+++ b/src/libexec/alias_manager.pl.in
@@ -111,7 +111,9 @@ F<sympa.conf> or F<robot.conf> is recommended.
 
 =head1 SYNOPSIS
 
-S<B<alias_manager.pl> B<add> E<124> B<del> I<listname> I<domain> [ I<file> ]>
+S<C<alias_manager.pl> C<add> I<listname> I<domain> [ I<file> ]>
+
+S<C<alias_manager.pl> C<del> I<listname> I<domain> [ I<file> ]>
 
 =head1 DESCRIPTION
 
@@ -124,18 +126,18 @@ Alias management is performed only if it was setup in F<--CONFIG-->
 Administrators using MTA functionalities to manage aliases (ie
 virtual_regexp and transport_regexp with postfix) can disable alias
 management by setting
-C<sendmail_aliases> configuration parameter to B<none>.
+C<sendmail_aliases> configuration parameter to C<none>.
 
 =head1 OPTIONS
 
 =over 4
 
-=item B<add> I<listname> I<domain>
+=item C<add> I<listname> I<domain> [ I<file> ]
 
 Add the set of aliases for the mailing list I<listname> in the
 domain I<domain>.
 
-=item B<del> I<listname> I<domain>
+=item C<del> I<listname> I<domain> [ I<file> ]
 
 Remove the set of aliases for the mailing list I<listname> in the
 domain I<domain>.

--- a/src/sbin/archived.pl.in
+++ b/src/sbin/archived.pl.in
@@ -236,7 +236,7 @@ archived, archived.pl - Mailing List Archiving Daemon for Sympa
 
 =head1 SYNOPSIS
 
-S<B<archived.pl> [ B<--foreground> ] [ B<--debug> ]>
+C<archived.pl> S<[ C<--foreground> ]> S<[ C<--debug> ]>
 
 =head1 DESCRIPTION
 
@@ -259,20 +259,20 @@ options is included below.
 
 =over 5
 
-=item B<-F>, B<--foreground>
+=item C<-F>, C<--foreground>
 
 Do not detach TTY.
 
-=item B<-f>, B<--config=>I<file>
+=item C<-f>, C<--config=>I<file>
 
 Force archived to use an alternative configuration file instead
 of F<--CONFIG-->.
 
-=item B<-d>, B<--debug>
+=item C<-d>, C<--debug>
 
 Run the program in a debug mode.
 
-=item B<-h>, B<--help>
+=item C<-h>, C<--help>
 
 Print this help message.
 

--- a/src/sbin/bounced.pl.in
+++ b/src/sbin/bounced.pl.in
@@ -232,7 +232,7 @@ bounced, bounced.pl - Mailing List Bounce Processing Daemon for Sympa
 
 =head1 SYNOPSIS
 
-S<B<bounced> [ B<--foreground> ] [ B<--debug> ]>
+C<bounced.pl> S<[ C<--foreground> ]> S<[ C<--debug> ]>
 
 =head1 DESCRIPTION
 
@@ -251,24 +251,24 @@ options is included below.
 
 =over 5
 
-=item B<-F>, B<--foreground>
+=item C<-F>, C<--foreground>
 
 Do not detach TTY.
 
-=item B<-f>, B<--config=>I<file>
+=item C<-f>, C<--config=>I<file>
 
 Force bounced to use an alternative configuration file instead
 of F<--CONFIG-->.
 
-=item B<-d>, B<--debug>
+=item C<-d>, C<--debug>
 
 Run the program in a debug mode.
 
-=item B<-h>, B<--help>
+=item C<-h>, C<--help>
 
 Print this help message.
 
-=item B<--log_level=>I<level>
+=item C<--log_level=>I<level>
 
 Sets daemon log level.
 

--- a/src/sbin/bulk.pl.in
+++ b/src/sbin/bulk.pl.in
@@ -197,7 +197,7 @@ bulk, bulk.pl - Daemon for submitting messages to SMTP engine
 
 =head1 SYNOPSIS
 
-S<B<bulk.pl> [ B<--foreground> ] [ B<--debug> ]>
+C<bulk.pl> S<[ C<--foreground> ]> S<[ C<--debug> ]>
 
 =head1 DESCRIPTION 
 
@@ -210,28 +210,28 @@ traffic.
 
 =over 4
 
-=item B<-d>, B<--debug>
+=item C<-d>, C<--debug>
 
 Sets the debug mode
 
-=item B<-f>, B<--config=>I<file>
+=item C<-f>, C<--config=>I<file>
 
 Force bulk to use an alternative configuration file instead
 of F<--CONFIG-->.
 
-=item B<-F>, B<--foreground>
+=item C<-F>, C<--foreground>
 
 Prevents the script from being daemonized
 
-=item B<-h>, B<--help>
+=item C<-h>, C<--help>
 
 Prints this help message.
 
-=item B<--log_level=>I<level>
+=item C<--log_level=>I<level>
 
 Set log level.
 
-=item B<-m>, B<--mail>
+=item C<-m>, C<--mail>
 
 Logs every sendmail calls.
 

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -1053,15 +1053,15 @@ sympa, sympa.pl - Command line utility to manage Sympa
 
 =head1 SYNOPSIS
 
-S<B<sympa.pl> [ B<-d, --debug> ] [ B<-f, --file>=I<another.sympa.conf> ]>
-      S<[ B<-l, --lang>=I<lang> ]> [ B<-m, --mail> ]
-      S<[ B<-h, --help> ]> [ B<-v, --version> ]
-      S<>
-      S<[ B<--import>=I<listname> ]>
-      S<[ B<--close_list>=I<list[@robot]> ]>
-      S<[ B<--purge_list>=I<list[@robot]> ]>
-      S<[ B<--lowercase> ] [ B<--make_alias_file> ]>
-      S<[ B<--dump>=I<listname> | ALL ]>
+C<sympa.pl> S<[ C<-d, --debug> ]> S<[ C<-f, --file>=I<another.sympa.conf> ]>
+S<[ C<-l, --lang>=I<lang> ]> S<[ C<-m, --mail> ]>
+S<[ C<-h, --help> ]> S<[ C<-v, --version> ]>
+S<>
+S<[ C<--import>=I<listname> ]>
+S<[ C<--close_list>=I<list>[I<@robot>] ]>
+S<[ C<--purge_list>=I<list>[I<@robot>] ]>
+S<[ C<--lowercase> ]> S<[ C<--make_alias_file> ]>
+S<[ C<--dump>=I<listname> | ALL ]>
 
 =head1 DESCRIPTION
 
@@ -1077,22 +1077,22 @@ F<sympa.pl> may run with following options in general.
 
 =over 4
 
-=item B<-d>, B<--debug>
+=item C<-d>, C<--debug>
 
 Enable debug mode.
 
-=item B<-f>, B<--config=>I<file>
+=item C<-f>, C<--config=>I<file>
 
 Force Sympa to use an alternative configuration file instead
 of F<--CONFIG-->.
 
-=item B<-l>, B<--lang=>I<lang>
+=item C<-l>, C<--lang=>I<lang>
 
 Set this option to use a language for Sympa. The corresponding
 gettext catalog file must be located in F<$LOCALEDIR>
 directory.
 
-=item B<--log_level=>I<level>
+=item C<--log_level=>I<level>
 
 Sets Sympa log level.
 
@@ -1102,55 +1102,55 @@ With the following options F<sympa.pl> will run in batch mode:
 
 =over 4
 
-=item B<--add_list=>I<family_name> B<--robot=>I<robot_name>
-    B<--input_file=>I</path/to/file.xml>
+=item C<--add_list=>I<family_name> C<--robot=>I<robot_name>
+C<--input_file=>I</path/to/file.xml>
 
 Add the list described by the file.xml under robot_name, to the family
 family_name.
 
-=item B<--change_user_email> B<--current_email=>I<xx> B<--new_email=>I<xx>
+=item C<--change_user_email> C<--current_email=>I<xx> C<--new_email=>I<xx>
 
 Changes a user email address in all Sympa  databases (subscriber_table,
 list config, etc) for all virtual robots.
 
-=item B<--close_family=>I<family_name> B<--robot=>I<robot_name>
+=item C<--close_family=>I<family_name> C<--robot=>I<robot_name>
 
 Close lists of family_name family under robot_name.      
 
-=item B<--close_list=>I<list[@robot]>
+=item C<--close_list=>I<list>[I<@robot>]
 
 Close the list (changing its status to closed), remove aliases and remove
 subscribers from DB (a dump is created in the list directory to allow
 restoring the list)
 
-=item B<--conf_2_db>
+=item C<--conf_2_db>
 
 Load sympa.conf and each robot.conf into database.
 
-=item B<--create_list> B<--robot=>I<robot_name>
-    B<--input_file=>I</path/to/file.xml >
+=item C<--create_list> C<--robot=>I<robot_name>
+C<--input_file=>I</path/to/file.xml >
 
 Create a list with the XML file under robot robot_name.
 
-=item B<--dump=>I<list>@I<dom>|C<ALL>
+=item C<--dump=>I<list>@I<dom>|C<ALL>
 
 Dumps subscribers of for `listname' list or all lists. Subscribers are 
 dumped in subscribers.db.dump.
 
 =begin comment
 
-=item B<--export_list> [B<--robot=>I<robot_name>]
+=item C<--export_list> [ C<--robot=>I<robot_name> ]
 
 B<Not fully implemented>.
 
 =end comment
 
-=item B<--health_check>
+=item C<--health_check>
 
 Check if F<sympa.conf>, F<robot.conf> of virtual robots and database structure
 are correct.  If any errors occur, exits with non-zero status.
 
-=item B<--import=>I<list>@I<dom>
+=item C<--import=>I<list>@I<dom>
 
 Import subscribers in the list. Data are read from standard input.
 The imported data should contain one entry per line : the first field
@@ -1164,24 +1164,24 @@ Sample:
     john.steward@some.company.com           John - accountant
     mary.blacksmith@another.company.com     Mary - secretary
 
-=item B<--instantiate_family=>I<family_name> B<--robot=>I<robot_name>
-    B<--input_file=>I</path/to/file.xml> [B<--close_unknown>] [B<--quiet>]
+=item C<--instantiate_family=>I<family_name> C<--robot=>I<robot_name>
+C<--input_file=>I</path/to/file.xml> [ C<--close_unknown> ] [ C<--quiet> ]
 
 Instantiate family_name lists described in the file.xml under robot_name.
 The family directory must exist; automatically close undefined lists in a
 new instantiation if --close_unknown is specified; do not print report if
 C<--quiet> is specified.
 
-=item B<--lowercase>
+=item C<--lowercase>
 
 Lowercases email addresses in database.
 
-=item B<--make_alias_file> [ B<--robot> robot ]
+=item C<--make_alias_file> [ C<--robot> robot ]
 
 Create an aliases file in /tmp/ with all list aliases. It uses the
 F<list_aliases.tt2> template  (useful when list_aliases.tt2 was changed).
 
-=item B<--md5_encode_password>
+=item C<--md5_encode_password>
 
 Rewrite password in C<user_table> of database using MD5 fingerprint.
 YOU CAN'T UNDO unless you save this table first.
@@ -1189,54 +1189,54 @@ YOU CAN'T UNDO unless you save this table first.
 B<Note> that this option was obsoleted.
 Use L<upgrade_sympa_password(1)>.
 
-=item B<--modify_list=>I<family_name> B<--robot=>I<robot_name>
-    B<--input_file=>I</path/to/file.xml>
+=item C<--modify_list=>I<family_name> C<--robot=>I<robot_name>
+C<--input_file=>I</path/to/file.xml>
 
 Modify the existing list installed under the robot robot_name and that
 belongs to the family family_name. The new description is in the C<file.xml>.
 
-=item B<--purge_list>=I<list>[@I<robot>]
+=item C<--purge_list>=I<list>[@I<robot>]
 
 Remove the list (remove archive, configuration files, users and owners in admin table. Restore is not possible after this operation.
 
-=item B<--reload_list_config>
-    [B<--list=>I<mylist>@I<mydom>] [B<--robot=>I<mydom>]
+=item C<--reload_list_config>
+[ C<--list=>I<mylist>@I<mydom> ] [ C<--robot=>I<mydom> ]
 
 Recreates all F<config.bin> files or cache in C<list_table>.
 You should run this command if you edit authorization scenarios.
 The list and robot parameters are optional.
 
-=item B<--rename_list=>I<listname>@I<robot>
-    B<--new_listname=>I<newlistname> B<--new_listrobot=>I<newrobot>
+=item C<--rename_list=>I<listname>@I<robot>
+C<--new_listname=>I<newlistname> C<--new_listrobot=>I<newrobot>
 
 Renames a list or move it to another virtual robot.
 
-=item B<--send_digest> [B<--keep_digest>]
+=item C<--send_digest> [ C<--keep_digest> ]
 
 Send digest right now.
-If B<--keep_digest> is specified, stocked digest will not be removed.
+If C<--keep_digest> is specified, stocked digest will not be removed.
 
-=item B<--sync_include=>I<listname>@I<robot>
+=item C<--sync_include=>I<listname>@I<robot>
 
 Trigger the list members update.
 
-=item B<--sync_list_db> [ B<--list=>I<listname>@I<robot> ]
+=item C<--sync_list_db> [ C<--list=>I<listname>@I<robot> ]
 
 Syncs filesystem list configs to the database cache of list configs,
 optionally syncs an individual list if specified.
 
-=item B<--test_database_message_buffer>
+=item C<--test_database_message_buffer>
 
 B<Note>:
 This option was deprecated.
 
 Test the database message buffer size.
 
-=item B<--upgrade> [B<--from=>I<X>] [B<--to=>I<Y>]
+=item C<--upgrade> [ C<--from=>I<X> ] [ C<--to=>I<Y> ]
 
 Runs Sympa maintenance script to upgrade from version I<X> to version I<Y>.
 
-=item B<--upgrade_shared> [B<--list=>I<X>] [B<--robot=>I<Y>]>
+=item C<--upgrade_shared> [ C<--list=>I<X> ] [ C<--robot=>I<Y> ]
 
 B<Note>:
 This option was deprecated.
@@ -1250,16 +1250,16 @@ With following options F<sympa.pl> will print some information and exit.
 
 =over 4
 
-=item B<-h>, B<--help>
+=item C<-h>, C<--help>
 
 Print this help message.
 
-=item B<--md5_digest=>I<password>
+=item C<--md5_digest=>I<password>
 
 Output a MD5 digest of a password (useful for SOAP client trusted
 application).
 
-=item B<-v>, B<--version>
+=item C<-v>, C<--version>
 
 Print the version number.
 

--- a/src/sbin/sympa_automatic.pl.in
+++ b/src/sbin/sympa_automatic.pl.in
@@ -315,10 +315,11 @@ sympa_automatic, sympa_automatic.pl - Automatic list creation daemon
 
 =head1 SYNOPSIS
 
-S<B<sympa_automatic.pl> [ B<-d, --debug> ] [ B<-f, --file>=I<another.sympa.conf> ]>
-      S<[ B<-k, --keepcopy>=I<directory> ]>
-      S<[ [ B<-m, --mail> ]>
-      S<[ B<-h, --help> ]> [ B<-v, --version> ]
+C<sympa_automatic.pl> S<[ C<-d, --debug> ]>
+S<[ C<-f, --file>=I<another.sympa.conf> ]>
+S<[ C<-k, --keepcopy>=I<directory> ]>
+S<[ [ C<-m, --mail> ]>
+S<[ C<-h, --help> ]> S<[ C<-v, --version> ]>
 
 =head1 DESCRIPTION
 
@@ -335,16 +336,16 @@ F<sympa_automatic.pl> may run with following options in general.
 
 =over 4
 
-=item B<-d>, B<--debug>
+=item C<-d>, C<--debug>
 
 Enable debug mode.
 
-=item B<-f>, B<--config=>I<file>
+=item C<-f>, C<--config=>I<file>
 
 Force Sympa to use an alternative configuration file instead
 of F<--CONFIG-->.
 
-=item B<--log_level=>I<level>
+=item C<--log_level=>I<level>
 
 Sets Sympa log level.
 
@@ -354,17 +355,17 @@ F<sympa_automatic.pl> may run in daemon mode with following options.
 
 =over 4
 
-=item B<--foreground>
+=item C<--foreground>
 
 The process remains attached to the TTY.
 
-=item B<-k>, B<--keepcopy=>F<directory>
+=item C<-k>, C<--keepcopy=>I<directory>
 
 This option tells Sympa to keep a copy of every incoming message, 
 instead of deleting them. `directory' is the directory to 
 store messages.
 
-=item B<-m>, B<--mail>
+=item C<-m>, C<--mail>
 
 Sympa will log calls to sendmail, including recipients. This option is
 useful for keeping track of each mail sent (log files may grow faster
@@ -376,11 +377,11 @@ With following options F<sympa_automatic.pl> will print some information and exi
 
 =over 4
 
-=item B<-h>, B<--help>
+=item C<-h>, C<--help>
 
 Print this help message.
 
-=item B<-v>, B<--version>
+=item C<-v>, C<--version>
 
 Print the version number.
 

--- a/src/sbin/sympa_msg.pl.in
+++ b/src/sbin/sympa_msg.pl.in
@@ -425,10 +425,11 @@ sympa_msg, sympa_msg.pl - Daemon to handle incoming messages
 
 =head1 SYNOPSIS
 
-S<B<sympa_msg.pl> [ B<-d, --debug> ] [ B<-f, --file>=I<another.sympa.conf> ]>
-      S<[ B<-k, --keepcopy>=I<directory> ]>
-      S<[ B<-l, --lang>=I<lang> ]> [ B<-m, --mail> ]
-      S<[ B<-h, --help> ]> [ B<-v, --version> ]
+C<sympa_msg.pl> S<[ C<-d>, C<--debug> ]>
+S<[ C<-f>, C<--file>=I<another.sympa.conf> ]>
+S<[ C<-k>, C<--keepcopy>=I<directory> ]>
+S<[ C<-l>, C<--lang>=I<lang> ]> S<[ C<-m>, C<--mail> ]>
+S<[ C<-h>, C<--help> ]> S<[ C<-v>, C<--version> ]>
 
 =head1 DESCRIPTION
 
@@ -449,22 +450,22 @@ options is included below.
 
 =over 4
 
-=item B<-d>, B<--debug>
+=item C<-d>, C<--debug>
 
 Enable debug mode.
 
-=item B<-f>, B<--config=>I<file>
+=item C<-f>, C<--config=>I<file>
 
 Force Sympa to use an alternative configuration file instead
 of F<--CONFIG-->.
 
-=item B<-l>, B<--lang=>I<lang>
+=item C<-l>, C<--lang=>I<lang>
 
 Set this option to use a language for Sympa. The corresponding
 gettext catalog file must be located in F<$LOCALEDIR>
 directory.
 
-=item B<--log_level=>I<level>
+=item C<--log_level=>I<level>
 
 Sets Sympa log level.
 
@@ -474,29 +475,30 @@ F<sympa_msg.pl> may run in daemon mode with following options.
 
 =over 4
 
-=item B<--foreground>
+=item C<--foreground>
 
 The process remains attached to the TTY.
 
-=item B<-k>, B<--keepcopy=>F<directory>
+=item C<-k>, C<--keepcopy=>F<directory>
 
 This option tells Sympa to keep a copy of every incoming message, 
 instead of deleting them. `directory' is the directory to 
 store messages.
 
-=item B<-m>, B<--mail>
+=item C<-m>, C<--mail>
 
 Sympa will log calls to sendmail, including recipients. This option is
 useful for keeping track of each mail sent (log files may grow faster
 though).
 
-=item B<--service=process_command>|B<process_message>|B<process_creation>
+=item C<--service=>I<service>
 
 B<Note>:
 This option was deprecated.
 
-Process is dedicated to messages distribution, commands or to automatic lists
-creation (default three of them).
+Process is dedicated to messages distribution (C<process_message>),
+commands (C<process_command>) or to automatic lists
+creation (C<process_creation>, default three of them).
 
 =back
 
@@ -504,11 +506,11 @@ With following options F<sympa_msg.pl> will print some information and exit.
 
 =over 4
 
-=item B<-h>, B<--help>
+=item C<-h>, C<--help>
 
 Print this help message.
 
-=item B<-v>, B<--version>
+=item C<-v>, C<--version>
 
 Print the version number.
 

--- a/src/sbin/sympa_newaliases.pl.in
+++ b/src/sbin/sympa_newaliases.pl.in
@@ -177,10 +177,10 @@ sympa_newaliases, sympa_newaliases.pl - Alias database maintenance
 
 =head1 DESCRIPTION
 
-sympa_newaliases is a program to maintain alias database.
+F<sympa_newaliases.pl> is a program to maintain alias database.
 
-It is typically called by
-L<alias_manager(8)> via sympa_newaliases-wrapper,
+It is typically invoked from
+L<Sympa::Aliases::Template> module via sympa_newaliases-wrapper,
 then updates alias database.
 
 =head1 OPTIONS
@@ -189,16 +189,16 @@ F<sympa_newaliases.pl> may run with following options.
 
 =over
 
-=item B<--domain=>I<domain>
+=item C<--domain=>I<domain>
 
 Name of virtual robot on which aliases will be updated.
 
-=item B<-f>, B<--config=>I<file>
+=item C<-f>, C<--config=>I<file>
 
 Force sympa_newaliases to use an alternative configuration file instead
 of F<--CONFIG-->.
 
-=item B<-h>, B<--help>
+=item C<-h>, C<--help>
 
 Print this help message.
 
@@ -291,6 +291,6 @@ IKEDA Soji <ikeda@conversion.co.jp>.
 
 =head1 SEE ALSO
 
-L<alias_manager(8)>.
+L<Sympa::Aliases::Template>.
 
 =cut

--- a/src/sbin/sympa_wizard.pl.in
+++ b/src/sbin/sympa_wizard.pl.in
@@ -691,44 +691,44 @@ sympa_wizard, sympa_wizard.pl - Help Performing Sympa Initial Setup
     
 =head1 SYNOPSIS
 
-S<B<sympa_wizard.pl>>
-    S<[B<--batch> [I<key>=I<value> ...]]>
-    S<[B<--check>]>
-    S<[B<--create> [B<--target=>I<file>]]>
-    S<[B<--display>]>
-    S<[B<-h, --help>]>
-    S<[B<-v, --version>]>
+C<sympa_wizard.pl>
+S<[ C<--batch> [ I<key>=I<value> ... ] ]>
+S<[ C<--check> ]>
+S<[ C<--create> [ C<--target=>I<file> ] ]>
+S<[ C<--display> ]>
+S<[ C<-h, --help> ]>
+S<[ C<-v, --version> ]>
 
 =head1 OPTIONS
 
 =over 4
 
-=item sympa_wizard.pl
+=item C<sympa_wizard.pl>
 
 Edit current Sympa configuration.
 
-=item sympa_wizard.pl --batch I<key>=I<value> ...
+=item C<sympa_wizard.pl> C<--batch> I<key>=I<value> ...
 
 Edit in batch mode.
 Arguments would include pairs of parameter name and value.
 
-=item sympa_wizard.pl --check
+=item C<sympa_wizard.pl> C<--check>
 
 Check CPAN modules needed for running Sympa.
 
-=item sympa_wizard.pl --create [--target file]
+=item C<sympa_wizard.pl> C<--create> [ C<--target> I<file> ]
 
 Creates a new F<sympa.conf> configuration file.
 
-=item sympa_wizard.pl --display
+=item C<sympa_wizard.pl> C<--display>
 
 Outputs all configuration parameters.
 
-=item sympa_wizard.pl --help
+=item C<sympa_wizard.pl> C<--help>
 
 Display usage instructions.
 
-=item sympa_wizard.pl --version
+=item C<sympa_wizard.pl> C<--version>
 
 Print version number.
 

--- a/src/sbin/task_manager.pl.in
+++ b/src/sbin/task_manager.pl.in
@@ -2086,7 +2086,7 @@ task_manager, task_manager.pl - Daemon to Process Periodical Sympa Tasks
 
 =head1 SYNOPSIS
 
-S<B<task_manager.pl> [ B<--foreground> ] [ B<--debug> ]>
+C<task_manager.pl> S<[ C<--foreground> ]> S<[ C<--debug> ]>
 
 =head1 DESCRIPTION
 
@@ -2096,24 +2096,24 @@ XXX @todo doc
 
 =over 4
 
-=item B<-d>, B<--debug>
+=item C<-d>, C<--debug>
 
 Sets the debug mode
 
-=item B<-f>, B<--config=>I<file>
+=item C<-f>, C<--config=>I<file>
 
 Force task_manager to use an alternative configuration file instead
 of F<--CONFIG-->.
 
-=item B<-F>, B<--foreground>
+=item C<-F>, C<--foreground>
 
 Prevents the script from being daemonized
 
-=item B<-h>, B<--help>
+=item C<-h>, C<--help>
 
 Prints this help message.
 
-=item B<--log_level=>I<level>
+=item C<--log_level=>I<level>
 
 Set log level.
 


### PR DESCRIPTION
At least with kramdown, a variant of Markdown, two hyphens (`--`) in the text is altered to an en dash: See <https://github.com/gettalong/kramdown/issues/472>.  To avoid it, use `C<...>` instead of `B<...>` etc. in POD.