### PR TITLE
Characters in pages are garbled (get "mojibake") with Perl 5.22.0 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - autoreconf -i
   - ./configure
   - cd src; make; cd ..
-  - make check-local TEST_FILES='t/compile_executables.t t/compile_modules.t t/parse_templates.t t/pod-syntax.t'
+  - make check-local TEST_FILES='t/compile_executables.t t/compile_modules.t t/parse_templates.t t/pod-syntax.t t/Language.t'
 
 after_success:
   - coverage-report

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - autoreconf -i
   - ./configure
   - cd src; make; cd ..
-  - make check-local TEST_FILES='t/compile_executables.t t/compile_modules.t t/parse_templates.t t/pod-syntax.t t/Language.t'
+  - make check-local TEST_FILES='t/compile_executables.t t/compile_modules.t t/parse_templates.t t/pod-syntax.t'
 
 after_success:
   - coverage-report

--- a/src/lib/Sympa/Language.pm
+++ b/src/lib/Sympa/Language.pm
@@ -31,6 +31,7 @@ use strict;
 use warnings;
 use base qw(Class::Singleton);
 
+use Encode qw();
 use Locale::Messages;
 use POSIX qw();
 
@@ -688,6 +689,7 @@ sub gettext_strftime {
         POSIX::setlocale(POSIX::LC_TIME(), $self->{locale_time});
     }
     my $ret = POSIX::strftime($format, @args);
+    Encode::_utf8_off($ret);
 
     POSIX::setlocale(POSIX::LC_TIME(), $orig_locale);
     return $ret;

--- a/t/Language.t
+++ b/t/Language.t
@@ -199,6 +199,9 @@ my %tests = (
     ## Emulated strftime()
     gettext_strftime =>
         [['%a, %d %b %Y' => "\xC4\x8Ct 01. Led 1970", 'emulated strftime'],],
+ 
+    ## Failed if utf8 flag set
+    gettext_strftime_noutf8 => [['%a, %d %b %Y'],],
 );
 
 plan tests => scalar map {@$_} values %tests;
@@ -297,5 +300,12 @@ foreach my $test (@{$tests{gettext_strftime}}) {
     is($language->gettext_strftime($test->[0], gmtime 0),
         $test->[1],
         "gettext_strftime($test->[0])" . ($test->[2] ? ": $test->[2]" : ''));
+}
+
+# PR #134
+$language->set_lang('zh-TW');
+foreach my $test (@{$tests{gettext_strftime_noutf8}}) {
+    ok(!Encode::is_utf8($language->gettext_strftime($test->[0], gmtime 0)),
+        "!is_utf8 gettext_strftime($test->[0])");
 }
 


### PR DESCRIPTION
This bug was reported by a japanese listmaster.  Users in non-Latin-1 languages (language other than "en", "de", "fr", ...) will notice this bug. Latin-1 users rarely realize it but warnings are spit out to error log:
```
wwsympa.fcgi: Use of wide characters in FCGI::Stream::PRINT is deprecated and will stop wprking in a future version of FCGI at /usr/local/lib/perl5/site_perl/mach/5.24/Template.pm line 162.
```

Background: Starting with Perl 5.22.0, POSIX::strftime() returns Unicode (utf8 flag set) string under UTF-8 locale.
- https://metacpan.org/pod/release/SHAY/perl-5.26.1/pod/perl5220delta.pod#Better-heuristics-on-older-platforms-for-determining-locale-UTF-8ness
- https://perl5.git.perl.org/perl.git/commit/9717af6d049902fc887c412facb2d15e785ef1a4

Sympa::Language::gettext_strftime() uses it to format localized date/time, and utf8-flagged texts were mixed in the output.

Fixed by dropping utf8 flag from the result of POSIX::strftime().

----
4 Dec Update: Added warning message.