### PR TITLE
wwsympa.fcgi.in: fix calling order for List->new(): should be (list, robot)

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1515,7 +1515,7 @@ while ($query = CGI::Fast->new) {
         while ($action) {
             if (defined $in{'list'} and length $in{'list'}) {
                 # Create a new Sympa::List instance.
-                unless ($list = Sympa::List->new($robot, $in{'list'})) {
+                unless ($list = Sympa::List->new($in{'list'}, $robot)) {
                     wwslog('info', 'Unknown list "%s"', $in{'list'});
                     if ($action eq 'info') {
                         # To prevent sniffing lists, don't notice error to


### PR DESCRIPTION
After building and installing a copy of 6.2.25b.3, the 'my lists' page showed the expected lists. However, clicking the 'info' or 'admin' links resulted in a return to the home page and a wwsympa.log entry of the form

``Mar 19 21:01:52 HOSTNAME wwsympa[21958]: info main:: [robot ROBOT] [session 65344701597375] [client IPADDR] [user ADDRESS] Unknown list "LISTNAME"
``
Based on some debug logging and poking around, it looks like a call to `List->new()` in wwsympa.fcgi has the robot and list parameters reversed: 

``unless ($list = Sympa::List->new($robot, $in{'list'})) {``

Updating this to

``unless ($list = Sympa::List->new($in{'list'}, $robot)) {``

restores the expected behavior.