### PR TITLE
Fix bug by change of issue #172

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1169,6 +1169,9 @@ while ($query = CGI::Fast->new) {
     # Compat.: deprecated attributes of Robot.
     $param->{'conf'}{'sympa'} = Sympa::get_address($robot);
     $param->{'conf'}{'request'} = Sympa::get_address($robot, 'owner');
+    # Compat <= 6.2.16: CSS related.
+    $param->{'css_path'} = sprintf '%s/%s', $Conf::Conf{'css_path'}, $robot;
+    $param->{'css_url'}  = sprintf '%s/%s', $Conf::Conf{'css_url'}, $robot;
 
     foreach my $auth (keys %{$Conf::Conf{'cas_id'}{$robot}}) {
         $log->syslog('debug2', 'CAS authentication service %s', $auth);
@@ -1241,31 +1244,6 @@ while ($query = CGI::Fast->new) {
 
     # Propagate plugins parameters
     $param->{'plugin'} = $in{'plugin'};
-
-    # # Static content
-    # $param->{'static_content_url'} =
-    #     Conf::get_robot_conf($robot, 'static_content_url');
-
-    ## CSS related
-    $param->{'css_path'} = Conf::get_robot_conf($robot, 'css_path');
-    $param->{'css_url'}  = Conf::get_robot_conf($robot, 'css_url');
-
-    ## If CSS file not found, let Sympa do the job...
-    #unless ($param->{'css_path'} and -f $param->{'css_path'} . '/style.css') {
-    #    wwslog(
-    #        'err',
-    #        'Could not find CSS file %s, using default CSS',
-    #        $param->{'css_path'} . '/style.css'
-    #    ) if $param->{'css_path'};    # Notice only if path was defined.
-    #    $param->{'css_url'} =
-    #        Sympa::get_url($robot, 'css', authority => 'omit');
-    #}
-
-    wwslog(
-        'info',
-        'Parameter css_url "%s" seems strange, it must be the url of a directory not a css file',
-        $param->{'css_url'}
-    ) if $param->{'css_url'} =~ /\.css$/;
 
     $session = Sympa::Session->new(
         $robot,

--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -2032,18 +2032,6 @@ sub _infer_robot_parameter_values {
     $param->{'config_hash'}{'static_content_path'} ||=
         $Conf{'static_content_path'};
 
-    ## CSS
-    my $final_separator = '';
-    $final_separator = '/' if ($param->{'config_hash'}{'robot_name'});
-    $param->{'config_hash'}{'css_url'} ||=
-          $param->{'config_hash'}{'css_url'}
-        . $final_separator
-        . $param->{'config_hash'}{'robot_name'};
-    $param->{'config_hash'}{'css_path'} ||=
-          $param->{'config_hash'}{'css_path'}
-        . $final_separator
-        . $param->{'config_hash'}{'robot_name'};
-
     unless ($param->{'config_hash'}{'email'}) {
         $param->{'config_hash'}{'email'} = $Conf{'email'};
     }

--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -852,45 +852,26 @@ sub checkfiles {
         }
     }
 
-    # Create pictures dir if useful for each robot.
-    foreach my $robot (keys %{$Conf{'robots'}}) {
-        my $dir = get_robot_conf($robot, 'pictures_path');
-        if ($dir ne '' && -d $dir) {
-            unless (-f $dir . '/index.html') {
-                unless (open(FF, ">$dir" . '/index.html')) {
-                    $log->syslog(
-                        'err',
-                        'Unable to create %s/index.html as an empty file to protect directory: %m',
-                        $dir
-                    );
-                }
-                close FF;
-            }
+    # Create pictures directory. FIXME: Would be created on demand.
+    my $pictures_dir = $Conf::Conf{'pictures_path'};
+    unless (-d $pictures_dir) {
+        unless (mkdir $pictures_dir, 0775) {
+            $log->syslog('err', 'Unable to create directory %s',
+                $pictures_dir);
+            $config_err++;
+        } else {
+            chmod 0775, $pictures_dir;  # set masked bits.
 
-            # create picture dir
-            if (get_robot_conf($robot, 'pictures_feature') eq 'on') {
-                my $pictures_dir =
-                    get_robot_conf($robot, 'pictures_path');
-                unless (-d $pictures_dir) {
-                    unless (mkdir($pictures_dir, 0775)) {
-                        $log->syslog('err', 'Unable to create directory %s',
-                            $pictures_dir);
-                        $config_err++;
-                    }
-                    chmod 0775, $pictures_dir;
-
-                    my $index_path = $pictures_dir . '/index.html';
-                    unless (-f $index_path) {
-                        unless (open(FF, ">$index_path")) {
-                            $log->syslog(
-                                'err',
-                                'Unable to create %s as an empty file to protect directory',
-                                $index_path
-                            );
-                        }
-                        close FF;
-                    }
-                }
+            my $index_path = $pictures_dir . '/index.html';
+            my $fh;
+            unless (open $fh, '>', $index_path) {
+                $log->syslog(
+                    'err',
+                    'Unable to create %s as an empty file to protect directory',
+                    $index_path
+                );
+            } else {
+                close $fh;
             }
         }
     }

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -1320,14 +1320,12 @@ our @params = (
     {   'name'       => 'pictures_path',
         'default_s'  => '$PICTURESDIR',
         'gettext_id' => 'Directory for subscribers pictures',
-        'vhost'      => '1',
     },
     {   'name'       => 'pictures_url',
         'default'    => '/static-sympa/pictures',
         'gettext_id' => 'URL for subscribers pictures',
         'gettext_comment' =>
             'HTTP server have to map it with "pictures_path" directory.',
-        'vhost' => '1',
     },
     {   'name'       => 'color_0',
         'gettext_id' => 'Colors for web interface',
@@ -1666,6 +1664,7 @@ our @params = (
         'gettext_comment' =>
             "Enables or disables the pictures feature by default.  If enabled, subscribers can upload their picture (from the \"Subscriber option\" page) to use as an avatar.\nPictures are stored in a directory specified by the \"static_content_path\" parameter.",
         'default' => 'on',
+        'vhost'   => '1',
     },
     {   'name'         => 'pictures_max_size',
         'gettext_id'   => 'The maximum size of uploaded picture',

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -1310,16 +1310,12 @@ our @params = (
         'gettext_id' => 'Directory for static style sheets (CSS)',
         'gettext_comment' =>
             'After an upgrade, static CSS files are upgraded with the newly installed "css.tt2" template. Therefore, this is not a good place to store customized CSS files.',
-        'optional' => '1',
-        'vhost'    => '1',
     },
     {   'name'       => 'css_url',
         'default'    => '/static-sympa/css',
         'gettext_id' => 'URL for style sheets (CSS)',
         'gettext_comment' =>
             'To use auto-generated static CSS, HTTP server have to map it with "css_path".',
-        'optional' => '1',
-        'vhost'    => '1',
     },
     {   'name'       => 'pictures_path',
         'default_s'  => '$PICTURESDIR',

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -1773,21 +1773,14 @@ sub send_notify_to_owner {
     return 1;
 }
 
-# Note: This would be moved to Robot package.
+# FIXME:This might be moved to Sympa::WWW namespace.
 sub get_picture_path {
     my $self = shift;
-    return join '/',
-        Conf::get_robot_conf($self->{'domain'}, 'pictures_path'),
-        $self->get_id, @_;
+    return join '/', $Conf::Conf{'pictures_path'}, $self->get_id, @_;
 }
 
-# Note: This would be moved to Robot package.
-sub get_picture_url {
-    my $self = shift;
-    return join '/',
-        Conf::get_robot_conf($self->{'domain'}, 'pictures_url'),
-        $self->get_id, @_;
-}
+# No longer used.  Use Sympa::List::find_picture_url().
+#sub get_picture_url;
 
 =over 4
 
@@ -1800,6 +1793,7 @@ Returns the type of a pictures according to the user.
 =cut
 
 # Old name: tools::pictures_filename()
+# FIXME:This might be moved to Sympa::WWW namespace.
 sub find_picture_filenames {
     my $self  = shift;
     my $email = shift;
@@ -1816,6 +1810,7 @@ sub find_picture_filenames {
     return @ret;
 }
 
+# FIXME:This might be moved to Sympa::WWW namespace.
 sub find_picture_paths {
     my $self  = shift;
     my $email = shift;
@@ -1836,13 +1831,16 @@ Find pictures URL
 =cut
 
 # Old name: tools::make_pictures_url().
+# FIXME:This might be moved to Sympa::WWW namespace.
 sub find_picture_url {
     my $self  = shift;
     my $email = shift;
 
     my ($filename) = $self->find_picture_filenames($email);
     return undef unless $filename;
-    return $self->get_picture_url($filename);
+
+    return Sympa::Tools::Text::weburl(
+        $Conf::Conf{'pictures_url'}, [$self->get_id, $filename]);
 }
 
 =over
@@ -1855,6 +1853,7 @@ Deletes a member's picture file.
 
 =cut
 
+# FIXME:This might be moved to Sympa::WWW namespace.
 sub delete_list_member_picture {
     $log->syslog('debug2', '(%s, %s)', @_);
     my $self  = shift;

--- a/src/lib/Sympa/Tools/WWW.pm
+++ b/src/lib/Sympa/Tools/WWW.pm
@@ -724,10 +724,8 @@ sub _get_css_url {
         $template_path =
             Sympa::search_fullpath($robot, 'css.tt2', subdir => 'web_tt2');
         unless ($template_path) {    # Impossible case.
-            my $url =
-                Sympa::Tools::Text::weburl(
-                Conf::get_robot_conf($robot, 'css_url'),
-                ['style.css']);
+            my $url = Sympa::Tools::Text::weburl($Conf::Conf{'css_url'},
+                [$robot, 'style.css']);
             return ($url);
         }
     }
@@ -744,10 +742,7 @@ sub _get_css_url {
 
     my ($dir, $path, $url);
     if (%colors) {
-        $dir =
-            sprintf '%s/%s/%s',
-            Conf::get_robot_conf($robot, 'static_content_path'),
-            'css', $robot;
+        $dir = sprintf '%s/%s', $Conf::Conf{'css_path'}, $robot;
         # Expire old files.
         if (opendir my $dh, $dir) {
             foreach my $file (readdir $dh) {
@@ -761,33 +756,29 @@ sub _get_css_url {
             closedir $dh;
         }
 
-        $path = $dir . '/style.' . $hash . '.css';
-        $url  = Sympa::Tools::Text::weburl(
-            Conf::get_robot_conf($robot, 'static_content_url'),
-            ['css', $robot, 'style.' . $hash . '.css']
-        );
+        $path = sprintf '%s/style.%s.css', $dir, $hash;
+        $url = Sympa::Tools::Text::weburl($Conf::Conf{'css_url'},
+            [$robot, sprintf 'style.%s.css', $hash]);
     } elsif ($lang) {
-        $dir =
-            sprintf '%s/%s/%s/%s',
-            Conf::get_robot_conf($robot, 'static_content_path'),
-            'css', $robot, $lang;
+        $dir = sprintf '%s/%s/%s', $Conf::Conf{'css_path'}, $robot, $lang;
 
-        $path = $dir . '/lang.css';
-        $url  = Sympa::Tools::Text::weburl(
-            Conf::get_robot_conf($robot, 'static_content_url'),
-            ['css', $robot, $lang, 'lang.css'],
+        $path = sprintf '%s/lang.css', $dir;
+        $url = Sympa::Tools::Text::weburl(
+            $Conf::Conf{'css_url'},
+            [$robot, $lang, 'lang.css'],
             query => {h => $hash}
         );
     } else {
         # Use css_path and css_url parameters so that the user may provide
         # their own CSS.
-        $dir = Conf::get_robot_conf($robot, 'css_path');
+        $dir = sprintf '%s/%s', $Conf::Conf{'css_path'}, $robot;
 
         $path = $dir . '/style.css';
-        $url =
-            Sympa::Tools::Text::weburl(
-            Conf::get_robot_conf($robot, 'css_url'),
-            ['style.css'], query => {h => $hash});
+        $url  = Sympa::Tools::Text::weburl(
+            $Conf::Conf{'css_url'},
+            [$robot, 'style.css'],
+            query => {h => $hash}
+        );
     }
 
     # Update the CSS if it is missing or if css.tt2 or configuration was

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -1292,7 +1292,7 @@ sub upgrade {
             }
 
             # CSS would be regenerated...
-            my $dir = Conf::get_robot_conf($robot, 'css_path');
+            my $dir = $Conf::Conf{'css_path'} . '/' . $robot;
             rename $dir . '/style.css', $dir . '/style.css.' . time
                 if -f $dir . '/style.css';
         }


### PR DESCRIPTION
This PR may fix bug of change on issue #172.

  - [bug] Values of css_url & css_path parameters by robot are broken.
  - [change] css_url & css_path no longer may be per-robot parameters.  Because robot subdirectories under CSSDIR are assumed.
  - [change] pictures_url & pictures_path may not be per-robot parameters, as proposed in original PR.  Because list subdirectories under PICTURESDIR are assumed.

**This would be merged in a day for quick fix.**
