### PR TITLE
Feature: support for Bcrypt password hashes

### DIFF
--- a/src/bin/upgrade_sympa_password.pl.in
+++ b/src/bin/upgrade_sympa_password.pl.in
@@ -92,7 +92,7 @@ while (my $user = $sth->fetchrow_hashref('NAME_lc')) {
             q{UPDATE user_table
               SET password_user = ?
               WHERE email_user = ?},
-            Sympa::User::password_fingerprint($clear_password, ''),
+            Sympa::User::password_fingerprint($clear_password, undef),
             $user->{'email_user'}
         )
         ) {

--- a/src/bin/upgrade_sympa_password.pl.in
+++ b/src/bin/upgrade_sympa_password.pl.in
@@ -42,7 +42,9 @@ die 'Error in configuration'
 my $sdm = Sympa::DatabaseManager->instance
     or die 'Can\'t connect to database';
 
-print "Recoding password using MD5 fingerprint.\n";
+my $password_hash = Conf::get_robot_conf('*', 'password_hash');
+
+print "Recoding password using $password_hash fingerprint.\n";
 
 my $sth = $sdm->do_query(q{SELECT email_user, password_user from user_table});
 unless ($sth) {
@@ -51,6 +53,7 @@ unless ($sth) {
 
 my $total     = 0;
 my $total_md5 = 0;
+my $total_bcrypt = 0;
 
 while (my $user = $sth->fetchrow_hashref('NAME_lc')) {
     my $clear_password;
@@ -64,6 +67,13 @@ while (my $user = $sth->fetchrow_hashref('NAME_lc')) {
         printf "Password from %s already encoded as md5 fingerprint\n",
             $user->{'email_user'};
         $total_md5++;
+        next;
+    }
+
+    if ($user->{'password_user'} =~ /^\$2a\$/) {
+        printf "Password from %s already encoded as bcrypt fingerprint\n",
+            $user->{'email_user'};
+        $total_bcrypt++;
         next;
     }
 
@@ -82,7 +92,7 @@ while (my $user = $sth->fetchrow_hashref('NAME_lc')) {
             q{UPDATE user_table
               SET password_user = ?
               WHERE email_user = ?},
-            Sympa::User::password_fingerprint($clear_password),
+            Sympa::User::password_fingerprint($clear_password, ''),
             $user->{'email_user'}
         )
         ) {
@@ -92,15 +102,15 @@ while (my $user = $sth->fetchrow_hashref('NAME_lc')) {
 $sth->finish();
 
 printf
-    "Updating password storage in table user_table using md5 for %d users.\n",
+    "Updating password storage in table user_table using $password_hash hashes for %d users.\n",
     $total;
-if ($total_md5) {
+if ($total_md5 || $total_bcrypt) {
     printf
-        "Found in table user %d password stored using md5, did you run Sympa before upgrading ?\n",
-        $total_md5;
+        "Found in table user %d password stored using md5, %d using bcrypt. Did you run Sympa before upgrading ?\n",
+        $total_md5, $total_bcrypt;
 }
 
-printf "Total password re-encoded using md5: %d\n", $total;
+printf "Total passwords re-encoded using $password_hash: %d\n", $total;
 
 exit 0;
 
@@ -115,11 +125,13 @@ Upgrading password in database
 
 =head1 DESCRIPTION
 
-Version later than 5.4 uses MD5 hash instead of
+Versions later than 5.4 uses MD5 hash instead of
 symmetric encryption to store password.
 
-This require to rewrite password in database. This upgrade IS NOT
-REVERSIBLE.
+Versions later than 6.2.26 support bcrypt.
+
+This upgrade requires to rewriting user password entries in the database.
+This upgrade IS NOT REVERSIBLE.
 
 =head1 HISTORY
 
@@ -127,5 +139,7 @@ As of Sympa 3.1b.7, passwords may be stored into user table with encrypted
 form by reversible RC4.
 
 Sympa 5.4 or later uses MD5 one-way hash function to encode user passwords.
+
+Sympa 6.2.26 or later has optional support for bcrypt.
 
 =cut

--- a/src/lib/Sympa/Auth.pm
+++ b/src/lib/Sympa/Auth.pm
@@ -147,7 +147,9 @@ sub authentication {
         ## the user passwords
         ## Other backends are Single Sign-On solutions
         if ($auth_service->{'auth_type'} eq 'user_table') {
-            my $fingerprint = Sympa::User::password_fingerprint($pwd);
+            # supply old password hash in case the hash uses a salt
+            my $fingerprint =
+                Sympa::User::password_fingerprint($pwd, $user->{'password'});
 
             if ($fingerprint eq $user->{'password'}) {
                 Sympa::User::update_global_user($email,

--- a/src/lib/Sympa/Auth.pm
+++ b/src/lib/Sympa/Auth.pm
@@ -147,11 +147,11 @@ sub authentication {
         ## the user passwords
         ## Other backends are Single Sign-On solutions
         if ($auth_service->{'auth_type'} eq 'user_table') {
-            # supply old password hash in case the hash uses a salt
             my $fingerprint =
                 Sympa::User::password_fingerprint($pwd, $user->{'password'});
 
             if ($fingerprint eq $user->{'password'}) {
+                Sympa::User::update_password_hash($user, $pwd);
                 Sympa::User::update_global_user($email,
                     {wrong_login_count => 0});
                 return {

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -1647,6 +1647,14 @@ our @params = (
         'gettext_comment' =>
             "\"md5\" or \"bcrypt\".\nIf set to \"md5\", Sympa will use MD5 password hashes. If set to \"bcrypt\", bcrypt hashes will be used instead. This only concerns passwords stored in the Sympa database, not the ones in LDAP.\nShould not be changed! May invalid all user passwords.",
     },
+    {   'name'       => 'password_hash_update',
+        'default'    => '1',
+        'gettext_id' => 'Update password hashing algorithm when users log in',
+        'file'       => 'wwsympa.conf',
+        #vhost      => '1', # per-robot config is impossible.
+        'gettext_comment' =>
+            "On successful login, update the encrypted user password to use the algorithm specified by \"password_hash\". This allows for a graceful transition to a new password hash algorithm. A value of 0 disables updating of existing password hashes.  New and reset passwords will use the \"password_hash\" setting in all cases.",
+    },
     {   'name'       => 'bcrypt_cost',
         'default'    => '12',
         'gettext_id' => 'Bcrypt hash cost',

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -1639,6 +1639,22 @@ our @params = (
         'gettext_comment' =>
             "\"insensitive\" or \"sensitive\".\nIf set to \"insensitive\", WWSympa's password check will be insensitive. This only concerns passwords stored in the Sympa database, not the ones in LDAP.\nShould not be changed! May invalid all user password.",
     },
+    {   'name'       => 'password_hash',
+        'default'    => 'md5',
+        'gettext_id' => 'Password hashing algorithm',
+        'file'       => 'wwsympa.conf',
+        #vhost      => '1', # per-robot config is impossible.
+        'gettext_comment' =>
+            "\"md5\" or \"bcrypt\".\nIf set to \"md5\", Sympa will use MD5 password hashes. If set to \"bcrypt\", bcrypt hashes will be used instead. This only concerns passwords stored in the Sympa database, not the ones in LDAP.\nShould not be changed! May invalid all user passwords.",
+    },
+    {   'name'       => 'bcrypt_cost',
+        'default'    => '12',
+        'gettext_id' => 'Bcrypt hash cost',
+        'file'       => 'wwsympa.conf',
+        #vhost      => '1', # per-robot config is impossible.
+        'gettext_comment' =>
+            "When \"password_hash\" is set to \"bcrypt\", this sets the \"cost\" parameter of the bcrypt hash function. The default of 12 is expected to require approximately 250ms to calculate the password hash on a 3.2GHz CPU. This only concerns passwords stored in the Sympa database, not the ones in LDAP.\nCan be changed but any new cost setting will only apply to new passwords.",
+    },
 
     # One time ticket
 

--- a/src/lib/Sympa/DatabaseDescription.pm
+++ b/src/lib/Sympa/DatabaseDescription.pm
@@ -177,7 +177,7 @@ my %full_db_struct = (
                 'order'  => 3,
             },
             'password_user' => {
-                'struct' => 'varchar(40)',
+                'struct' => 'varchar(64)',
                 'doc'    => 'password are stored as finger print',
                 'order'  => 2,
             },

--- a/src/lib/Sympa/ModDef.pm
+++ b/src/lib/Sympa/ModDef.pm
@@ -77,6 +77,12 @@ our %cpan_modules = (
         'gettext_id' =>
             'this module provides reversible encryption of user passwords in the database.  Useful when updating from old version with password reversible encryption, or if secure session cookies in non-SSL environments are required.',
     },
+    'Crypt::Eksblowfish' => {
+        required_version => '0.009',
+        package_name     => 'Crypt-Eksblowfish',
+        'gettext_id' =>
+            'used to encrypt passwords with the Bcrypt hash algorithm',
+    },
     'Crypt::OpenSSL::X509' => {
         required_version => '1.800.1',
         package_name     => 'Crypt-OpenSSL-X509',

--- a/src/lib/Sympa/User.pm
+++ b/src/lib/Sympa/User.pm
@@ -564,7 +564,7 @@ sub update_global_user {
     ## use hash fingerprint to store password
     ## hashes that use salts will randomly generate one
     $values->{'password'} =
-        Sympa::User::password_fingerprint($values->{'password'},'')
+        Sympa::User::password_fingerprint($values->{'password'}, undef)
         if ($values->{'password'});
 
     ## Canonicalize lang if possible.
@@ -642,9 +642,9 @@ sub add_global_user {
     my ($field, $value);
 
     ## encrypt password with the configured password hash algorithm
-    ## an empty salt means generate a new random one
+    ## an salt of 'undef' means generate a new random one
     $values->{'password'} =
-        Sympa::User::password_fingerprint($values->{'password'},'')
+        Sympa::User::password_fingerprint($values->{'password'}, undef)
         if ($values->{'password'});
 
     ## Canonicalize lang if possible


### PR DESCRIPTION
Some Sympa sites may find it desirable to use other password hash functions than MD5. At our site we have been looking at Bcrypt, which has useful properties like supporting a random salt and scaling in expense as computing power becomes cheaper over time. Both features make it much more costly to crack a site's user passwords if they are revealed in some way. 

Since Sympa has already modularized password hashing in `Sympa::User::password_fingerprint`, we found that the changes required for basic Bcrypt support are relatively small in number:

- add new sympa.conf options to select and control Bcrypt hashes:
  - `password_hash`: `md5` or `bcrypt` (default `md5`)
  - `bcrypt_cost`: integer value used to determine the "cost" parameter of the Bcrypt algorithm (default `12`)
- update `Sympa::User::password_fingerprint`: in `Auth.pm`:
  - select hash functions from an array of callbacks based on `password_hash` setting
  - add 'salt' parameter (ignored for `md5`, used as Bcrypt settings for `bcrypt`)
- update all calls to `Sympa::User::password_fingerprint` to supply the user's current password hash
- update `upgrade_sympa_password.pl` to recognize both MD5 and Bcrypt hashes
- increase the width of the `password_user` column from 40 to 64 columns in order to store Bcrypt hashes without truncation

Some additional notes:
- This implementation uses perl-Crypt-Eksblowfish, which is available in  EPEL for CentOS/RHEL 7, which matches our site's chosen Linux distribution. 
- The implementation only addresses authentication for Sympa users found in the `user_table`. Other Sympa features that use MD5 continue to use that hash exclusively.

We understand that it is not a trivial thing to suggest changes to the Sympa authentication infrastructure, and we definitely have some uncertainty about some of the choices here:

- are there better option names than `password_hash` etc?
- does making the `password_user` field wider present an issue?
- is perl-Crypt-Eksblowfish available on enough platforms to be a good choice?
- the extra argument to `password_fingerprint` seems awkward

If it would be more appropriate to pose this as an issue rather than a pull request, please let me know. Either way, we would like to improve this code to the point where it is acceptable inclusion in Sympa, so suggestions for improvement would be very welcome.
