### PR TITLE
Use font-awesome icons instead of stock images

### DIFF
--- a/default/web_tt2/d_read.tt2
+++ b/default/web_tt2/d_read.tt2
@@ -114,7 +114,7 @@
       <tr class="color0">
 	<td class="review_cels_mail">
           <a href="[% 'd_read' | url_rel([list,s.paths_d]) %]"> 
-            <img src="[% s.icon %]" alt="[% s.title %]" />
+            [% PROCESS SharedGetIcon shared_item = s %]
             [% s.name %]</a></td>
 	<td class="review_cels">
         [% IF s.owner ~%] 
@@ -178,27 +178,31 @@
       [% IF f.html ~%]
 	<td class="review_cels_mail">
         <a href="[% 'd_read' | url_rel([list,f.paths_d]) %]"
-          title="[%|loc%]Open in a new window[%END%]" target="html_window">
-	  <img src="[% f.icon %]" alt="[% f.title %]" /> [% f.name %] </a>
+         title="[%|loc%]Open in a new window[%END%]" target="html_window">
+          [% PROCESS SharedGetIcon shared_item = f %]
+          [% f.name %] </a>
 	</td>
       [%~ ELSIF f.url ~%]
         <td class="review_cels_mail">
 	<a href="[% f.url %]" title="[%|loc%]Open in a new window[%END%]"
-          target="html_window">
-	  <img src="[% f.icon %]" alt="[% f.title %]" /> [% f.label %] </a>
+         target="html_window">
+          [% PROCESS SharedGetIcon shared_item = f %]
+          [% f.label %] </a>
 	</td>
       [%~ ELSE ~%]
 	[% IF f.moderate ~%]
 	  [% IF expert_page ~%]
 	    <td class="review_cels_mail">
 	    <a href="[% 'd_read' | url_rel([list,f.paths_d]) %]">
-	      <img src="[% f.icon %]" alt="[% f.title %]" /> [% f.name %] </a>
+              [% PROCESS SharedGetIcon shared_item = f %]
+              [% f.name %] </a>
 	    </td>
           [%~ END %] 
 	[%~ ELSE ~%]
 	  <td class="review_cels_mail">
 	  <a href="[% 'd_read' | url_rel([list,f.paths_d]) %]">
-	    <img src="[% f.icon %]" alt="[% f.title %]" /> [% f.name %] </a>
+            [% PROCESS SharedGetIcon shared_item = f %]
+            [% f.name %] </a>
 	  </td>  
 	[%~ END ~%]
       [% END %] 
@@ -377,5 +381,59 @@
     [%~ END %]
   [%~ END %]
   [%~ END %]
