### PR TITLE
#195: Some tests fail with checked out source

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,7 +81,7 @@ MSGFMT=@MSGFMT@
 .po.mo:
 	$(MSGFMT) -o $@ $<
 
-check-local:
+check-local: $(check_DATA)
 	[ -z "$(TEST_FILES)" ] && TEST_FILES="$(check_SCRIPTS)"; \
 	PERL5LIB=src/lib; export PERL5LIB; \
 	$(PERL) -MTest::Harness -e 'runtests @ARGV' $$TEST_FILES


### PR DESCRIPTION
This may fix issue #195.

Sources checked out from repository lacks *.mo test data files so that some tests in t/Language.t fail. Only "make dist" generate these files.

Fixed by letting check-local rule depend on test files.
