### PR TITLE
Create $staticdir/pictures directory

### DIFF
--- a/www/Makefile.am
+++ b/www/Makefile.am
@@ -423,7 +423,7 @@ install-data-hook:
 	cd $(DESTDIR)$(staticdir); \
 	rm -f external/foundation/js/vendor/jquery.js
 	@echo "Creating writable directories"
-	-@for dir in $(staticdir)/css; do \
+	-@for dir in $(staticdir)/css $(staticdir)/pictures; do \
 		if [ ! -d $(DESTDIR)$$dir ] ; then \
 			echo "Creating $(DESTDIR)$$dir"; \
 			$(INSTALL) -d -m 755 $(DESTDIR)$$dir; \


### PR DESCRIPTION
This creates $staticdir/pictures as noticed in #172 in a smilar way the css directory creation was fixed with https://github.com/sympa-community/sympa/commit/85a6217e2657bfffdb884179d0feaed78c8b53e6