### PR TITLE
Double <hr> shown under some conditions

### DIFF
--- a/default/web_tt2/review.tt2
+++ b/default/web_tt2/review.tt2
@@ -68,10 +68,10 @@
       </a>
     </p>
     </div>
+    <hr>
   [%~ END %]
 [% END %]
 
-<hr>
 <h3>[%|loc%]Search for a User[%END%]</h3>
 <form action="[% path_cgi %]" method="post"> 
 <fieldset>


### PR DESCRIPTION
When a list is not 'open' and allow_subscribe_if_pending has been set to 'off', add cannot be performed and its block in the list review web page is not shown. The problem here is that a couple of `<hr` are shown. This change prevents this problem, making one of them dependent on the block that is hidden.