### PR TITLE
Issue #240: Unable to edit owners/subscribers

### DIFF
--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -1782,8 +1782,10 @@ sub upgrade {
         # As the field date_admin and date_subscriber are no longer used but
         # they have NOT NULL constraint, they should be deleted.
         if ($sdm and $sdm->can('delete_field')) {
+            $log->syslog('notice', 'Upgrading admin_table');
             $sdm->delete_field(
                 {table => 'admin_table', field => 'date_admin'});
+            $log->syslog('notice', 'Upgrading subscriber_table');
             $sdm->delete_field(
                 {table => 'subscriber_table', field => 'date_subscriber'});
         } else {


### PR DESCRIPTION
[bug] As the field `date_admin` and `date_subscriber` are no longer used but they have `NOT NULL` constraint, they should be deleted.

This may fix issue #240.

This bug affects PostgreSQL and Oracle; MySQL (without strict mode) and SQLite may not be affected.
