### PR TITLE
Issue #234: Sympa ldap search escapes chars incorrect

### DIFF
--- a/src/lib/Sympa/ModDef.pm
+++ b/src/lib/Sympa/ModDef.pm
@@ -348,6 +348,8 @@ our %cpan_modules = (
         'gettext_id' =>
             'required to query LDAP directories. Sympa can do LDAP-based authentication ; it can also build mailing lists with LDAP-extracted members.',
     },
+    # Net::LDAP::Entry, Net::LDAP::Util and Net::LDAPS are included in
+    # perl-ldap.
     'Net::SMTP' => {
         package_name => 'libnet',
         'gettext_id' =>


### PR DESCRIPTION
This may fix issue #234.

Fixed by:
  - Canonicalizing value of attrs1 as DN, if it is search base or root of it.
  - Escaping it as attributevalue in DN otherwise.