### PR TITLE
Inconsistencies in implementation and documentation of typical list profile (create list templates)

### DIFF
--- a/default/create_list_templates/confidential/config.tt2
+++ b/default/create_list_templates/confidential/config.tt2
@@ -51,6 +51,9 @@ owner
 [% FOREACH e = editor -%]
 editor
   email [% e.email %]
+  [% IF e.gecos -%] 
+  gecos [% e.gecos %]
+  [% END %]
 
 [% END %]
 [% END %]

--- a/default/create_list_templates/hotline/config.tt2
+++ b/default/create_list_templates/hotline/config.tt2
@@ -54,6 +54,9 @@ owner_include
 [% FOREACH e = editor -%]
 editor
   email [% e.email %]
+  [% IF e.gecos -%] 
+  gecos [% e.gecos %]
+  [% END %]
 
 [% END -%]
 [% END %]

--- a/default/create_list_templates/html-news-letter/config.tt2
+++ b/default/create_list_templates/html-news-letter/config.tt2
@@ -56,6 +56,9 @@ owner_include
 [% FOREACH e = editor -%]
 editor
   email [% e.email %]
+  [% IF e.gecos -%]
+  gecos [% e.gecos %]
+  [% END %]
 
 [% END -%]
 [% END %]

--- a/default/create_list_templates/intranet_list/config.tt2
+++ b/default/create_list_templates/intranet_list/config.tt2
@@ -52,6 +52,9 @@ owner_include
 [% FOREACH e = editor -%]
 editor
   email [% e.email %]
+  [% IF e.gecos -%]
+  gecos [% e.gecos %]
+  [% END %]
 
 [% END %]
 [% END %]

--- a/default/create_list_templates/news-letter/config.tt2
+++ b/default/create_list_templates/news-letter/config.tt2
@@ -50,6 +50,9 @@ owner_include
 [% FOREACH e = editor -%]
 editor
   email [% e.email %]
+  [% IF e.gecos -%]
+  gecos [% e.gecos %]
+  [% END %]
 
 [% END %]
 [% END %]

--- a/default/create_list_templates/private_working_group/config.tt2
+++ b/default/create_list_templates/private_working_group/config.tt2
@@ -57,6 +57,9 @@ owner_include
 [% FOREACH e = editor -%]
 editor
   email [% e.email %]
+  [% IF e.gecos -%]
+  gecos [% e.gecos %]
+  [% END %]
 
 [% END %]
 [% END %]

--- a/default/create_list_templates/public_web_forum/config.tt2
+++ b/default/create_list_templates/public_web_forum/config.tt2
@@ -58,6 +58,9 @@ owner_include
 [% FOREACH e = editor -%]
 editor
   email [% e.email %]