+
+[%~ BLOCK SharedGetIcon # (shared_item) ~%]
+  [% IF shared_item.type == 'directory' ~%]
+    <i class="fa fa-folder"
+     [%~ IF shared_item.title %] title="[% shared_item.title %]"
+     [%~ ELSE %] title="Icon of folder"
+     [%~ END %]></i>
+  [% ELSIF shared_item.type == 'url' ~%]
+    <i class="fa fa-link"
+     [%~ IF shared_item.title %] title="[% shared_item.title %]"
+     [%~ ELSE %] title="Icon of bookmark"
+     [%~ END %]></i>
+  [%~ ELSIF shared_item.mime_type == 'application/pdf' ~%]
+    <i class="fa fa-file-pdf-o"
+     [%~ IF shared_item.title %] title="[% shared_item.title %]"
+     [%~ ELSE %] title="Icon of PDF file"
+     [%~ END %]></i>
+  [%~ ELSIF shared_item.mime_type.search('application/') ~%]
+    <i class="fa fa-file-o"
+     [%~ IF shared_item.title %] title="[% shared_item.title %]"
+     [%~ ELSE %] title="Icon of file"
+     [%~ END %]></i>
+  [%~ ELSIF shared_item.mime_type.search('audio/') ~%]
+    <i class="fa fa-file-audio-o"
+     [%~ IF shared_item.title %] title="[% shared_item.title %]"
+     [%~ ELSE %] title="Icon of audio file"
+     [%~ END %]></i>
+  [%~ ELSIF shared_item.mime_type.search('image/') ~%]
+    <i class="fa fa-file-image-o"
+     [%~ IF shared_item.title %] title="[% shared_item.title %]"
+     [%~ ELSE %] title="Icon of image file"
+     [%~ END %]></i>
+  [%~ ELSIF shared_item.mime_type == 'text/html' ~%]
+    <i class="fa fa-file-code-o"
+     [%~ IF shared_item.title %] title="[% shared_item.title %]"
+     [%~ ELSE %] title="Icon of HTML file"
+     [%~ END %]></i>
+  [%~ ELSIF shared_item.mime_type.search('text/') ~%]
+    <i class="fa fa-file-text-o"
+     [%~ IF shared_item.title %] title="[% shared_item.title %]"
+     [%~ ELSE %] title="Icon of text file"
+     [%~ END %]></i>
+  [%~ ELSIF shared_item.mime_type.search('video/') ~%]
+    <i class="fa fa-file-video-o"
+     [%~ IF shared_item.title %] title="[% shared_item.title %]"
+     [%~ ELSE %] title="Icon of video file"
+     [%~ END %]></i>
+  [%~ ELSE ~%]
+    <i class="fa fa-file-o"
+     [%~ IF shared_item.title %] title="[% shared_item.title %]"
+     [%~ ELSE %] title="Icon of file"
+     [%~ END %]></i>
+  [%~ END %]
+[%~ END ~%]
 
 <!-- end d_read.tt2 -->

--- a/default/web_tt2/help_shared.tt2
+++ b/default/web_tt2/help_shared.tt2
@@ -13,13 +13,13 @@
 
 	<p>[%|helploc%]<strong>The 'Shared documents' section can contain three types of resources</strong>: <strong>folders</strong>, <strong>files</strong> and <strong>bookmarks</strong>.[%END%]</p>
 	<ul>
-		<li>[%|helploc(icons_url)%]<strong>Folders</strong> are preceded by the icon <img src="%1/folder.png" style="border: 0px;" title="Icon of folder" />.[%END%]
+		<li>[%|helploc%]<strong>Folders</strong> are preceded by the icon <i class="fa fa-folder" title="Icon of folder"> </i>.[%END%]
 		<ul>
 			<li>[%|helploc%]<strong>To browse a folder, click on its name</strong>.[%END%]</li>
 			<li>[%|helploc%]<strong>To go back up a level, click on the 'Up to higher level directory' link</strong> in the upper right corner of your screen.[%END%]</li>
 		</ul></li>
 		<li>[%|helploc%]<strong>Files</strong> are preceded by icons related to each type of file. You can <a href="#shared_read">download</a> and <a href="#shared_upload">upload</a> some.[%END%]</li>
-		<li>[%|helploc(icons_url)%]<strong>Bookmarks</strong> are preceded by the icon <img src="%1/link.png" style="border: 0px;" title="Icon of bookmark" />. They consist of <strong>shortcuts providing a single-click access to a particular website</strong>. If you click on a bookmark label, the website linked will open in a new window.[%END%]</li>
+		<li>[%|helploc%]<strong>Bookmarks</strong> are preceded by the icon <i class="fa fa-link" title="Icon of bookmark"> </i>. They consist of <strong>shortcuts providing a single-click access to a particular website</strong>. If you click on a bookmark label, the website linked will open in a new window.[%END%]</li>
 	</ul>
 
 	<p>[%|helploc%]The functions of editing and creation of documents, when they are available to you, are accessible through the <strong>Expert mode</strong>. To switch to expert mode, click on the <a class="actionMenuLinks">Expert mode</a> button on top of page.[%END%]</p>

--- a/default/web_tt2/review.tt2
+++ b/default/web_tt2/review.tt2
@@ -189,15 +189,19 @@
   </noscript>
   </fieldset>
   </form>
-   [% IF prev_page %]
-    <a href="[% 'review' | url_rel([list,prev_page,size,sortby]) %]"><img src="[% icons_url %]/left.png" alt="[%|loc%]Previous page[%END%]" /></a>
-   [% END %]
-   [% IF page %]
-     [%|loc(page,total_page)%]page %1 / %2[%END%]
-   [% END %]
-   [% IF next_page %]
-     <a href="[% 'review' | url_rel([list,next_page,size,sortby]) %]"><img src="[% icons_url %]/right.png" alt="[%|loc%]Next page[%END%]" /></a>
-   [% END %]
+  [% IF prev_page ~%]
+    <a href="[% 'review' | url_rel([list,prev_page,size,sortby]) %]">
+    <i class="fa fa-caret-left fa-lg" title="[%|loc%]Previous page[%END%]"></i>
+    </a>
+  [%~ END %]
+  [% IF page ~%]
+    [%|loc(page,total_page)%]page %1 / %2[%END%]
+  [%~ END %]
+  [% IF next_page ~%]
+    <a href="[% 'review' | url_rel([list,next_page,size,sortby]) %]">
+    <i class="fa fa-caret-right fa-lg" title="[%|loc%]Next page[%END%]"></i>
+    </a>
+  [%~ END %]
 </div>
 [% END %]
 

--- a/default/web_tt2/reviewbouncing.tt2
+++ b/default/web_tt2/reviewbouncing.tt2
@@ -59,15 +59,19 @@
 </form>
 
 <div class="text-center">
-        [% IF prev_page %]
-	  <a href="[% 'reviewbouncing' | url_rel([list,prev_page,size]) %]"><img src="[% icons_url %]/left.png" alt="[%|loc%]Previous page[%END%]"></a>
-        [% END %]
-        [% IF page %]
-  	  [%|loc(page,total_page)%]page %1 / %2[%END%]
-        [% END %]
-        [% IF next_page %]
-	  <a href="[% 'reviewbouncing' | url_rel([list,next_page,size]) %]"><img src="[% icons_url %]/right.png" alt="[%|loc%]Next page[%END%]"></a>
-        [% END %]
+[% IF prev_page ~%]
+  <a href="[% 'reviewbouncing' | url_rel([list,prev_page,size]) %]">
+  <i class="fa fa-caret-left fa-lg" title="[%|loc%]Previous page[%END%]"></i>
+  </a>
+[%~ END %]
+[% IF page ~%]
+  [%|loc(page,total_page)%]page %1 / %2[%END%]
+[%~ END %]
+[% IF next_page ~%]
+  <a href="[% 'reviewbouncing' | url_rel([list,next_page,size]) %]">
+  <i class="fa fa-caret-right fa-lg" title="[%|loc%]Next page[%END%]"></i>
+  </a>
+[%~ END %]
 </div>
 
 <form name="myform" action="[% path_cgi %]" method="POST"
@@ -134,17 +138,21 @@
 
         [% END %]
       </table>
-  <div class="text-center">
-        [% IF prev_page %]
-	  <a href="[% 'reviewbouncing' | url_rel([list,prev_page,size]) %]"><img src="[% icons_url %]/left.png" alt="[%|loc%]Previous page[%END%]" /></a>
-        [% END %]
-        [% IF page %]
-  	  [%|loc(page,total_page)%]page %1 / %2[%END%]
-        [% END %]
-        [% IF next_page %]
-	  <a href="[% 'reviewbouncing' | url_rel([list,next_page,size]) %]"><img src="[% icons_url %]/right.png" alt="[%|loc%]Next page[%END%]" /></a>
-        [% END %]
-  </div>
+<div class="text-center">
+[% IF prev_page ~%]
+  <a href="[% 'reviewbouncing' | url_rel([list,prev_page,size]) %]">
+  <i class="fa fa-caret-left fa-lg" title="[%|loc%]Previous page[%END%]"></i>
+  </a>
+[%~ END %]
+[% IF page ~%]
+  [%|loc(page,total_page)%]page %1 / %2[%END%]
+[%~ END %]
+[% IF next_page ~%]
+  <a href="[% 'reviewbouncing' | url_rel([list,next_page,size]) %]">
+  <i class="fa fa-caret-right fa-lg" title="[%|loc%]Next page[%END%]"></i>
+  </a>
+[%~ END %]
+</div>
   [% IF is_owner %]
   <div>
     <input class="MainMenuLinks" type="submit" name="action_del"

--- a/default/web_tt2/viewlogs.tt2
+++ b/default/web_tt2/viewlogs.tt2
@@ -254,15 +254,19 @@
   </fieldset>
   </form>
 <br />
-  [% IF prev_page %]
-    <a href="[% 'viewlogs' | url_rel([list,prev_page,size,sortby]) %]"><img src="[% icons_url %]/left.png" alt="[%|loc%]Previous page[%END%]" /></a>
-  [% END %]
-  [% IF page %]
+  [% IF prev_page ~%]
+    <a href="[% 'viewlogs' | url_rel([list,prev_page,size,sortby]) %]">
+    <i class="fa fa-caret-left fa-lg" title="[%|loc%]Previous page[%END%]"></i>
+    </a>
+  [%~ END %]
+  [% IF page ~%]
     [%|loc(page,total_page)%]page %1 / %2[%END%]
-  [% END %]
-  [% IF next_page %]
-    <a href="[% 'viewlogs' | url_rel([list,next_page,size,sortby]) %]"><img src="[% icons_url %]/right.png" alt="[%|loc%]Next page[%END%]" /></a>
-  [% END %]
+  [%~ END %]
+  [% IF next_page ~%]
+    <a href="[% 'viewlogs' | url_rel([list,next_page,size,sortby]) %]">
+    <i class="fa fa-caret-right fa-lg" title="[%|loc%]Next page[%END%]"></i>
+    </a>
+  [%~ END %]
   </div>
 [% END %]
 

--- a/src/lib/Sympa/WWW/SharedDocument.pm
+++ b/src/lib/Sympa/WWW/SharedDocument.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017 The Sympa Community. See the AUTHORS.md file at the top-level
-# directory of this distribution and at
+# Copyright 2017, 2018 The Sympa Community. See the AUTHORS.md file at the
+# top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -40,24 +40,6 @@ use Sympa::Scenario;
 use Sympa::Tools::Data;
 use Sympa::Tools::File;
 use Sympa::Tools::Text;
-
-# Hash of the icons linked with a type of file.
-my %icons = (
-    'unknown'        => 'unknown.png',
-    'folder'         => 'folder.png',
-    'current_folder' => 'folder.open.png',
-    'application'    => 'unknown.png',
-    'octet-stream'   => 'binary.png',
-    'audio'          => 'sound1.png',
-    'image'          => 'image2.png',
-    'text'           => 'text.png',
-    'video'          => 'movie.png',
-    'father'         => 'back.png',
-    'sort'           => 'down.png',
-    'url'            => 'link.png',
-    'left'           => 'left.png',
-    'right'          => 'right.png',
-);
 
 # Creates a new object.
 sub new {
@@ -314,7 +296,29 @@ sub _load_desc_file {
     return %hash;
 }
 
+# Hash of the icons linked with a type of file.
+# Note: Image icons are no longer used by templates. This is kept for
+# backward compatibility.
+my %icons = (
+    'unknown'        => 'unknown.png',
+    'folder'         => 'folder.png',
+    'current_folder' => 'folder.open.png',
+    'application'    => 'unknown.png',
+    'octet-stream'   => 'binary.png',
+    'audio'          => 'sound1.png',
+    'image'          => 'image2.png',
+    'text'           => 'text.png',
+    'video'          => 'movie.png',
+    'father'         => 'back.png',
+    'sort'           => 'down.png',
+    'url'            => 'link.png',
+    'left'           => 'left.png',
+    'right'          => 'right.png',
+);
+
 # Old name: Sympa::Tools::WWW::get_icon().
+# Note: Image icons are no longer used by templates. This is kept for
+# backward compatibility.
 sub _get_icon {
     my $robot = shift || '*';
     my $type = shift;

--- a/www/Makefile.am
+++ b/www/Makefile.am
@@ -376,39 +376,12 @@ nobase_static_DATA = \
 	fonts/foundation-icons/svgs/fi-zoom-out.svg \
 	fonts/Raleway/OFL.txt \
 	fonts/Raleway/Raleway-Regular.otf \
-	icons/arc.png \
-	icons/back.png \
-	icons/begin.png \
-	icons/binary.png \
-	icons/config.png \
 	icons/crosshairs.png \
-	icons/datasources.png \
-	icons/down.png \
-	icons/end.png \
 	icons/favicon_sympa.png \
-	icons/folder.open.png \
-	icons/folder.png \
 	icons/h.png \
-	icons/image2.png \
-	icons/junk.png \
-	icons/left.png \
-	icons/link.png \
-	icons/locked.png \
-	icons/logo-s-lock.png \
-	icons/logo-s.png \
 	icons/logo_sympa.png \
-	icons/movie.png \
-	icons/new_list.png \
 	icons/position.png \
-	icons/right.png \
-	icons/search.png \
-	icons/sound1.png \
-	icons/spinner.gif \
-	icons/subscribe.png \
 	icons/sv.png \
-	icons/text.png \
-	icons/top.png \
-	icons/unknown.png \
 	js/sympa.js
 
 EXTRA_DIST = $(nobase_static_DATA)


### PR DESCRIPTION
Several images under `STATICDIR/icons` will not be used as described in below.

Following images will be used continuously:

  - `favicon_sympa.png` (favicon)
  - `logo_sympa.png` (logo)
  - `crosshairs.png` (used by color picker)
  - `h.png` ( ,, )
  - `position.png` ( ,, )
  - `sv.png` ( ,, )

Following images will no longer be used:

  - `binary.png` (used by shared document repository)
  - `folder.png` ( ,, )
  - `image2.png` ( ,, )
  - `link.png` ( ,, )
  - `movie.png` ( ,, )
  - `sound1.png` ( ,, )
  - `text.png` ( ,, )
  - `unknown.png` ( ,, )
  - `left.png`
  - `right.png`

Following images have no longer been used by current stable:

  - `arc.png`
  - `back.png`
  - `begin.png`
  - `config.png`
  - `datasources.png`
  - `down.png`
  - `end.png`
  - `folder.open.png`
  - `junk.png`
  - `locked.png`
  - `logo-s-lock.png` (older logo, small, locked)
  - `logo-s.png` (older logo, small)
  - `new_list.png`
  - `search.png`
  - `spinner.gif`
  - `subscribe.png`
  - `top.png`
