### PR TITLE
Restore default_ttl #145

### DIFF
--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -1754,6 +1754,13 @@ our @params = (
         'file'    => 'sympa.conf',
         'default' => '300',
     },
+    {   'name'       => 'default_ttl',
+        'gettext_id' => 'Default of inclusion timeout',
+        'gettext_comment' =>
+            'Default timeout between two scheduled synchronizations of list members with data sources.',
+        'file'    => 'sympa.conf',
+        'default' => '3600',
+    },
 
     {   'gettext_id' => 'DKIM',
         'gettext_comment' =>
@@ -2011,12 +2018,6 @@ our @params = (
             'Defines the prefix allowing to recognize that a list is an automatic list.',
         'file'     => 'sympa.conf',
         'optional' => '1',
-    },
-    {   'name' => 'default_ttl',    #FIXME: maybe not used
-        'gettext_id' =>
-            'Default timeout between two scheduled synchronizations of list members with data sources.',
-        'file'    => 'sympa.conf',
-        'default' => '3600',
     },
     {   'name' => 'default_distribution_ttl',    #FIXME: maybe not used
         'gettext_id' =>

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -1686,7 +1686,7 @@ our %pinfo = (
             'Sympa caches user data extracted using the include parameter. Their TTL (time-to-live) within Sympa can be controlled using this parameter. The default value is 3600',
         'gettext_unit' => 'seconds',
         'format'       => '\d+',
-        'default'      => 3600,
+        'default'      => {'conf' => 'default_ttl'},
         'length'       => 6
     },
 


### PR DESCRIPTION
`default_ttl` configuration parameter was restored. It was removed on 6.2 pre-alpha without specific reason.

This may fix issue #145.
