### PR TITLE
sympa.pl: Improving --dump_users and adding --restore_users, and related fixes

### DIFF
--- a/default/web_tt2/review.tt2
+++ b/default/web_tt2/review.tt2
@@ -10,9 +10,9 @@
   [% END %]
   <a class="actionMenuLinks" href="[% 'reviewbouncing' | url_rel([list]) %]">[%|loc%]Bounces[%END%]</a>
   [% IF action == 'search' %]
-     <a class="actionMenuLinks" href="[% 'dump' | url_rel([list,filter]) %]">[%|loc%]Dump[%END%]</a>
+     <a class="actionMenuLinks" href="[% 'export_member' | url_rel([list],{filter=>filter}) %]">[%|loc%]Dump[%END%]</a>
   [% ELSE %]
-     <a class="actionMenuLinks" href="[% 'dump' | url_rel([list,'light']) %]">[%|loc%]Dump[%END%]</a> 
+     <a class="actionMenuLinks" href="[% 'export_member' | url_rel([list,'light']) %]">[%|loc%]Dump[%END%]</a> 
   [% END %]
      <a class="actionMenuLinks" href="[% 'show_exclude' | url_rel([list]) %]">[%|loc%]Exclude[%END%]</a> 
   <br />

--- a/default/web_tt2/reviewbouncing.tt2
+++ b/default/web_tt2/reviewbouncing.tt2
@@ -2,7 +2,7 @@
 <h2>[%|loc%]Manage bouncing list members[%END%] <a  href="[% 'nomenu/help/admin' | url_rel %]#manage_bounces" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=400,height=200')" target="wws_help"><i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i></a></h2>
 <br />
 [% IF bounce_rate %]