+  [% IF e.gecos -%]
+  gecos [% e.gecos %]
+  [% END %]
 
 [% END %]
 [% END %]

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -532,7 +532,7 @@ our %required_args = (
     ## other required parameters are checked in the subroutine
     'create_automatic_list'         => ['param.user.email', 'family'],
     'create_automatic_list_request' => ['param.user.email', 'family'],
-    'create_list'                   => ['param.user.email'],
+    'create_list'                   => ['param.user.email', 'info'],
     'create_list_request'           => ['param.user.email'],
     #XXX'css' => [],
     'd_admin'         => ['param.list', 'param.user.email'],

--- a/src/lib/Sympa/Family.pm
+++ b/src/lib/Sympa/Family.pm
@@ -345,6 +345,10 @@ sub modify_list {
     }
 
     my $hash_list = $config->getHash();
+    # Compatibility: single topic on 6.2.24 or earlier.
+    $hash_list->{config}{topics} ||= $hash_list->{config}{topic};
+    # "moderator" is documented as single editor.
+    $hash_list->{config}{editor} ||= [$hash_list->{config}{moderator}];
 
     #getting list
     my $list;
@@ -874,6 +878,10 @@ sub instantiate {
 
         ## stores the list config into the hash referenced by $hash_list.
         my $hash_list = $config->getHash();
+        # Compatibility: single topic on 6.2.24 or earlier.
+        $hash_list->{config}{topics} ||= $hash_list->{config}{topic};
+        # "moderator" is documented as single editor.
+        $hash_list->{config}{editor} ||= [$hash_list->{config}{moderator}];
 
         if ($list) {
             ## LIST ALREADY EXISTING
@@ -1056,6 +1064,10 @@ sub instantiate {
                 next;
             }
             my $hash_list = $config->getHash();
+            # Compatibility: single topic on 6.2.24 or earlier.
+            $hash_list->{config}{topics} ||= $hash_list->{config}{topic};
+            # "moderator" is documented as single editor.
+            $hash_list->{config}{editor} ||= [$hash_list->{config}{moderator}];
 
             my $result = $self->_update_existing_list($list, $hash_list);
             unless (defined $result) {

--- a/src/lib/Sympa/Family.pm
+++ b/src/lib/Sympa/Family.pm
@@ -347,8 +347,10 @@ sub modify_list {
     my $hash_list = $config->getHash();
     # Compatibility: single topic on 6.2.24 or earlier.
     $hash_list->{config}{topics} ||= $hash_list->{config}{topic};
-    # "moderator" is documented as single editor.
-    $hash_list->{config}{editor} ||= [$hash_list->{config}{moderator}];
+    # In old documentation "moderator" was single or multiple editors.
+    my $mod = $hash_list->{config}{moderator};
+    $hash_list->{config}{editor} ||=
+        (ref $mod eq 'ARRAY') ? $mod : (ref $mod eq 'HASH') ? [$mod] : [];
 
     #getting list
     my $list;
@@ -880,8 +882,10 @@ sub instantiate {
         my $hash_list = $config->getHash();
         # Compatibility: single topic on 6.2.24 or earlier.
         $hash_list->{config}{topics} ||= $hash_list->{config}{topic};
-        # "moderator" is documented as single editor.
-        $hash_list->{config}{editor} ||= [$hash_list->{config}{moderator}];
+        # In old documentation "moderator" was single or multiple editors.
+        my $mod = $hash_list->{config}{moderator};
+        $hash_list->{config}{editor} ||=
+            (ref $mod eq 'ARRAY') ? $mod : (ref $mod eq 'HASH') ? [$mod] : [];
 
         if ($list) {
             ## LIST ALREADY EXISTING
@@ -1066,8 +1070,10 @@ sub instantiate {
             my $hash_list = $config->getHash();
             # Compatibility: single topic on 6.2.24 or earlier.
             $hash_list->{config}{topics} ||= $hash_list->{config}{topic};
-            # "moderator" is documented as single editor.
-            $hash_list->{config}{editor} ||= [$hash_list->{config}{moderator}];
+            # In old documentation "moderator" was single or multiple editors.
+            my $mod = $hash_list->{config}{moderator};
+            $hash_list->{config}{editor} ||=
+            (ref $mod eq 'ARRAY') ? $mod : (ref $mod eq 'HASH') ? [$mod] : [];
 
             my $result = $self->_update_existing_list($list, $hash_list);
             unless (defined $result) {

--- a/src/lib/Sympa/Request/Handler/create_list.pm
+++ b/src/lib/Sympa/Request/Handler/create_list.pm
@@ -58,7 +58,7 @@ sub _twist {
     my $sender   = $request->{sender};
 
     # Obligatory parameters.
-    foreach my $arg (qw(subject template description topics)) {
+    foreach my $arg (qw(subject template topics)) {
         unless (defined $param->{$arg} and $param->{$arg} =~ /\S/) {
             $self->add_stash($request, 'user', 'missing_arg',
                 {argument => $arg});
@@ -67,7 +67,11 @@ sub _twist {
         }
     }
     # The 'other' topic means no topic.
-    delete $request->{topics} if $request->{topics} eq 'other';
+    $param->{topics} = lc $param->{topics};
+    delete $param->{topics} if $param->{topics} eq 'other';
+    # Sanytize editor.
+    $param->{editor} =
+        [grep { ref $_ eq 'HASH' and $_->{email} } @{$param->{editor} || []}];
 
     # owner.email || owner_include.source
     _check_owner_defined($param);

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -587,8 +587,10 @@ if ($main::options{'dump'}) {
     my $hash = $config->getHash();
     # Compatibility: single topic on 6.2.24 or earlier.
     $hash->{config}{topics} ||= $hash->{config}{topic};
-    # "moderator" is documented as single editor.
-    $hash->{config}{editor} ||= [$hash->{config}{moderator}];
+    # In old documentation "moderator" was single or multiple editors.
+    my $mod = $hash->{config}{moderator};
+    $hash->{config}{editor} ||=
+        (ref $mod eq 'ARRAY') ? $mod : (ref $mod eq 'HASH') ? [$mod] : [];
 
     my $spindle = Sympa::Spindle::ProcessRequest->new(
         context    => $robot,
@@ -689,8 +691,10 @@ if ($main::options{'dump'}) {
     my $hash = $config->getHash();
     # Compatibility: single topic on 6.2.24 or earlier.
     $hash->{config}{topics} ||= $hash->{config}{topic};
-    # "moderator" is documented as single editor.
-    $hash->{config}{editor} ||= [$hash->{config}{moderator}];
+    # In old documentation "moderator" was single or multiple editors.
+    my $mod = $hash->{config}{moderator};
+    $hash->{config}{editor} ||=
+        (ref $mod eq 'ARRAY') ? $mod : (ref $mod eq 'HASH') ? [$mod] : [];
 
     my $spindle = Sympa::Spindle::ProcessRequest->new(
         context => $family,

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -585,6 +585,10 @@ if ($main::options{'dump'}) {
         exit 1;
     }
     my $hash = $config->getHash();
+    # Compatibility: single topic on 6.2.24 or earlier.
+    $hash->{config}{topics} ||= $hash->{config}{topic};
+    # "moderator" is documented as single editor.
+    $hash->{config}{editor} ||= [$hash->{config}{moderator}];
 
     my $spindle = Sympa::Spindle::ProcessRequest->new(
         context    => $robot,
@@ -683,6 +687,10 @@ if ($main::options{'dump'}) {
         exit 1;
     }
     my $hash = $config->getHash();
+    # Compatibility: single topic on 6.2.24 or earlier.
+    $hash->{config}{topics} ||= $hash->{config}{topic};
+    # "moderator" is documented as single editor.
+    $hash->{config}{editor} ||= [$hash->{config}{moderator}];
 
     my $spindle = Sympa::Spindle::ProcessRequest->new(
         context => $family,


### PR DESCRIPTION
  - [bug] Feature of create_list is *not* the same as what described in documentation:
      - description (info) parameter is not mandatory.
      - the "moderator" parameter in documentation has never been implemented: "editor" would be used.
      - moreover, "moderator" was treated either as [multiple values](http://www.sympa.org/manual/list-families#configtt2) or [single value](http://www.sympa.org/manual/list-creation#xml_file_format) in a few parts of documentation.
      - "topic" was implemented as documentation describes, not "topics", but some of code uses "topics".

    Fixed, with implementing "moderator" attribute in XML file as synonym of "editor", allowing both single and multipe values.

    **NOTE**: Inconsistencies in documentation were fixed on [the new documentation site](https://sympa-community.github.io/): [1](https://github.com/sympa-community/sympa-community.github.io/commit/8f8796a0a9ab849665ddea60dac1f8014e2aa6d8), [2](https://github.com/sympa-community/sympa-community.github.io/commit/5455f2509cac682fedb1340c3275f8993dda8529).
 
  - [bug] Files config.tt2 in default templates did not support gecos of editors.

  