### PR TITLE
Fixing issue #167 along with problem reported on the list by Pat Alle…

### DIFF
--- a/src/lib/Sympa/User.pm
+++ b/src/lib/Sympa/User.pm
@@ -508,21 +508,43 @@ sub update_global_user {
 
     $who = Sympa::Tools::Text::canonic_email($who);
 
-    ## use md5 fingerprint to store password
-    $values->{'password'} =
-        Sympa::User::password_fingerprint($values->{'password'})
-        if ($values->{'password'});
-
-    ## Canonicalize lang if possible.
-    $values->{'lang'} = Sympa::Language::canonic_lang($values->{'lang'})
-        || $values->{'lang'}
-        if $values->{'lang'};
-
+    ## Check whether password is already defined.
     my $sdm = Sympa::DatabaseManager->instance;
     unless ($sdm) {
         $log->syslog('err', 'Unavailable database connection');
         return undef;
     }
+
+
+    push @sth_stack, $sth;
+
+    $sth = $sdm->do_query(
+        "SELECT password_user FROM user_table WHERE (email_user=%s)",
+        $sdm->quote($who)
+    );
+    unless (defined $sth) {
+        $log->syslog('err',
+            'Could not check password information for user %s in user_table', $who);
+        $sth = pop @sth_stack;
+        return undef;
+    }
+
+    my $current_password = $sth->fetchrow();
+
+    $sth = pop @sth_stack;
+
+    if ($values->{'password'}) {
+        if($current_password ne $values->{'password'}) {
+            ## use hash fingerprint to store password
+            ## hashes that use salts will randomly generate one
+            $values->{'password'} = Sympa::User::password_fingerprint($values->{'password'}, undef);
+        }
+    }
+
+    ## Canonicalize lang if possible.
+    $values->{'lang'} = Sympa::Language::canonic_lang($values->{'lang'})
+        || $values->{'lang'}
+        if $values->{'lang'};
 
     my ($field, $value);
 


### PR DESCRIPTION
Fixing issue #167 along with problem reported on the list by Pat Allen: password was reset when subscribing to a list. When updating a user, password was systematically rehashed even if it was not a new password. Consequently, anytime a user was updated, the password replaced y its own hash. Fixed by checking the database for a pre-existing password before computing the hash.