### PR TITLE
"libexecdir" is misleadingly used instead of "execcgidir"

### DIFF
--- a/src/etc/script/Makefile.am
+++ b/src/etc/script/Makefile.am
@@ -67,7 +67,7 @@ sympa: sympa.in Makefile
 	$(AM_V_GEN)$(SED) \
 		-e 's|--USER--|$(USER)|' \
 		-e 's|--GROUP--|$(GROUP)|' \
-		-e 's|--libexecdir--|$(libexecdir)|' \
+		-e 's|--execcgidir--|$(execcgidir)|' \
 		-e 's|--piddir--|$(piddir)|' \
 		-e 's|--sbindir--|$(sbindir)|' \
 		< $(srcdir)/$@in > $@

--- a/src/etc/script/nginx-sympasoap.servicein
+++ b/src/etc/script/nginx-sympasoap.servicein
@@ -9,7 +9,7 @@ PIDFile=--piddir--/sympasoap.pid
 ExecStart=/usr/bin/spawn-fcgi -F $FCGI_CHILDREN \
     -P --piddir--/sympasoap.pid \
     -u $FCGI_USER -g $FCGI_GROUP $FCGI_OPTS -- \
-    --libexecdir--/sympa_soap_server.fcgi
+    --execcgidir--/sympa_soap_server.fcgi
 Environment="FCGI_CHILDREN=5"
 Environment="FCGI_USER=--USER--"
 Environment="FCGI_GROUP=--GROUP--"

--- a/src/etc/script/nginx-wwsympa.servicein
+++ b/src/etc/script/nginx-wwsympa.servicein
@@ -9,7 +9,7 @@ PIDFile=--piddir--/wwsympa.pid
 ExecStart=/usr/bin/spawn-fcgi -F $FCGI_CHILDREN \
     -P --piddir--/wwsympa.pid \
     -u $FCGI_USER -g $FCGI_GROUP $FCGI_OPTS -- \
-    --libexecdir--/wwsympa.fcgi
+    --execcgidir--/wwsympa.fcgi
 Environment="FCGI_CHILDREN=5"
 Environment="FCGI_USER=--USER--"
 Environment="FCGI_GROUP=--GROUP--"


### PR DESCRIPTION
`libexecdir` is misleadingly used instead of `execcgidir` in src/etc/script/Makefile.am