### PR TITLE
[bug] unsubscribe.open scenario omits [email]

### DIFF
--- a/src/lib/Sympa/Spindle/AuthorizeRequest.pm
+++ b/src/lib/Sympa/Spindle/AuthorizeRequest.pm
@@ -65,6 +65,10 @@ sub _twist {
 
     my $context = $self->{scenario_context}
         or die 'bug in logic. Ask developer';
+    # Suppress target email kept only in request.
+    # FIXME: $request and $context would be merged in some future
+    $context = {email => $request->{email}, %$context}
+        if exists $request->{email};
 
     # Call scenario: auth_method MD5 do not have any sense in
     # scenario because auth is performed by AUTH command.


### PR DESCRIPTION
Fixed by assigning $request->{email} to scenario context.

This may fix issue #233.
