### PR TITLE
Create all needed spool directories at install time

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -115,7 +115,8 @@ installdir:
 		chown $(USER) $(DESTDIR)$$dir; \
 		chgrp $(GROUP) $(DESTDIR)$$dir; \
 	done
-	-@for subdir in automatic bounce msg task tmp; do \
+	-@for subdir in automatic bounce bulk digest moderation msg outgoing \
+		subscribe task tmp viewmail; do\
 		if [ ! -d $(DESTDIR)$(spooldir)/$$subdir ] ; then \
 			echo "Creating $(DESTDIR)$(spooldir)/$$subdir"; \
 			$(INSTALL) -d -m 750 $(DESTDIR)$(spooldir)/$$subdir; \


### PR DESCRIPTION
Hi,

Some spool directories are not created at install time.
The following directories are created:
- automatic
- bounce
- msg
- task
- tmp
The following directories are missing:
- bulk
- digest
- moderation
- outgoing
- subscribe
- viewmail

This PR fixes the creation of the missing directories.

Regards,
Xavier