### PR TITLE
Deprecate datetime field type in database

### DIFF
--- a/src/lib/Sympa/Database.pm
+++ b/src/lib/Sympa/Database.pm
@@ -473,22 +473,16 @@ sub quote {
 ## This sub takes a single argument: the name of the field to be used in
 ## the query.
 ##
-sub get_canonical_write_date {
-    my $self  = shift;
-    my $field = shift;
-    return $self->get_formatted_date({'mode' => 'write', 'target' => $field});
-}
+# Moved to Sympa::Upgrade::_get_canonical_write_date().
+#sub get_canonical_write_date;
 
 ## Returns a character string corresponding to the expression to use in
 ## a write query (e.g. UPDATE or INSERT) for the value given as argument.
 ## This sub takes a single argument: the value of the date to be used in
 ## the query.
 ##
-sub get_canonical_read_date {
-    my $self  = shift;
-    my $value = shift;
-    return $self->get_formatted_date({'mode' => 'read', 'target' => $value});
-}
+# Moved to Sympa::Upgrade::_get_canonical_read_date().
+#sub get_canonical_read_date;
 
 # We require that user also matches (except SQLite).
 sub get_id {

--- a/src/lib/Sympa/DatabaseDescription.pm
+++ b/src/lib/Sympa/DatabaseDescription.pm
@@ -1282,6 +1282,8 @@ Text with length up to 2^32 - 4 o.
 =item datetime
 
 Timestamp.
+B<Deprecated> as of Sympa 6.2.25b.3.
+Use C<int(11)> (Unix time) instead.
 
 =item mediumblob
 

--- a/src/lib/Sympa/DatabaseDescription.pm
+++ b/src/lib/Sympa/DatabaseDescription.pm
@@ -106,11 +106,18 @@ my %full_db_struct = (
                 'not_null' => 1,
                 'order'    => 11,
             },
-            'update_subscriber' => {
-                'struct' => 'datetime',
+            # Obsoleted as of 6.2.25b.2. Use update_epoch_subscriber.
+            #'update_subscriber' => {
+            #    'struct' => 'datetime',
+            #    'doc' =>
+            #        'the latest date where subscription is confirmed by subscriber',
+            #    'order' => 12,
+            #},
+            'update_epoch_subscriber' => {
+                'struct' => 'int(11)',
                 'doc' =>
-                    'the latest date where subscription is confirmed by subscriber',
-                'order' => 12,
+                    'the last time when subscription is confirmed by subscriber',
+                'order' => 12.5,
             },
             'comment_subscriber' => {
                 'struct' => 'varchar(150)',
@@ -889,10 +896,16 @@ my %full_db_struct = (
                 'not_null' => 1,
                 'order'    => 6,
             },
-            'update_admin' => {
-                'struct' => 'datetime',
-                'doc'    => 'last update timestamp',
-                'order'  => 7,
+            # Obsoleted as of 6.2.25b.2. Use update_epoch_admin.
+            #'update_admin' => {
+            #    'struct' => 'datetime',
+            #    'doc'    => 'last update timestamp',
+            #    'order'  => 7,
+            #},
+            'update_epoch_admin' => {
+                'struct' => 'int(11)',
+                'doc'    => 'last update time',
+                'order'  => 7.5,
             },
             'reception_admin' => {
                 'struct' => 'varchar(20)',

--- a/src/lib/Sympa/DatabaseDescription.pm
+++ b/src/lib/Sympa/DatabaseDescription.pm
@@ -100,11 +100,17 @@ my %full_db_struct = (
                 'doc'    => 'FIXME',
                 'order'  => 10,
             },
-            'date_subscriber' => {
-                'struct'   => 'datetime',
+            #'date_subscriber' => {
+            #    'struct'   => 'datetime',
+            #    'doc'      => 'date of subscription',
+            #    'not_null' => 1,
+            #    'order'    => 11,
+            #},
+            'date_epoch_subscriber' => {
+                'struct'   => 'int(11)',
                 'doc'      => 'date of subscription',
                 'not_null' => 1,
-                'order'    => 11,
+                'order'    => 11.5,
             },
             # Obsoleted as of 6.2.25b.2. Use update_epoch_subscriber.
             #'update_subscriber' => {
@@ -890,11 +896,17 @@ my %full_db_struct = (
                     'privilege level for this owner, value //normal// or //privileged//. The related privilege are listed in edit_list.conf. ',
                 'order' => 5,
             },
-            'date_admin' => {
-                'struct'   => 'datetime',
+            #'date_admin' => {
+            #    'struct'   => 'datetime',
+            #    'doc'      => 'date this user become a list admin',
+            #    'not_null' => 1,
+            #    'order'    => 6,
+            #},
+            'date_epoch_admin' => {
+                'struct'   => 'int(11)',
                 'doc'      => 'date this user become a list admin',
                 'not_null' => 1,
-                'order'    => 6,
+                'order'    => 6.5,
             },
             # Obsoleted as of 6.2.25b.2. Use update_epoch_admin.
             #'update_admin' => {

--- a/src/lib/Sympa/DatabaseDriver.pm
+++ b/src/lib/Sympa/DatabaseDriver.pm
@@ -144,6 +144,8 @@ This method was deprecated.
 
 =item get_formatted_date ( { mode => $mode, target => $target } )
 
+B<Deprecated> as of Sympa 6.2.25b.3.
+
 I<Mandatory for SQL driver>.
 Returns a character string corresponding to the expression to use in a query
 involving a date.

--- a/src/lib/Sympa/DatabaseDriver/MySQL.pm
+++ b/src/lib/Sympa/DatabaseDriver/MySQL.pm
@@ -84,19 +84,8 @@ sub get_substring_clause {
 # DEPRECATED.
 #sub get_limit_clause ( { rows_count => $rows, offset => $offset } );
 
-sub get_formatted_date {
-    my $self  = shift;
-    my $param = shift;
-    $log->syslog('debug', 'Building SQL date formatting');
-    if (lc($param->{'mode'}) eq 'read') {
-        return sprintf 'UNIX_TIMESTAMP(%s)', $param->{'target'};
-    } elsif (lc($param->{'mode'}) eq 'write') {
-        return sprintf 'FROM_UNIXTIME(%d)', $param->{'target'};
-    } else {
-        $log->syslog('err', "Unknown date format mode %s", $param->{'mode'});
-        return undef;
-    }
-}
+# DEPRECATED.
+#sub get_formatted_date;
 
 sub is_autoinc {
     my $self  = shift;

--- a/src/lib/Sympa/DatabaseDriver/ODBC.pm
+++ b/src/lib/Sympa/DatabaseDriver/ODBC.pm
@@ -38,12 +38,8 @@ sub build_connect_string {
     return 'DBI:ODBC:' . $self->{'db_name'};
 }
 
-sub get_formatted_date {
-    my $self  = shift;
-    my $param = shift;
-
-    die 'Not yet implemented: This is required by Sympa';
-}
+# DEPRECATED.  Never implemented.
+#sub get_formatted_date;
 
 sub translate_type {
     my $self = shift;

--- a/src/lib/Sympa/DatabaseDriver/Oracle.pm
+++ b/src/lib/Sympa/DatabaseDriver/Oracle.pm
@@ -88,25 +88,8 @@ sub get_substring_clause {
 #DEPRECATED.
 #sub get_limit_clause ( { rows_count => $rows, offset => $offset } );
 
-sub get_formatted_date {
-    my $self  = shift;
-    my $param = shift;
-    $log->syslog('debug', 'Building SQL date formatting');
-    if (lc($param->{'mode'}) eq 'read') {
-        return
-            sprintf
-            q{((to_number(to_char(%s,'J')) - to_number(to_char(to_date('01/01/1970','dd/mm/yyyy'), 'J'))) * 86400) +to_number(to_char(%s,'SSSSS'))},
-            $param->{'target'}, $param->{'target'};
-    } elsif (lc($param->{'mode'}) eq 'write') {
-        return
-            sprintf
-            q{to_date(to_char(floor(%s/86400) + to_number(to_char(to_date('01/01/1970','dd/mm/yyyy'), 'J'))) || ':' ||to_char(mod(%s,86400)), 'J:SSSSS')},
-            $param->{'target'}, $param->{'target'};
-    } else {
-        $log->syslog('err', "Unknown date format mode %s", $param->{'mode'});
-        return undef;
-    }
-}
+#DEPRECATED.
+#sub get_formatted_date;
 
 sub is_autoinc {
     my $self  = shift;

--- a/src/lib/Sympa/DatabaseDriver/PostgreSQL.pm
+++ b/src/lib/Sympa/DatabaseDriver/PostgreSQL.pm
@@ -115,20 +115,8 @@ sub get_substring_clause {
 # DEPRECATED.
 #sub get_limit_clause ( { rows_count => $rows, offset => $offset } );
 
-sub get_formatted_date {
-    my $self  = shift;
-    my $param = shift;
-    $log->syslog('debug', 'Building SQL date formatting');
-    if (lc($param->{'mode'}) eq 'read') {
-        return sprintf 'date_part(\'epoch\',%s)', $param->{'target'};
-    } elsif (lc($param->{'mode'}) eq 'write') {
-        return sprintf '\'epoch\'::timestamp with time zone + \'%d sec\'',
-            $param->{'target'};
-    } else {
-        $log->syslog('err', "Unknown date format mode %s", $param->{'mode'});
-        return undef;
-    }
-}
+# DEPRECATED.
+#sub get_formatted_date;
 
 sub is_autoinc {
     my $self  = shift;

--- a/src/lib/Sympa/DatabaseDriver/SQLite.pm
+++ b/src/lib/Sympa/DatabaseDriver/SQLite.pm
@@ -79,17 +79,8 @@ sub get_substring_clause {
 # DEPRECATED.
 #sub get_limit_clause ( { rows_count => $rows, offset => $offset } );
 
-sub get_formatted_date {
-    my $self  = shift;
-    my $param = shift;
-    $log->syslog('debug', 'Building SQL date formatting');
-    if (lc($param->{'mode'}) eq 'read' or lc($param->{'mode'}) eq 'write') {
-        return $param->{'target'};
-    } else {
-        $log->syslog('err', "Unknown date format mode %s", $param->{'mode'});
-        return undef;
-    }
-}
+# DEPRECATED.
+#sub get_formatted_date;
 
 sub is_autoinc {
     my $self  = shift;

--- a/src/lib/Sympa/DatabaseDriver/Sybase.pm
+++ b/src/lib/Sympa/DatabaseDriver/Sybase.pm
@@ -81,21 +81,8 @@ sub get_substring_clause {
 # DEPRECATED.
 #sub get_limit_clause ( { rows_count => $rows, offset => $offset } );
 
-sub get_formatted_date {
-    my $self  = shift;
-    my $param = shift;
-    $log->syslog('debug', 'Building SQL date formatting');
-    if (lc($param->{'mode'}) eq 'read') {
-        return sprintf 'datediff(second, \'01/01/1970\',%s)',
-            $param->{'target'};
-    } elsif (lc($param->{'mode'}) eq 'write') {
-        return sprintf 'dateadd(second,%s,\'01/01/1970\')',
-            $param->{'target'};
-    } else {
-        $log->syslog('err', "Unknown date format mode %s", $param->{'mode'});
-        return undef;
-    }
-}
+# DEPRECATED.
+#sub get_formatted_date;
 
 sub is_autoinc {
     my $self  = shift;

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -2477,6 +2477,7 @@ sub get_exclusion {
 # Mapping between var and field names.
 sub _map_list_member_cols {
     my %map_field = (
+        date        => 'date_epoch_subscriber',
         update_date => 'update_epoch_subscriber',
         gecos       => 'comment_subscriber',
         email       => 'user_subscriber',
@@ -2516,12 +2517,7 @@ sub _list_member_cols {
 
     my %map_field = _map_list_member_cols();
     return join ', ', map {
-        my $col;
-        if ($_ eq 'date') {
-            $col = $sdm->get_canonical_read_date($map_field{$_});
-        } else {
-            $col = $map_field{$_};
-        }
+        my $col = $map_field{$_};
         ($col eq $_) ? $col : sprintf('%s AS "%s"', $col, $_);
     } sort keys %map_field;
 }
@@ -2898,21 +2894,19 @@ sub _get_admins {
 
     unless (
         $sdm and $sth = $sdm->do_prepared_query(
-            sprintf(
-                q{SELECT user_admin AS email, comment_admin AS gecos,
-                         role_admin AS "role",
-                         reception_admin AS reception,
-                         visibility_admin AS visibility,
-                         %s AS "date", update_epoch_admin AS update_date,
-                         info_admin AS info, profile_admin AS profile,
-                         subscribed_admin AS subscribed,
-                         included_admin AS included,
-                         include_sources_admin AS id
-                  FROM admin_table
-                  WHERE list_admin = ? AND robot_admin = ?
-                  ORDER BY user_admin},
-                $sdm->get_canonical_read_date('date_admin')
-            ),
+            q{SELECT user_admin AS email, comment_admin AS gecos,
+                     role_admin AS "role",
+                     reception_admin AS reception,
+                     visibility_admin AS visibility,
+                     date_epoch_admin AS "date",
+                     update_epoch_admin AS update_date,
+                     info_admin AS info, profile_admin AS profile,
+                     subscribed_admin AS subscribed,
+                     included_admin AS included,
+                     include_sources_admin AS id
+              FROM admin_table
+              WHERE list_admin = ? AND robot_admin = ?
+              ORDER BY user_admin},
             $self->{'name'},
             $self->{'domain'}
         )
@@ -3431,11 +3425,7 @@ sub update_list_member {
         die sprintf 'Unknown database field %s', $field
             unless $map_field{$field};
 
-        if ($field eq 'date') {
-            push @set_list,
-                sprintf('%s = %s',
-                $map_field{$field}, $sdm->get_canonical_write_date($value));
-        } elsif ($field eq 'custom_attribute') {
+        if ($field eq 'custom_attribute') {
             push @set_list, sprintf('%s = ?', $map_field{$field});
             push @val_list,
                 Sympa::Tools::Data::encode_custom_attribute($value);
@@ -3566,7 +3556,7 @@ sub update_list_admin {
     my %map_field = (
         reception   => 'reception_admin',
         visibility  => 'visibility_admin',
-        date        => 'date_admin',
+        date        => 'date_epoch_admin',
         update_date => 'update_epoch_admin',
         gecos       => 'comment_admin',
         password    => 'password_user',
@@ -3619,18 +3609,14 @@ sub update_list_admin {
             }
 
             if ($map_table{$field} eq $table) {
-                if ($field eq 'date') {
-                    $value = $sdm->get_canonical_write_date($value);
-                } elsif ($value and $value eq 'NULL') {    # get_null_value?
+                if ($value and $value eq 'NULL') {    #FIXME:get_null_value?
                     if ($Conf::Conf{'db_type'} eq 'mysql') {
                         $value = '\N';
                     }
+                } elsif ($numeric_field{$map_field{$field}}) {
+                    $value ||= 0;    #FIXME:Can't have a null value
                 } else {
-                    if ($numeric_field{$map_field{$field}}) {
-                        $value ||= 0;    ## Can't have a null value
-                    } else {
-                        $value = $sdm->quote($value);
-                    }
+                    $value = $sdm->quote($value);
                 }
                 my $set = sprintf "%s=%s", $map_field{$field}, $value;
 
@@ -3835,27 +3821,24 @@ sub add_list_member {
         unless (
             $sdm
             and $sdm->do_prepared_query(
-                sprintf(
-                    q{INSERT INTO subscriber_table
-                      (user_subscriber, comment_subscriber,
-                       list_subscriber, robot_subscriber,
-                       date_subscriber, update_epoch_subscriber,
-                       reception_subscriber, topics_subscriber,
-                       visibility_subscriber, subscribed_subscriber,
-                       included_subscriber, include_sources_subscriber,
-                       custom_attribute_subscriber,
-                       suspend_subscriber,
-                       suspend_start_date_subscriber,
-                       suspend_end_date_subscriber,
-                       number_messages_subscriber)
-                      VALUES (?, ?, ?, ?, %s, ?, ?, ?, ?, ?, ?, ?, ?,
-                              ?, ?, ?, 0)},
-                    $sdm->get_canonical_write_date($new_user->{'date'})
-                ),
+                q{INSERT INTO subscriber_table
+                  (user_subscriber, comment_subscriber,
+                   list_subscriber, robot_subscriber,
+                   date_epoch_subscriber, update_epoch_subscriber,
+                   reception_subscriber, topics_subscriber,
+                   visibility_subscriber, subscribed_subscriber,
+                   included_subscriber, include_sources_subscriber,
+                   custom_attribute_subscriber,
+                   suspend_subscriber,
+                   suspend_start_date_subscriber,
+                   suspend_end_date_subscriber,
+                   number_messages_subscriber)
+                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)},
                 $who,
                 $new_user->{'gecos'},
                 $name,
                 $self->{'domain'},
+                $new_user->{'date'},
                 $new_user->{'update_date'},
                 $new_user->{'reception'},
                 $new_user->{'topics'},
@@ -3975,21 +3958,19 @@ sub add_list_admin {
         unless (
             $sdm
             and $sdm->do_prepared_query(
-                sprintf(
-                    q{INSERT INTO admin_table
-                      (user_admin, comment_admin, list_admin, robot_admin,
-                       date_admin, update_epoch_admin, reception_admin,
-                       visibility_admin,
-                       subscribed_admin,
-                       included_admin, include_sources_admin,
-                       role_admin, info_admin, profile_admin)
-                      VALUES (?, ?, ?, ?, %s, ?, ?, ?, ?, ?, ?, ?, ?, ?)},
-                    $sdm->get_canonical_write_date($new_admin_user->{'date'})
-                ),
+                q{INSERT INTO admin_table
+                  (user_admin, comment_admin, list_admin, robot_admin,
+                   date_epoch_admin, update_epoch_admin, reception_admin,
+                   visibility_admin,
+                   subscribed_admin,
+                   included_admin, include_sources_admin,
+                   role_admin, info_admin, profile_admin)
+                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)},
                 $who,
                 $new_admin_user->{'gecos'},
                 $name,
                 $self->{'domain'},
+                $new_admin_user->{'date'},
                 $new_admin_user->{'update_date'},
                 $new_admin_user->{'reception'},
                 $new_admin_user->{'visibility'},

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -1727,6 +1727,33 @@ sub upgrade {
         );
     }
 
+    if (lower_version($previous_version, '6.2.25b.2')) {
+        my $sdm = Sympa::DatabaseManager->instance;
+
+        $log->syslog('notice', 'Upgrading subscriber_table.');
+        # update_subscriber (datetime) was obsoleted.
+        # Use update_epoch_subscriber (int).
+        $sdm->do_prepared_query(
+            sprintf(
+                q{UPDATE subscriber_table
+                  SET update_epoch_subscriber = %s
+                  WHERE update_subscriber IS NOT NULL},
+                $sdm->get_canonical_read_date('update_subscriber')
+            )
+        );
+        $log->syslog('notice', 'Upgrading admin_table.');
+        # update_admin (datetime) was obsoleted.
+        # Use update_epoch_admin (int).
+        $sdm->do_prepared_query(
+            sprintf(
+                q{UPDATE admin_table
+                  SET update_epoch_admin = %s
+                  WHERE update_admin IS NOT NULL},
+                $sdm->get_canonical_read_date('update_admin')
+            )
+        );
+    }
+
     # GH Issue #43: Preliminary notice on abolishment of "host" list parameter.
     if (lower_version($previous_version, '6.2.28')) {
         my $all_lists = Sympa::List::get_lists('*');


### PR DESCRIPTION
This PR deprecates datetime field type in database.  Because:
  - There are no portable way to compare, increase or decrease such field values.
  - It's slow: Values should be converted to Unix timestamp; Index cannot be applied.

Database will be upgraded automatically during upgrading process.