-<a class="actionMenuLinks" href="[% 'dump' | url_rel([list,'bounce']) %]">[%|loc%]Dump[%END%]</a>
+<a class="actionMenuLinks" href="[% 'export_member' | url_rel([list,'bounce']) %]">[%|loc%]Dump[%END%]</a>
 
 <form action="[% path_cgi %]" method="post"> 
 <fieldset>

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -279,7 +279,7 @@ our %comm = (
     'd_set_owner'          => 'do_d_set_owner',
     'd_admin'              => 'do_d_admin',
     'dump_scenario'        => 'do_dump_scenario',
-    'dump'                 => 'do_dump',
+    'export_member'        => 'do_export_member',
     'remind'               => 'do_remind',
     'move_user'            => 'do_move_user',
     'load_cert'            => 'do_load_cert',
@@ -338,6 +338,7 @@ my %comm_aliases = (
     'automatic_lists_request' => 'create_automatic_list_request',
     'change_email'            => 'move_user',
     'change_email_request'    => 'move_user',
+    'dump'                    => 'export_member',
     'ignoresig'               => 'decl_del',
     'ignoresub'               => 'decl_add',
     'del_fromsig'             => 'auth_del',
@@ -454,7 +455,7 @@ our %action_args = (
     'd_control'       => ['list', '@path'],
     'd_change_access' => ['list', '@path'],
     'd_set_owner'     => ['list', '@path'],
-    'dump'            => ['list', 'format'],
+    'export_member'   => ['list', 'format'],
     'search'          => ['list', 'filter'],
     'search_user'     => ['email'],
     'set_lang'        => ['lang'],
@@ -556,13 +557,13 @@ our %required_args = (
     'delete_pictures' => ['param.list', 'param.user.email'],
     'distribute'      => ['param.list', 'param.user.email', 'id|idspam'],
     'add_frommod'     => ['param.list', 'param.user.email', 'id'],
-    'dump'               => ['param.list'],
     'dump_scenario'      => ['param.list', 'pname'],
     'edit_list'          => ['param.user.email', 'param.list'],
     'edit_list_request'  => ['param.user.email', 'param.list'],
     'edit_template'      => ['webormail'],
     'editfile'           => ['param.user.email'],
     'editsubscriber'     => ['param.list', 'param.user.email', 'email'],
+    'export_member'      => ['param.list'],
     'get_closed_lists'   => ['param.user.email'],
     'get_inactive_lists' => ['param.user.email'],
     'get_latest_lists'   => ['param.user.email'],
@@ -750,8 +751,8 @@ my %action_type = (
     'd_admin'            => 'admin',
     'd_reject_shared'    => 'admin',
     'd_install_shared'   => 'admin',
+    'export_member'      => 'admin',
     'dump_scenario'      => 'admin',
-    'dump'               => 'admin',
     'open_list'          => 'admin',
     'remind'             => 'admin',
     #'subindex' => 'admin',
@@ -15903,87 +15904,103 @@ sub do_dump_scenario {
     return 1;
 }
 
-## Subscribers' list
-sub do_dump {
-    wwslog('info', '(%s)', $param->{'list'});
+# Subscribers' list
+# Old name: do_dump().
+sub do_export_member {
+    wwslog('info', '(%s, %s, %s)', $param->{'list'}, $in{'format'},
+        $in{'filter'});
 
-    ## Whatever the action return, it must never send a complex html page
-    $param->{'bypass'}       = 1;
-    $param->{'content_type'} = "text/plain";
-    $param->{'file'}         = undef;
-
-    ## Access control
-    unless (defined check_authz('do_dump', 'review')) {
-        undef $param->{'bypass'};
+    # Access control
+    unless (defined check_authz('do_export_member', 'review')) {
         return undef;
     }
 
-    $list->dump_user('member');
-    $param->{'file'} = $list->{'dir'} . '/member.dump';
+    my $format = $in{'format'} || 'full';
+    my $filter = $in{'filter'};
+    $filter = '' unless defined $filter;
 
-    if ($in{'format'} eq 'light') {
-        unless (open(DUMP, $param->{'file'})) {
-            Sympa::WWW::Report::reject_report_web('intern', 'cannot_open_file',
-                {'file' => $param->{'file'}},
-                $param->{'action'}, '', $param->{'user'}{'email'}, $robot);
-            wwslog('info', 'Unable to open file %s', $param->{'file'});
-            return undef;
-        }
-        unless (open(LIGHTDUMP, ">$param->{'file'}.light")) {
-            Sympa::WWW::Report::reject_report_web(
-                'intern',
-                'cannot_open_file',
-                {'file' => "$param->{'file'}.light"},
-                $param->{'action'},
-                '',
-                $param->{'user'}{'email'},
-                $robot
-            );
-            wwslog('err', 'Unable to create file %s.light', $param->{'file'});
-            return undef;
-        }
-        while (<DUMP>) {
-            next unless ($_ =~ /^email\s(.*)/);
-            print LIGHTDUMP "$1\n";
-        }
-        close LIGHTDUMP;
-        close DUMP;
-        $param->{'file'} = $list->{'dir'} . '/member.dump.light';
+    $param->{'bypass'} = 'extreme';
+    printf "Content-Type: text/plain; Charset=\"UTF-8\"; name=\"%s.txt\"\n"
+        . "Content-Disposition: attachment; filename=\"%s.txt\"\n"
+        . "Content-Transfer-Encoding: 8BIT\n" . "\n",
+        $list->get_id, $list->get_id;
 
+    if ($format eq 'bounce') {
+        print '# '
+            . join("\t",
+            'Email',
+            'Name',
+            'Bounce score',
+            'Bounce count',
+            'First bounce',
+            'Last bounce')
+            . "\n";
+    } elsif ($format eq 'light') {
+        ;
     } else {
-        $param->{'file'} = "$list->{'dir'}/select.dump";
-        wwslog('info', 'Opening %s', $param->{'file'});
-
-        unless (open(DUMP, ">$param->{'file'}")) {
-            Sympa::WWW::Report::reject_report_web('intern', 'file_update_failed',
-                {}, $param->{'action'}, '', $param->{'user'}{'email'},
-                $robot);
-            wwslog('err', 'Unable to create file %s', $param->{'file'});
-            return undef;
-        }
-
-        if ($in{'format'} eq 'bounce') {
-            $in{'size'} = 'all';
-            do_reviewbouncing();
-            print DUMP "# Exported bouncing subscribers\n";
-            print DUMP
-                "# Email\t\tName\tBounce score\tBounce count\tFirst bounce\tLast bounce\n";
-            foreach my $user (@{$param->{'members'}}) {
-                print DUMP
-                    "$user->{'email'}\t$user->{'gecos'}\t$user->{'bounce_score'}\t$user->{'bounce_count'}\t$user->{'first_bounce'}\t$user->{'last_bounce'}\n";
-            }
-        } else {
-            $in{'filter'} = $in{'format'};
-            do_search();
-            print DUMP
-                "# Exported subscribers with search filter \"$in{'format'}\"\n";
-            foreach my $user (@{$param->{'members'}}) {
-                print DUMP "$user->{'email'}\t$user->{'gecos'}\n";
-            }
-        }
-        close DUMP;
+        printf "# Exported subscribers with search filter \"%s\"\n", $filter;
     }
+    my $searchkey = Sympa::Tools::Text::foldcase($filter)
+        if defined $filter and length $filter;
+
+    for (
+        my $subscriber = _subscriber_first($list, type => $format);
+        $subscriber;
+        $subscriber = _subscriber_next($list, type => $format)
+        ) {
+        my $email = $subscriber->{email};
+        my $gecos = $subscriber->{gecos};
+        next unless defined $email and length $email;    # malformed record.
+
+        if (defined $searchkey and length $searchkey) {
+            my $e = Sympa::Tools::Text::foldcase($email);
+            my $g = Sympa::Tools::Text::foldcase($gecos);
+            next
+                unless 0 <= index $e, $searchkey
+                or 0 <= index $g, $searchkey;
+        }
+
+        if ($format eq 'bounce') {
+            print join "\t",
+                $email, $gecos,
+                @{$subscriber}
+                {qw(bounce_score bounce_count first_bounce last_bounce)};
+            print "\n";
+        } elsif ($format eq 'light') {
+            print "$email\n";
+        } else {
+            print join "\t", $email, $gecos;
+            print "\n";
+        }
+    }
+
     return 1;
+}
+
+sub _subscriber_first {
+    my $list    = shift;
+    my %options = @_;
+
+    if ($options{type} and $options{type} eq 'bounce') {
+        my $i = $list->get_first_bouncing_list_member;
+        $list->parse_list_member_bounce($i) if $i;
+        return $i;
+    } else {
+        return $list->get_first_list_member;
+    }
+}
+
+sub _subscriber_next {
+    my $list    = shift;
+    my %options = @_;
+
+    if ($options{type} and $options{type} eq 'bounce') {
+        my $i = $list->get_next_bouncing_list_member;
+        $list->parse_list_member_bounce($i) if $i;
+        return $i;
+    } else {
+        return $list->get_next_list_member;
+    }
 }
 
 ## returns a mailto according to list spam protection parameter

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -15918,8 +15918,8 @@ sub do_dump {
         return undef;
     }
 
-    $list->dump();
-    $param->{'file'} = $list->{'dir'} . '/subscribers.db.dump';
+    $list->dump_user('member');
+    $param->{'file'} = $list->{'dir'} . '/member.dump';
 
     if ($in{'format'} eq 'light') {
         unless (open(DUMP, $param->{'file'})) {
@@ -15948,7 +15948,7 @@ sub do_dump {
         }
         close LIGHTDUMP;
         close DUMP;
-        $param->{'file'} = "$list->{'dir'}/subscribers.db.dump.light";
+        $param->{'file'} = $list->{'dir'} . '/member.dump.light';
 
     } else {
         $param->{'file'} = "$list->{'dir'}/select.dump";

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -144,7 +144,7 @@ Delete the indicated users from the list.
 Delete the indicated admin user with the predefined role from the list.
 ROLE may be C<'owner'> or C<'editor'>.
 
-=item dump_user ( ROLE )
+=item dump_users ( ROLE )
 
 Dump user information in user store into file C<I<$role>.dump> under
 list directory. ROLE may be C<'member'>, C<'owner'> or C<'editor'>.
@@ -204,7 +204,7 @@ the list.
 OBSOLETED.
 Use get_admins().
 
-=item suck_user ( ROLE )
+=item restore_users ( ROLE )
 
 Import user information into user store from file C<I<$role>.dump> under
 list directory. ROLE may be C<'member'>, C<'owner'> or C<'editor'>.
@@ -708,7 +708,7 @@ sub _cache_put {
 
 # Dumps a copy of list users to disk, in text format.
 # Old name: Sympa::List::dump() which dumped only members.
-sub dump_user {
+sub dump_users {
     $log->syslog('debug2', '(%s, %s)', @_);
     my $self = shift;
     my $role = shift;
@@ -4368,7 +4368,7 @@ sub load_data_sources_list {
 
 ## Loads the list of users.
 # Old name:: Sympa::List::_load_list_members_file($file) which loaded members.
-sub suck_user {
+sub restore_users {
     $log->syslog('debug2', '(%s, %s)', @_);
     my $self = shift;
     my $role = shift;
@@ -7416,7 +7416,7 @@ sub _inclusion_loop {
 #sub _load_total_db;
 
 ## Writes the user list to disk
-# Depreceted.  Use Sympa::List::dump_user().
+# Depreceted.  Use Sympa::List::dump_users().
 #sub _save_list_members_file;
 
 ## Does the real job : stores the message given as an argument into

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -7416,35 +7416,8 @@ sub _inclusion_loop {
 #sub _load_total_db;
 
 ## Writes the user list to disk
-sub _save_list_members_file {
-    my ($self, $file) = @_;
-    $log->syslog('debug3', '(%s)', $file);
-
-    my ($k, $s);
-
-    $log->syslog('debug2', 'Saving user file %s', $file);
-
-    rename("$file", "$file.old");
-    open my $fh, '>', $file or return undef;
-
-    for (
-        $s = $self->get_first_list_member();
-        $s;
-        $s = $self->get_next_list_member()
-        ) {
-        foreach $k (
-            'date',      'update_date', 'email', 'gecos',
-            'reception', 'visibility'
-            ) {
-            printf $fh "%s %s\n", $k, $s->{$k}
-                if defined $s->{$k} and length $s->{$k};
-
-        }
-        print $fh "\n";
-    }
-    close $fh;
-    return 1;
-}
+# Depreceted.  Use Sympa::List::dump_user().
+#sub _save_list_members_file;
 
 ## Does the real job : stores the message given as an argument into
 ## the digest of the list.

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -142,6 +142,12 @@ Delete the indicated users from the list.
 =item delete_list_admin ( ROLE, ARRAY )
 
 Delete the indicated admin user with the predefined role from the list.
+ROLE may be C<'owner'> or C<'editor'>.
+
+=item dump_user ( ROLE )
+
+Dump user information in user store into file C<I<$role>.dump> under
+list directory. ROLE may be C<'member'>, C<'owner'> or C<'editor'>.
 
 =item get_cookie ()
 
@@ -197,6 +203,11 @@ the list.
 
 OBSOLETED.
 Use get_admins().
+
+=item suck_user ( ROLE )
+
+Import user information into user store from file C<I<$role>.dump> under
+list directory. ROLE may be C<'member'>, C<'owner'> or C<'editor'>.
 
 =item update_list_member ( $email, key =E<gt> value, ... )
 
@@ -695,24 +706,61 @@ sub _cache_put {
 # Moved to: Sympa::Spindle::DistributeMessage::_extract_verp_rcpt().
 #sub _extract_verp_rcpt;
 
-## Dumps a copy of lists to disk, in text format
-sub dump {
+# Dumps a copy of list users to disk, in text format.
+# Old name: Sympa::List::dump() which dumped only members.
+sub dump_user {
+    $log->syslog('debug2', '(%s, %s)', @_);
     my $self = shift;
-    $log->syslog('debug2', '(%s)', $self->{'name'});
+    my $role = shift;
 
-    unless (defined $self) {
-        $log->syslog('err', 'Unknown list');
+    die 'bug in logic. Ask developer'
+        unless grep {$role eq $_} qw(member owner editor);
+
+    my $file = $self->{'dir'} . '/' . $role . '.dump';
+
+    unlink $file . '.old' if -e $file . '.old';
+    rename $file, $file . '.old' if -e $file;
+    my $lock_fh = Sympa::LockedFile->new($file, 5, '>');
+    unless ($lock_fh) {
+        $log->syslog('err', 'Failed to save file %s.new: %s', $file,
+            Sympa::LockedFile->last_error);
         return undef;
     }
 
-    my $user_file_name = "$self->{'dir'}/subscribers.db.dump";
-
-    unless ($self->_save_list_members_file($user_file_name)) {
-        $log->syslog('err', 'Failed to save file %s', $user_file_name);
-        return undef;
+    if ($role eq 'member') {
+        my $user;
+        for (
+            $user = $self->get_first_list_member();
+            $user;
+            $user = $self->get_next_list_member()
+            ) {
+            foreach my $k (
+                qw(date update_date email gecos
+                reception visibility)) {
+                printf $lock_fh "%s %s\n", $k, $user->{$k}
+                    if defined $user->{$k} and length $user->{$k};
+    
+            }
+            print $lock_fh "\n";
+        }
+    } else {
+        foreach my $user (@{$self->_get_admins || []}) {
+            next unless $user->{role} eq $role;
+            foreach my $k (
+                qw(date update_date email gecos profile
+                reception visibility info
+                subscribed included id)
+                ) {
+                printf $lock_fh "%s %s\n", $k, $user->{$k}
+                    if defined $user->{$k} and length $user->{$k};
+    
+            }
+            print $lock_fh "\n";
+        }
     }
 
-    # Note: "subscribers" file was deprecated. No need to load "stats" file.
+    $lock_fh->close;
+
     # FIXME:Are these lines required?
     $self->{'_mtime'}{'config'} =
         Sympa::Tools::File::get_mtime($self->{'dir'} . '/config');
@@ -4319,37 +4367,96 @@ sub load_data_sources_list {
 # No longer used.
 #sub _load_stats_file;
 
-## Loads the list of subscribers.
-sub _load_list_members_file {
-    my $file = shift;
-    $log->syslog('debug2', '(%s)', $file);
+## Loads the list of users.
+# Old name:: Sympa::List::_load_list_members_file($file) which loaded members.
+sub suck_user {
+    $log->syslog('debug2', '(%s, %s)', @_);
+    my $self = shift;
+    my $role = shift;
 
-    ## Open the file and switch to paragraph mode.
-    open(L, $file) || return undef;
+    die 'bug in logic. Ask developer'
+        unless grep {$role eq $_} qw(member owner editor);
 
-    ## Process the lines
-    local $RS;
-    my $data = <L>;
+    my $file = $self->{'dir'} . '/' . $role . '.dump';
 
-    my @users;
-    foreach (split /\n\n/, $data) {
-        my (%user, $email);
-        $user{'email'} = $email = $1 if (/^\s*email\s+(.+)\s*$/om);
-        $user{'gecos'}       = $1 if (/^\s*gecos\s+(.+)\s*$/om);
-        $user{'date'}        = $1 if (/^\s*date\s+(\d+)\s*$/om);
-        $user{'update_date'} = $1 if (/^\s*update_date\s+(\d+)\s*$/om);
-        $user{'reception'}   = $1
-            if (
-            /^\s*reception\s+(digest|nomail|summary|notice|txt|html|urlize|not_me)\s*$/om
-            );
-        $user{'visibility'} = $1
-            if (/^\s*visibility\s+(conceal|noconceal)\s*$/om);
+    # Open the file and switch to paragraph mode.
+    my $lock_fh = Sympa::LockedFile->new($file, 5, '<') or return;
+    local $RS = '';
 
-        push @users, \%user;
+    my $user;
+    while (my $para = <$lock_fh>) {
+        if ($role eq 'member') {
+            $user = {
+                map {
+                    #FIMXE:Define appropriate schema.
+                    if (/^\s*email\s+(.+)\s*$/) {
+                        (email => $1);
+                    } elsif (/^\s*gecos\s+(.+)\s*$/) {
+                        (gecos => $1);
+                    } elsif (/^\s*date\s+(\d+)\s*$/) {
+                        (date => $1);
+                    } elsif (/^\s*update_date\s+(\d+)\s*$/) {
+                        (update_date => $1);
+                    } elsif (
+                        /^\s*reception\s+(digest|nomail|summary|notice|txt|html|urlize|not_me)\s*$/
+                        ) {
+                        (reception => $1);
+                    } elsif (/^\s*visibility\s+(conceal|noconceal)\s*$/) {
+                        (visibility => $1);
+                    } else {
+                        ();
+                    }
+                    } split /\n/, $para
+            };
+        } else {
+            my $r;
+            $user = {
+                map {
+                    #FIMXE:Define appropriate schema.
+                    if (/^\s*role\s+(owner|editor)\s*$/) {
+                        $r = $1;
+                        ();
+                    } elsif (/^\s*email\s+(.+)\s*$/) {
+                        (email => $1);
+                    } elsif (/^\s*gecos\s+(.+)\s*$/) {
+                        (gecos => $1);
+                    } elsif (/^\s*profile\s+(normal|privileged)\s*$/) {
+                        (gecos => $1);
+                    } elsif (/^\s*date\s+(\d+)\s*$/) {
+                        (date => $1);
+                    } elsif (/^\s*update_date\s+(\d+)\s*$/) {
+                        (update_date => $1);
+                    } elsif (
+                        /^\s*reception\s+(mail|nomail)\s*$/
+                        ) {
+                        (reception => $1);
+                    } elsif (/^\s*visibility\s+(conceal|noconceal)\s*$/) {
+                        (visibility => $1);
+                    } elsif (/^\s*info\s+(.+)\s*$/) {
+                        (info => $1);
+                    } elsif (/^\s*subscribed\s+(\S+)\s*$/) {
+                        (subscribed => !!$1);
+                    } elsif (/^\s*included\s+(\S+)*$/) {
+                        (included => !!$1);
+                    } elsif (/^\s*id\s+(.+)*$/) {
+                        (id => $1);
+                    } else {
+                        ();
+                    }
+                    } split /\n/, $para
+            };
+            next unless $r and $r eq $role;
+        }
+        next unless %$user;
+
+        if ($role eq 'member') {
+            $self->add_list_member($user);
+        } else {
+            $self->add_list_admin($role, $user);
+        }
     }
-    close(L);
+    $lock_fh->close;
 
-    return @users;
 }
 
 ## include a remote sympa list as subscribers.

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -728,18 +728,17 @@ sub dump_user {
     }
 
     if ($role eq 'member') {
+        my %map_field = _map_list_member_cols();
+
         my $user;
         for (
             $user = $self->get_first_list_member();
             $user;
             $user = $self->get_next_list_member()
             ) {
-            foreach my $k (
-                qw(date update_date email gecos
-                reception visibility)) {
+            foreach my $k (sort keys %map_field) {
                 printf $lock_fh "%s %s\n", $k, $user->{$k}
                     if defined $user->{$k} and length $user->{$k};
-    
             }
             print $lock_fh "\n";
         }
@@ -4383,80 +4382,54 @@ sub suck_user {
     my $lock_fh = Sympa::LockedFile->new($file, 5, '<') or return;
     local $RS = '';
 
-    my $user;
-    while (my $para = <$lock_fh>) {
-        if ($role eq 'member') {
-            $user = {
-                map {
-                    #FIMXE:Define appropriate schema.
-                    if (/^\s*email\s+(.+)\s*$/) {
-                        (email => $1);
-                    } elsif (/^\s*gecos\s+(.+)\s*$/) {
-                        (gecos => $1);
-                    } elsif (/^\s*date\s+(\d+)\s*$/) {
-                        (date => $1);
-                    } elsif (/^\s*update_date\s+(\d+)\s*$/) {
-                        (update_date => $1);
-                    } elsif (
-                        /^\s*reception\s+(digest|nomail|summary|notice|txt|html|urlize|not_me)\s*$/
-                        ) {
-                        (reception => $1);
-                    } elsif (/^\s*visibility\s+(conceal|noconceal)\s*$/) {
-                        (visibility => $1);
-                    } else {
-                        ();
-                    }
-                    } split /\n/, $para
-            };
-        } else {
-            my $r;
-            $user = {
-                map {
-                    #FIMXE:Define appropriate schema.
-                    if (/^\s*role\s+(owner|editor)\s*$/) {
-                        $r = $1;
-                        ();
-                    } elsif (/^\s*email\s+(.+)\s*$/) {
-                        (email => $1);
-                    } elsif (/^\s*gecos\s+(.+)\s*$/) {
-                        (gecos => $1);
-                    } elsif (/^\s*profile\s+(normal|privileged)\s*$/) {
-                        (gecos => $1);
-                    } elsif (/^\s*date\s+(\d+)\s*$/) {
-                        (date => $1);
-                    } elsif (/^\s*update_date\s+(\d+)\s*$/) {
-                        (update_date => $1);
-                    } elsif (
-                        /^\s*reception\s+(mail|nomail)\s*$/
-                        ) {
-                        (reception => $1);
-                    } elsif (/^\s*visibility\s+(conceal|noconceal)\s*$/) {
-                        (visibility => $1);
-                    } elsif (/^\s*info\s+(.+)\s*$/) {
-                        (info => $1);
-                    } elsif (/^\s*subscribed\s+(\S+)\s*$/) {
-                        (subscribed => !!$1);
-                    } elsif (/^\s*included\s+(\S+)*$/) {
-                        (included => !!$1);
-                    } elsif (/^\s*id\s+(.+)*$/) {
-                        (id => $1);
-                    } else {
-                        ();
-                    }
-                    } split /\n/, $para
-            };
-            next unless $r and $r eq $role;
-        }
-        next unless %$user;
+    if ($role eq 'member') {
+        my %map_field = _map_list_member_cols();
 
-        if ($role eq 'member') {
+        while (my $para = <$lock_fh>) {
+            my $user = {
+                map {
+                    #FIMXE: Define appropriate schema.
+                    if (/^\s*(suspend|subscribed|included)\s+(\S+)\s*$/) {
+                        ($1 => !!$2);
+                    } elsif (/^\s*(date|update_date|startdate|enddate|bounce_score|number_messages)\s+(\d+)\s*$/
+                        or /^\s*(reception)\s+(mail|digest|nomail|summary|notice|txt|html|urlize|not_me)\s*$/
+                        or /^\s*(visibility)\s+(conceal|noconceal)\s*$/
+                        or (/^\s*(\w+)\s+(.+)\s*$/ and $map_field{$1})) {
+                        ($1 => $2);
+                    } else {
+                        ();
+                    }
+                    } split /\n/, $para
+            };
+            next unless $user->{email};
+
             $self->add_list_member($user);
-        } else {
+        }
+    } else {
+        while (my $para = <$lock_fh>) {
+            my $user = {
+                map {
+                    #FIMXE:Define appropriate schema.
+                    if (/^\s*(subscribed|included)\s+(\S+)\s*$/) {
+                        ($1 => !!$2);
+                    } elsif (/^\s*(email|gecos|info|id)\s+(.+)\s*$/
+                        or /^\s*(profile)\s+(normal|privileged)\s*$/
+                        or /^\s*(date|update_date)\s+(\d+)\s*$/
+                        or /^\s*(reception)\s+(mail|nomail)\s*$/
+                        or /^\s*(visibility)\s+(conceal|noconceal)\s*$/) {
+                        ($1 => $2);
+                    } else {
+                        ();
+                    }
+                    } split /\n/, $para
+            };
+            next unless $user->{email};
+
             $self->add_list_admin($role, $user);
         }
     }
-    $lock_fh->close;
 
+    $lock_fh->close;
 }
 
 ## include a remote sympa list as subscribers.

--- a/src/lib/Sympa/Request/Handler/close_list.pm
+++ b/src/lib/Sympa/Request/Handler/close_list.pm
@@ -154,9 +154,10 @@ sub _close {
         Conf::get_robot_conf($list->{'domain'}, 'alias_manager'));
     $aliases->del($list) if $aliases;
 
-    # Dump subscribers.
-    $list->_save_list_members_file(
-        $list->{'dir'} . '/subscribers.closed.dump');
+    # Dump users.
+    $list->dump_user('member');
+    $list->dump_user('owner');
+    $list->dump_user('editor');
 
     ## Delete users
     my @users;

--- a/src/lib/Sympa/Request/Handler/close_list.pm
+++ b/src/lib/Sympa/Request/Handler/close_list.pm
@@ -155,9 +155,9 @@ sub _close {
     $aliases->del($list) if $aliases;
 
     # Dump users.
-    $list->dump_user('member');
-    $list->dump_user('owner');
-    $list->dump_user('editor');
+    $list->dump_users('member');
+    $list->dump_users('owner');
+    $list->dump_users('editor');
 
     ## Delete users
     my @users;

--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -221,9 +221,9 @@ sub _move {
     my $aliases = Sympa::Aliases->new(
         Conf::get_robot_conf($current_list->{'domain'}, 'alias_manager'));
     $aliases->del($current_list) if $aliases;
-    $current_list->dump_user('member');
-    $current_list->dump_user('owner');
-    $current_list->dump_user('editor');
+    $current_list->dump_users('member');
+    $current_list->dump_users('owner');
+    $current_list->dump_users('editor');
 
     # Set list status to pending if creation list is moderated.
     # Save config file for the new() later to reload it.

--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -221,8 +221,9 @@ sub _move {
     my $aliases = Sympa::Aliases->new(
         Conf::get_robot_conf($current_list->{'domain'}, 'alias_manager'));
     $aliases->del($current_list) if $aliases;
-    $current_list->_save_list_members_file(
-        $current_list->{'dir'} . '/subscribers.closed.dump');
+    $current_list->dump_user('member');
+    $current_list->dump_user('owner');
+    $current_list->dump_user('editor');
 
     # Set list status to pending if creation list is moderated.
     # Save config file for the new() later to reload it.

--- a/src/lib/Sympa/Request/Handler/open_list.pm
+++ b/src/lib/Sympa/Request/Handler/open_list.pm
@@ -100,9 +100,9 @@ sub _twist {
         }
     }
     # Load permanent users.
-    $list->suck_user('member');
-    $list->suck_user('owner');
-    $list->suck_user('editor');
+    $list->restore_users('member');
+    $list->restore_users('owner');
+    $list->restore_users('editor');
     # Load initial transitional owners/editors from external data sources.
     if ($mode eq 'install') {
         $list->sync_include_admin;

--- a/src/lib/Sympa/Request/Handler/open_list.pm
+++ b/src/lib/Sympa/Request/Handler/open_list.pm
@@ -25,6 +25,7 @@ package Sympa::Request::Handler::open_list;
 
 use strict;
 use warnings;
+use English qw(-no_match_vars);
 use File::Path qw();
 
 use Sympa;
@@ -80,16 +81,32 @@ sub _twist {
         return undef;
     }
 
-    unless (-f $list->{'dir'} . '/subscribers.closed.dump') {
-        $log->syslog('notice', 'No subscribers to restore');
-    }
-    my @users = Sympa::List::_load_list_members_file(
-        $list->{'dir'} . '/subscribers.closed.dump');
-    # Insert users in database.
-    $list->add_list_member(@users);
+    # Dump initial permanent owners/editors in config file.
+    if ($mode eq 'install') {
+        my ($fh, $fh_config);
+        foreach my $role (qw(owner editor)) {
+            my $file   = $list->{'dir'} . '/' . $role . '.dump';
+            my $config = $list->{'dir'} . '/config';
 
-    # Restore admins
-    $list->sync_include_admin;
+            if (    !-e $file
+                and open($fh,        '>', $file)
+                and open($fh_config, '<', $config)) {
+                local $RS = '';    # read paragraph by each
+                my $admins = join '', grep {/\A\s*$role\b/} <$fh_config>;
+                print $fh $admins;
+                close $fh;
+                close $fh_config;
+            }
+        }
+    }
+    # Load permanent users.
+    $list->suck_user('member');
+    $list->suck_user('owner');
+    $list->suck_user('editor');
+    # Load initial transitional owners/editors from external data sources.
+    if ($mode eq 'install') {
+        $list->sync_include_admin;
+    }
 
     # Install new aliases.
     my $aliases = Sympa::Aliases->new(

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -751,7 +751,7 @@ sub upgrade {
                     and rename $list->{'dir'} . '/subscribers',
                     $list->{'dir'} . '/member.dump'
                     ) {
-                    $list->suck_user('member');
+                    $list->restore_users('member');
 
                     my $total = $list->{'add_outcome'}{'added_members'};
                     if (defined $list->{'add_outcome'}{'errors'}) {

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -746,30 +746,29 @@ sub upgrade {
                     $list->{'name'}
                 );
 
-                my @users = Sympa::List::_load_list_members_file(
-                    "$list->{'dir'}/subscribers");
+                # Load <list dir>/subscribers to the DB
+                if (-e $list->{'dir'} . '/subscribers'
+                    and rename $list->{'dir'} . '/subscribers',
+                    $list->{'dir'} . '/member.dump'
+                    ) {
+                    $list->suck_user('member');
+
+                    my $total = $list->{'add_outcome'}{'added_members'};
+                    if (defined $list->{'add_outcome'}{'errors'}) {
+                        $log->syslog('err', 'Failed to add users: %s',
+                            $list->{'add_outcome'}{'errors'}
+                                {'error_message'});
+                    }
+                    $log->syslog('notice',
+                        '%d subscribers have been loaded into the database',
+                        $total);
+                }
 
                 $list->{'admin'}{'user_data_source'} = 'include2';
 
-                ## Add users to the DB
-                $list->add_list_member(@users);
-                my $total = $list->{'add_outcome'}{'added_members'};
-                if (defined $list->{'add_outcome'}{'errors'}) {
-                    $log->syslog(
-                        'err',
-                        'Failed to add users: %s',
-                        $list->{'add_outcome'}{'errors'}{'error_message'}
-                    );
-                }
-
-                $log->syslog('notice',
-                    '%d subscribers have been loaded into the database',
-                    $total);
-
                 unless ($list->save_config('automatic')) {
                     $log->syslog('err',
-                        'Failed to save config file for list %s',
-                        $list->{'name'});
+                        'Failed to save config file for list %s', $list);
                 }
             } elsif ($list->{'admin'}{'user_data_source'} eq 'database') {
 
@@ -943,7 +942,7 @@ sub upgrade {
             'task_manager_pidfile' => 'No more used',
             'archived_pidfile'     => 'No more used',
             'bounced_pidfile'      => 'No more used',
-            'use_fast_cgi'         => 'No longer used', # 6.2.25b deprecated
+            'use_fast_cgi'         => 'No longer used',   # 6.2.25b deprecated
         );
 
         ## Set language of new file content
@@ -1773,6 +1772,38 @@ sub upgrade {
                 _get_canonical_read_date($sdm, 'update_admin')
             )
         );
+
+        $log->syslog('notice', 'Upgrading user dumps of closed lists.');
+        # Upgrading user dumps of closed lists.
+        my $lists =
+            Sympa::List::get_lists('*',
+            filter => [status => 'closed|family_closed']);
+        foreach my $list (@{$lists || []}) {
+            my $dir = $list->{'dir'};
+
+            if (-e $dir . '/subscribers.closed.dump') {
+                unlink $dir . '/member.dump.old';
+                rename $dir . '/member.dump', $dir . '/member.dump.old';
+                rename $dir . '/subscribers.closed.dump',
+                    $dir . '/member.dump';
+            }
+
+            my ($fh, $fh_config);
+            foreach my $role (qw(owner editor)) {
+                my $file   = $list->{'dir'} . '/' . $role . '.dump';
+                my $config = $list->{'dir'} . '/config';
+
+                if (!-e $file
+                    and open($fh, '>', $file)
+                    and open($fh_config, '<', $config)) {
+                    local $RS = '';     # read paragraph by each
+                    my $admins = join '', grep {/\A\s*$role\b/} <$fh_config>;
+                    print $fh $admins;
+                    close $fh;
+                    close $fh_config;
+                }
+            }
+        }
     }
 
     # GH Issue #240: PostgreSQL: Unable to edit owners/subscribers.

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -60,7 +60,7 @@ srand(time());
 my %options;
 unless (
     GetOptions(
-        \%main::options,        'dump=s',
+        \%main::options,        'dump:s',
         'debug|d',              'log_level=s',
         'config|f=s',           'lang|l=s',
         'mail|m',               'help|h',
@@ -83,6 +83,7 @@ unless (
         'conf_2_db',            'export_list',
         'health_check',         'send_digest',
         'keep_digest',          'upgrade_config_location',
+        'role=s',               'suck',
     )
     ) {
     pod2usage(-exitval => 1, -output => \*STDERR);
@@ -280,33 +281,114 @@ unless (Conf::checkfiles()) {
 }
 
 # Daemon called for dumping subscribers list
-if ($main::options{'dump'}) {
+if (defined $main::options{'dump'}) {
+    my $all_lists;
 
-    my ($all_lists, $list);
-    if ($main::options{'dump'} eq 'ALL') {
-        $all_lists = Sympa::List::get_lists('*');
-    } else {
+    # Compat. for old style "--dump=LIST".
+    my $list_id =
+        (length $main::options{'dump'})
+        ? $main::options{'dump'}
+        : $main::options{'list'};
 
-        ## The parameter can be a list address
-        unless ($main::options{'dump'} =~ /\@/) {
-            $log->syslog('err', 'Incorrect list address %s',
-                $main::options{'dump'});
-
-            exit;
+    if (defined $list_id and $list_id eq 'ALL') {
+        $all_lists =
+            Sympa::List::get_lists('*', filter => [status => 'open']);
+    } elsif (defined $list_id and length $list_id) {
+        # The parameter is list ID and list have to be open.
+        unless (0 < index $list_id, '@') {
+            $log->syslog('err', 'Incorrect list address %s', $list_id);
+            exit 1;
         }
-
-        my $list = Sympa::List->new($main::options{'dump'});
+        my $list = Sympa::List->new($list_id);
         unless (defined $list) {
-            $log->syslog('err', 'Unknown list %s', $main::options{'dump'});
-
-            exit;
+            $log->syslog('err', 'Unknown list %s', $list_id);
+            exit 1;
         }
-        push @$all_lists, $list;
+        unless ($list->{'admin'}{'status'} eq 'open') {
+            $log->syslog('err', 'List is not open: %s', $list);
+            exit 1;
+        }
+
+        $all_lists = [$list];
+    } else {
+        $log->syslog('err', 'No lists specified');
+        exit 1;
+    }
+
+    my @roles = qw(member);
+    if ($main::options{'role'}) {
+        my %roles = map { ($_ => 1) }
+            ($main::options{'role'} =~ /\b(member|owner|editor)\b/g);
+        @roles = sort keys %roles;
+        unless (@roles) {
+            $log->syslog('err', 'Unknown role %s', $main::options{'role'});
+            exit 1;
+        }
     }
 
     foreach my $list (@$all_lists) {
-        unless ($list->dump_user('member')) {
-            print STDERR "Could not dump list(s)\n";
+        foreach my $role (@roles) {
+            unless ($list->dump_user($role)) {
+                printf STDERR "%s: Could not dump list users (%s)\n",
+                    $list->get_id, $role;
+            } else {
+                printf STDERR "%s: Dumped list users (%s)\n",
+                    $list->get_id, $role;
+            }
+        }
+    }
+
+    exit 0;
+} elsif ($main::options{'suck'}) {
+    my $all_lists;
+
+    my $list_id = $main::options{'list'};
+
+    if (defined $list_id and $list_id eq 'ALL') {
+        $all_lists =
+            Sympa::List::get_lists('*', filter => [status => 'open']);
+    } elsif (defined $list_id and length $list_id) {
+        # The parameter is list ID and list have to be open.
+        unless (0 < index $list_id, '@') {
+            $log->syslog('err', 'Incorrect list address %s', $list_id);
+            exit 1;
+        }
+        my $list = Sympa::List->new($list_id);
+        unless (defined $list) {
+            $log->syslog('err', 'Unknown list %s', $list_id);
+            exit 1;
+        }
+        unless ($list->{'admin'}{'status'} eq 'open') {
+            $log->syslog('err', 'List is not open: %s', $list);
+            exit 1;
+        }
+
+        $all_lists = [$list];
+    } else {
+        $log->syslog('err', 'No lists specified');
+        exit 1;
+    }
+
+    my @roles = qw(member);
+    if ($main::options{'role'}) {
+        my %roles = map { ($_ => 1) }
+            ($main::options{'role'} =~ /\b(member|owner|editor)\b/g);
+        @roles = sort keys %roles;
+        unless (@roles) {
+            $log->syslog('err', 'Unknown role %s', $main::options{'role'});
+            exit 1;
+        }
+    }
+
+    foreach my $list (@$all_lists) {
+        foreach my $role (@roles) {
+            unless ($list->suck_user($role)) {
+                printf STDERR "%s: Could not suck list users (%s)\n",
+                    $list->get_id, $role;
+            } else {
+                printf STDERR "%s: Sucked list users (%s)\n",
+                    $list->get_id, $role;
+            }
         }
     }
 
@@ -1080,7 +1162,8 @@ S<[ C<--import>=I<listname> ]>
 S<[ C<--close_list>=I<list>[I<@robot>] ]>
 S<[ C<--purge_list>=I<list>[I<@robot>] ]>
 S<[ C<--lowercase> ]> S<[ C<--make_alias_file> ]>
-S<[ C<--dump>=I<listname> | ALL ]>
+S<[ C<--dump> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
+S<[ C<--suck> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
 
 =head1 DESCRIPTION
 
@@ -1151,13 +1234,19 @@ C<--input_file=>I</path/to/file.xml >
 
 Create a list with the XML file under robot robot_name.
 
-=item C<--dump=>I<list>@I<dom>|C<ALL>
+=item C<--dump> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
 
-Dumps subscribers of for `listname' list or all lists. Subscribers are 
-dumped in F<member.dump>.
+Dumps users of a list or all lists.
 
-Note: On Sympa prior to 6.2.25b.2, subscribers were dumped in
-F<subscribers.db.dump>.
+C<--role> may specify C<member>, C<owner>, C<editor> or any of them separated
+by comma (C<,>). Only C<member> is chosen by default.
+
+Users are dumped in files I<role>C<.dump> in each list directory.
+
+Note: On Sympa prior to 6.2.31b.1, subscribers were dumped in
+F<subscribers.db.dump> file, and owners and moderators could not be dumped.
+
+See also C<--suck>.
 
 =begin comment
 
@@ -1237,6 +1326,12 @@ Renames a list or move it to another virtual robot.
 
 Send digest right now.
 If C<--keep_digest> is specified, stocked digest will not be removed.
+
+=item C<--suck> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
+
+Restore users from files dumped by C<--dump>.
+
+Note: This option was added on Sympa 6.2.32.
 
 =item C<--sync_include=>I<listname>@I<robot>
 

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -305,7 +305,7 @@ if ($main::options{'dump'}) {
     }
 
     foreach my $list (@$all_lists) {
-        unless ($list->dump()) {
+        unless ($list->dump_user('member')) {
             print STDERR "Could not dump list(s)\n";
         }
     }
@@ -1154,7 +1154,10 @@ Create a list with the XML file under robot robot_name.
 =item C<--dump=>I<list>@I<dom>|C<ALL>
 
 Dumps subscribers of for `listname' list or all lists. Subscribers are 
-dumped in subscribers.db.dump.
+dumped in F<member.dump>.
+
+Note: On Sympa prior to 6.2.25b.2, subscribers were dumped in
+F<subscribers.db.dump>.
 
 =begin comment
 

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -60,7 +60,7 @@ srand(time());
 my %options;
 unless (
     GetOptions(
-        \%main::options,        'dump:s',
+        \%main::options,        'dump=s',
         'debug|d',              'log_level=s',
         'config|f=s',           'lang|l=s',
         'mail|m',               'help|h',
@@ -83,7 +83,8 @@ unless (
         'conf_2_db',            'export_list',
         'health_check',         'send_digest',
         'keep_digest',          'upgrade_config_location',
-        'role=s',               'suck',
+        'role=s',               'dump_users',
+        'restore_users',
     )
     ) {
     pod2usage(-exitval => 1, -output => \*STDERR);
@@ -281,14 +282,11 @@ unless (Conf::checkfiles()) {
 }
 
 # Daemon called for dumping subscribers list
-if (defined $main::options{'dump'}) {
+if ($main::options{'dump'} or $main::options{'dump_users'}) {
     my $all_lists;
 
     # Compat. for old style "--dump=LIST".
-    my $list_id =
-        (length $main::options{'dump'})
-        ? $main::options{'dump'}
-        : $main::options{'list'};
+    my $list_id = $main::options{'dump'} || $main::options{'list'};
 
     if (defined $list_id and $list_id eq 'ALL') {
         $all_lists =
@@ -328,7 +326,7 @@ if (defined $main::options{'dump'}) {
 
     foreach my $list (@$all_lists) {
         foreach my $role (@roles) {
-            unless ($list->dump_user($role)) {
+            unless ($list->dump_users($role)) {
                 printf STDERR "%s: Could not dump list users (%s)\n",
                     $list->get_id, $role;
             } else {
@@ -339,7 +337,7 @@ if (defined $main::options{'dump'}) {
     }
 
     exit 0;
-} elsif ($main::options{'suck'}) {
+} elsif ($main::options{'restore_users'}) {
     my $all_lists;
 
     my $list_id = $main::options{'list'};
@@ -382,11 +380,11 @@ if (defined $main::options{'dump'}) {
 
     foreach my $list (@$all_lists) {
         foreach my $role (@roles) {
-            unless ($list->suck_user($role)) {
-                printf STDERR "%s: Could not suck list users (%s)\n",
+            unless ($list->restore_users($role)) {
+                printf STDERR "%s: Could not restore list users (%s)\n",
                     $list->get_id, $role;
             } else {
-                printf STDERR "%s: Sucked list users (%s)\n",
+                printf STDERR "%s: Restored list users (%s)\n",
                     $list->get_id, $role;
             }
         }
@@ -1162,8 +1160,8 @@ S<[ C<--import>=I<listname> ]>
 S<[ C<--close_list>=I<list>[I<@robot>] ]>
 S<[ C<--purge_list>=I<list>[I<@robot>] ]>
 S<[ C<--lowercase> ]> S<[ C<--make_alias_file> ]>
-S<[ C<--dump> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
-S<[ C<--suck> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
+S<[ C<--dump_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
+S<[ C<--restore_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
 
 =head1 DESCRIPTION
 
@@ -1234,7 +1232,11 @@ C<--input_file=>I</path/to/file.xml >
 
 Create a list with the XML file under robot robot_name.
 
-=item C<--dump> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
+=item C<--dump=>I<list>@I<domain>|C<ALL>
+
+Obsoleted option.  Use C<--dump_users>.
+
+=item C<--dump_users> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
 
 Dumps users of a list or all lists.
 
@@ -1246,7 +1248,9 @@ Users are dumped in files I<role>C<.dump> in each list directory.
 Note: On Sympa prior to 6.2.31b.1, subscribers were dumped in
 F<subscribers.db.dump> file, and owners and moderators could not be dumped.
 
-See also C<--suck>.
+See also C<--restore_users>.
+
+Note: This option replaced C<--dump> on Sympa 6.2.34.
 
 =begin comment
 
@@ -1327,11 +1331,11 @@ Renames a list or move it to another virtual robot.
 Send digest right now.
 If C<--keep_digest> is specified, stocked digest will not be removed.
 
-=item C<--suck> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
+=item C<--restore_users> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
 
-Restore users from files dumped by C<--dump>.
+Restore users from files dumped by C<--dump_users>.
 
-Note: This option was added on Sympa 6.2.32.
+Note: This option was added on Sympa 6.2.34.
 
 =item C<--sync_include=>I<listname>@I<robot>
 


### PR DESCRIPTION
Changes:
  - If list is closed, members, owners and editors are dumped to files `member.dump`, `owner.dump` and `editor.dump` in `EXPLDIR/`_list path_`/` directory.  On previous versions, only members were dumped and file name was `subscriber.closed.dump`.

Improvements:
  - New and improved options for `sympa.pl`:
      - ~~`--dump`~~ `--dump_users` dumps list members/owners/editors to file under list directory.
      - ~~`--suck`~~ `--restore_users` restores list members/owners/editor from this file.  This is the new option.
  - Note that dump files are the same as those created when list is closed.  ~~`--dump`~~`--dump_users` and ~~`--suck`~~`--restore_users` work only on open list and closed/pending lists are omitted.    On previous versions of Sympa, only members were dumped and file name was `subscriber.db.dump`.

Fixed bug:
  - If a list is closed once and then reopened, list members are registered as permanent (not included) members. Also, subscription suspension option are cleared and so on.

This PR may fix issue #232.

----
2018-04-21 Update: Renamed functions.