### PR TITLE
Pictures max size fix

### DIFF
--- a/default/web_tt2/picture_upload.tt2
+++ b/default/web_tt2/picture_upload.tt2
@@ -6,7 +6,7 @@
 	 
  	 <form method="post" action="[% path_cgi %]" enctype="multipart/form-data" >
 
-<p>[%|loc(conf.pictures_max_size / 1024)%]You can upload your picture below. It will be available in the list review page. The picture should use a standard format (GIF, JPP, JPEG or PNG) and the file size should not exceed %1 Kb.[%END%]</p><br />
+<p>[%|loc(conf.pictures_max_size / 1024)%]You can upload your picture below. It will be available in the list review page. The picture should use a standard format (GIF, JPG, JPEG or PNG) and the file size should not exceed %1 Kb.[%END%]</p><br />
 
 	 <fieldset>
            <label for="uploaded_file"><input id="uploaded_file" type="file" name="uploaded_file"/></label>

--- a/default/web_tt2/picture_upload.tt2
+++ b/default/web_tt2/picture_upload.tt2
@@ -6,7 +6,7 @@
 	 
  	 <form method="post" action="[% path_cgi %]" enctype="multipart/form-data" >
 
-<p>[%|loc%]You can upload your picture below. It will be available in the list review page. The picture should use a standard format (GIF, JPP, JPEG or PNG) and the file size should not exceed 100 Kb.[%END%]</p><br />
+<p>[%|loc(conf.pictures_max_size / 1024)%]You can upload your picture below. It will be available in the list review page. The picture should use a standard format (GIF, JPP, JPEG or PNG) and the file size should not exceed %1 Kb.[%END%]</p><br />
 
 	 <fieldset>
            <label for="uploaded_file"><input id="uploaded_file" type="file" name="uploaded_file"/></label>

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1157,6 +1157,7 @@ while ($query = CGI::Fast->new) {
         'reporting_spam_script_path',
         'automatic_list_families',
         'spam_protection',
+        'pictures_max_size',
         ) {
 
         $param->{'conf'}{$p} = Conf::get_robot_conf($robot, $p);


### PR DESCRIPTION
This fixes #180, but I'm not completely satisfied with the fix, as the pictures_max_size will be properly reported but the size will be expressed in bytes, while it would probably be better to report it in kilobytes.