### PR TITLE
Removed extra periods at the end of these sentences

### DIFF
--- a/default/web_tt2/d_properties.tt2
+++ b/default/web_tt2/d_properties.tt2
@@ -82,9 +82,9 @@
   <fieldset>
   <label for="content">
   [% IF shared_doc.type == 'directory' %]
-  [%|loc(fname)%]Describe directory '%1'[%END%]
+  [%|loc(shared_doc.name)%]Describe directory '%1'[%END%]
   [% ELSE %]
-  [%|loc(fname)%]Describe file '%1'[%END%]
+  [%|loc(shared_doc.name)%]Describe file '%1'[%END%]
   [% END %]
   </label>
   <input id="content" size="50" maxlength="100" name="content"
@@ -101,9 +101,9 @@
   <fieldset>
   <label for="new_name">
   [% IF shared_doc.type == 'directory' %]
-  [%|loc(fname)%]Rename directory %1[%END%]
+  [%|loc(shared_doc.name)%]Rename directory %1[%END%]
   [% ELSE %]
-  [%|loc(fname)%]Rename file %1[%END%]
+  [%|loc(shared_doc.name)%]Rename file %1[%END%]
   [% END %]
   </label>
   <input size="50" maxlength="100" name="new_name" />

--- a/default/web_tt2/editfile.tt2
+++ b/default/web_tt2/editfile.tt2
@@ -57,7 +57,7 @@
 [% IF files.$item4 %]
 <a href="[% 'editfile' | url_rel([list,'invite.tt2',previous_action]) %]" class="MainMenuLinks">[%|loc%]Edit[%END%]</a> [%|loc%]Subscribing invitation message: sent to a person if someone uses the INVITE command to invite someone to subscribe.[%END%]<br />
 [% END %]
-
+<br />
 [% END %]
 
 [% item1 = 'message.footer'
@@ -71,7 +71,7 @@
 [% IF files.$item2 %]
 <a href="[% 'editfile' | url_rel([list,'message.header',previous_action]) %]" class="MainMenuLinks">[%|loc%]Edit[%END%]</a> [%|loc%]Message header: If this file is not empty, it is added as a MIME attachment at the beginning of each message distributed to the list.[%END%]<br />
 [% END %]
-
+<br />
 [% END %]
 
 [% item1 = 'bye.tt2'

--- a/default/web_tt2/modform.tt2
+++ b/default/web_tt2/modform.tt2
@@ -33,10 +33,10 @@
   </select>
   [% IF conf.reporting_spam_script_path %]
      [%- IF msg.value.spam_status != 'spam' -%]
-        <br /> <input id="signal_spam[% line_count %]" type=checkbox name="signal_spam" /><label for="signal_spam[% line_count %]">[%|loc %]Report message as undetected spam[%END%]</label>
+        <br /> <input id="signal_spam[% line_count %]" type=checkbox name="signal_spam" /> <label for="signal_spam[% line_count %]">[%|loc %]Report message as undetected spam[%END%]</label>
      [% END %] 
   [% END %] 
-  <br /> <input id="blacklist[% line_count %]" type=checkbox name="blacklist" /><label for="blacklist[% line_count %]">[%|loc %]Add sender to blacklist[%END%]</label>
+  <br /> <input id="blacklist[% line_count %]" type=checkbox name="blacklist" /> <label for="blacklist[% line_count %]">[%|loc %]Add sender to blacklist[%END%]</label>
 
   <div class="formError" style="display:none"  id="warningSpam[% line_count %]">
    <p class="alert-box info text-left"><input type="checkbox" name="iConfirm" value="1" /> [%|loc%]You should rejet spams quietly because the sender of a spam is often spoofed, if you really want to send this notification, please confirm [%END%]</p>

--- a/default/web_tt2/modindex.tt2
+++ b/default/web_tt2/modindex.tt2
@@ -23,7 +23,7 @@
    <br />
   </p>
   <p>
-    <input type=checkbox name="blacklist" form="moderate_mails" />[%|loc %]Add to blacklist[%END%]
+    <input type=checkbox name="blacklist" form="moderate_mails" /> [%|loc %]Add to blacklist[%END%]
   </p>
 
   <h3>[%|loc%]Listing messages to moderate[%END%]</h3>

--- a/default/web_tt2/serveradmin.tt2
+++ b/default/web_tt2/serveradmin.tt2
@@ -61,7 +61,7 @@
 <span>[%|loc%]View session information for users connected to this web interface:[%END%]</span>
 <label for="session_delay">[%|loc%]Delay for active sessions (minutes)[%END%] </label>
 <input type="text" id="session_delay" name="session_delay" size="2" value="10" />
-<input type="checkbox" id="connected_only" name="connected_only" /><label for="connected_only">[%|loc%]Show only currently connected users[%END%] </label><br />
+<input type="checkbox" id="connected_only" name="connected_only" /> <label for="connected_only">[%|loc%]Show only currently connected users[%END%] </label><br />
 <input type="submit" name="action_show_sessions" value="[%|loc%]Show Sessions[%END%]" />
 </fieldset>
 </form>

--- a/default/web_tt2/set_pending_list_request.tt2
+++ b/default/web_tt2/set_pending_list_request.tt2
@@ -28,7 +28,7 @@
 <input type="hidden" name="mode" value="install" />
 <input type="hidden" name="previous_action" value="[% action %]" />
 <input class="MainMenuLinks" type="submit" value="[%|loc%]submit[%END%]" />
-<input id="notify" type="checkbox" name="notify" checked="checked" /><label for="notify">[%|loc%]notify owner[%END%]</label>
+<input id="notify" type="checkbox" name="notify" checked="checked" /> <label for="notify">[%|loc%]notify owner[%END%]</label>
 </fieldset>
 </form>
 </div>

--- a/default/web_tt2/suboptions.tt2
+++ b/default/web_tt2/suboptions.tt2
@@ -114,7 +114,7 @@
     style="display: inline-block; max-width: 40%"
     placeholder="[%|loc%]dd-mm-yyyy[%END%]" />
   <noscript>([%|loc%]dd-mm-yyyy[%END%])</noscript>
-  <input type="checkbox" name="indefinite" />[%|loc%]Suspend my membership indefinitely[%END%]
+  <input type="checkbox" name="indefinite" /> [%|loc%]Suspend my membership indefinitely[%END%]
 </div>
 
   <input type="hidden" name="listname" value="[% list %]" />

--- a/default/web_tt2/subscribe.tt2
+++ b/default/web_tt2/subscribe.tt2
@@ -8,10 +8,10 @@
   </a></p>
 [%~ ELSE ~%]
   [% IF listconf.custom_attribute.size() ~%]
-    <p>[%|loc(list)%]You want to subscribe to list %1.[%END%].
+    <p>[%|loc(list)%]You want to subscribe to list %1.[%END%]
     [%|loc%]Please fill in the form below and then click the validation button:[%END%]</p>
   [%~ ELSE ~%]
-    <p>[%|loc(list)%]You've made a subscription request to %1.[%END%].
+    <p>[%|loc(list)%]You've made a subscription request to %1.[%END%]
     [%|loc%]To confirm your request, please click the button below:[%END%]</p>
   [%~ END %]
 

--- a/default/web_tt2/suspend_request.tt2
+++ b/default/web_tt2/suspend_request.tt2
@@ -91,7 +91,7 @@
       style="display: inline-block; max-width: 40%"
       placeholder="[%|loc%]dd-mm-yyyy[%END%]" />
     <noscript>([%|loc%]dd-mm-yyyy[%END%])</noscript>
-    <input type="checkbox" name="indefinite" />[%|loc%]Suspend my membership indefinitely[%END%]
+    <input type="checkbox" name="indefinite" /> [%|loc%]Suspend my membership indefinitely[%END%]
   </div>
     
     [% IF suspended %]

--- a/default/web_tt2/ticket.tt2
+++ b/default/web_tt2/ticket.tt2
@@ -31,7 +31,7 @@
 [%END%]
 
 [% IF ticket_context.result == 'not_found' -%]
-[%|loc(ticket_context.printable_date)%]The requested authentication ticket is unrecognized or has expired.[%END%].
+[%|loc(ticket_context.printable_date)%]The requested authentication ticket is unrecognized or has expired.[%END%]
 [% IF user.email %]
 <br/>[%|loc%]However, as you are logged in already, you can probably perform the action you requested anyway.[%END%]
 [% ELSE %]

--- a/default/web_tt2/ticket.tt2
+++ b/default/web_tt2/ticket.tt2
@@ -22,7 +22,7 @@
 [%END%]
 
 [% IF ticket_context.result == 'expired' -%]
-[%|loc(ticket_context.printable_date)%]The requested ticket has expired.[%END%]
+[%|loc%]The requested ticket has expired.[%END%]
 [% IF user.email %]
 <br/>[%|loc%]However, as you are logged in already, you can probably perform the action you requested anyway.[%END%]
 [% ELSE %]
@@ -31,7 +31,7 @@
 [%END%]
 
 [% IF ticket_context.result == 'not_found' -%]
-[%|loc(ticket_context.printable_date)%]The requested authentication ticket is unrecognized or has expired.[%END%]
+[%|loc%]The requested authentication ticket is unrecognized or has expired.[%END%]
 [% IF user.email %]
 <br/>[%|loc%]However, as you are logged in already, you can probably perform the action you requested anyway.[%END%]
 [% ELSE %]


### PR DESCRIPTION
There was a period both in the localization string and outside it in these sentences. This error caused doble periods to be displayed in the rendered pages.