### PR TITLE
#11: Spurious error on duplicate keys with admin sync, and changes on configuration for owners/moderators

### DIFF
--- a/default/web_tt2/edit.tt2
+++ b/default/web_tt2/edit.tt2
@@ -1,0 +1,110 @@
+<!-- edit.tt2 -->
+<h2>
+[% IF role == 'owner' ~%]
+  [%|loc%]Owner[%END%]
+[%~ ELSIF role == 'editor' ~%]
+  [%|loc%]Moderator[%END%]
+[%~ ELSE ~%]
+  [% RETURN %]
+[%~ END %]
+</h2>
+
+<form action="[% path_cgi %]" method="post">
+<fieldset>
+[% SET pV = config_values.${role}.0 ~%]
+
+  <input type="hidden" name="previous_action" value="[% previous_action %]" />
+  <input type="hidden" name="list" value="[% list %]" />
+  <input type="hidden" name="role" value="[% role %]" />
+  <input type="hidden" name="email" value="[% pV.email %]" />
+
+<div class="row">
+
+<div class="columns">
+  <label for="email">[%|loc%]Email:[%END%]  </label>
+  [% pV.email %]
+</div>
+
+<div class="columns">
+  <label for="gecos">[%|loc%]Name:[%END%]  </label>
+  <input type="text" name="single_param.[% role %].0.gecos" id="gecos"
+   value="[% pV.gecos %]" size="25" />
+</div>
+
+[% IF is_privileged_owner ~%]
+  <div class="columns">
+    <label for="info">[%|loc%]private information[%END%]  </label>
+    <input type="text" name="single_param.[% role %].0.info" id="info"
+     value="[% pV.info %]" size="30" />
+  </div>
+[%~ END %]
+
+[% IF role == 'owner' ~%]
+  <div class="columns">
+    <label for="profile">[%|loc%]profile[%END%]  </label>
+    [% IF is_listmaster ~%]
+      <select name="single_param.[% role %].0.profile" id="profile">
+      [% FOREACH r = ['normal', 'privileged'] ~%]
+        <option value="[% r %]"
+         [%~ IF r == pV.profile %] selected="selected"[% END ~%]
+        >
+        [%~ r | optdesc ~%]
+        </option>
+      [% END %]
+      </select>
+    [%~ ELSE  ~%]
+      [% pV.profile | optdesc %]
+    [%~ END %]
+  </div>
+[%~ END %]
+
+<div class="columns">
+  <label for="reception">[%|loc%]Receiving:[%END%]  </label>
+  <select name="single_param.[% role %].0.reception" id="reception">
+  [% FOREACH r = ['mail', 'nomail'] ~%]
+    <option value="[% r %]"
+     [%~ IF r == pV.reception %] selected="selected"[% END ~%]
+    >
+    [%~ r | optdesc ~%]
+    </option>
+  [% END %]
+  </select>
+</div>
+
+<div class="columns">
+  <label for="visibility">[%|loc%]Visibility:[%END%]  </label>
+  <select id="visibility" name="single_param.[% role %].0.visibility">
+  [% FOREACH r = ['noconceal', 'conceal'] ~%]
+    <option value="[% r %]"
+     [%~ IF r == pV.visibility %] selected="selected"[% END ~%]
+    >
+    [%~ r | optdesc ~%]
+    </option>
+  [% END %]
+  </select>
+</div>
+
+<div class="columns">
+  <label>[%|loc%]Delegated since:[%END%] </label>
+  [% pV.date | optdesc('unixtime') %]
+</div>
+
+<div class="columns">
+  <label>[%|loc%]Last update:[%END%] </label>
+  [% pV.update_date | optdesc('unixtime') %]
+</div>
+
+[% IF is_privileged_owner ~%]
+  <input type="hidden" name="submit" value="submit" />
+  <div class="columns">
+    <input class="MainMenuLinks" type="submit" name="action_edit"
+     value="[%|loc%]Update[%END%]" />
+  </div>
+[%~ END %]
+
+</div>
+
+</fieldset>
+</form>
+
+<!-- end edit.tt2 -->

--- a/default/web_tt2/info.tt2
+++ b/default/web_tt2/info.tt2
@@ -56,7 +56,12 @@
         <div class="item_content">
           <a class="item_title" href="[% 'admin' | url_rel([list]) %]"><i class="fa fa-wrench fa-3x pull-left fa-border"></i> [%|loc%]List Configuration[%END%]</a>
           <ul class="fa-ul">
-            <li><i class="fa-li fa fa-arrow-right"></i><a href="[% 'edit_list_request' | url_rel([list,'description']) %]">[%|loc%]Modify owners or moderators (editors)[%END%]</a></li>
+            <li>
+              <i class="fa-li fa fa-arrow-right"></i>
+              <a href="[% 'review' | url_rel([list,'owner']) %]">
+                [%|loc%]Modify owners or moderators (editors)[%END%]
+              </a>
+            </li>
             <li><i class="fa-li fa fa-arrow-right"></i><a href="[% 'edit_list_request' | url_rel([list,'description']) %]">[%|loc%]Modify list subject and visibility[%END%]</a></li>
             <li><i class="fa-li fa fa-arrow-right"></i><a href="[% 'edit_list_request' | url_rel([list,'sending']) %]">[%|loc%]Change who can post to this list[%END%]</a></li>
             <li><i class="fa-li fa fa-arrow-right"></i><a href="[% 'edit_list_request' | url_rel([list,'command']) %]">[%|loc%]Change who can (un)subscribe and view list information[%END%]</a></li>

--- a/default/web_tt2/list_panel.tt2
+++ b/default/web_tt2/list_panel.tt2
@@ -43,7 +43,10 @@
 
     [% IF is_priv %]
       <span>
-        <a href="[% 'edit_list_request' | url_rel([list,'description'],{},'owner') %]"><i class="fa fa-pencil-square fa-lg" title="[%|loc%](Edit)[%END%]"></i></a>
+        <a href="[% 'review' | url_rel([list,'owner']) %]">
+          <i class="fa fa-pencil-square fa-lg" title="[%|loc%](Edit)[%END%]">
+          </i>
+        </a>
       </span>
     [% END %]
   </span>
@@ -78,7 +81,10 @@
 
     [% IF is_priv %]
       <span>
-        <a href="[% 'edit_list_request' | url_rel([list,'description'],{},'editor') %]"><i class="fa fa-pencil-square fa-lg" title="[%|loc%](Edit)[%END%]"></i></a>
+        <a href="[% 'review' | url_rel([list,'editor']) %]">
+          <i class="fa fa-pencil-square fa-lg" title="[%|loc%](Edit)[%END%]">
+          </i>
+        </a>
       </span>
     [% END %]
   </span>

--- a/default/web_tt2/nav.tt2
+++ b/default/web_tt2/nav.tt2
@@ -141,10 +141,30 @@
              <li class="[% class %]"><a href="[% 'edit_list_request' | url_rel([list,'other']) %]" >[%|loc%]Miscellaneous[%END%]</a></li>
           </ul>
     </li>
-[% IF is_owner %]
-[% IF action == 'review' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-    <li class="[% class %]"><a  href="[% 'review' | url_rel([list]) %]">[%|loc%]Manage Subscribers[%END%]</a></li>
-[% END %]
+  [% IF is_owner ~%]
+    <li class="has-dropdown [% IF action == 'review' %]active[%END%]">
+      <a href="#">
+        [%|loc%]Users[%END%]
+      </a>
+      <ul class="dropdown">
+        <li [% IF page.match('^\d+$') %]class="active"[%END%]>
+          <a  href="[% 'review' | url_rel([list]) %]" >
+            [%|loc%]Subscribers[%END%]
+          </a>
+        </li>
+        <li [% IF page == 'owner' %]class="active"[%END%]>
+          <a  href="[% 'review' | url_rel([list,'owner']) %]" >
+            [%|loc%]Owners[%END%]
+          </a>
+        </li>
+        <li [% IF page == 'editor' %]class="active"[%END%]>
+          <a  href="[% 'review' | url_rel([list,'editor']) %]" >
+            [%|loc%]Editors[%END%]
+          </a>
+        </li>
+      </ul>
+    </li>
+  [%~ END %]
 [% IF conf.use_blacklist != 'none' %]
 [% IF action == 'blacklist' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
     <li class="[% class %]"><a  href="[% 'blacklist' | url_rel([list]) %]" >[%|loc%]Blacklist[%END%]</a></li>

--- a/default/web_tt2/review.tt2
+++ b/default/web_tt2/review.tt2
@@ -4,9 +4,11 @@
   [% PROCESS ReviewMembers ~%]
 [%~ ELSIF page == 'owner' ~%]
   [% PROCESS ReviewUsers
+     role = page
      users = owners %]
 [%~ ELSIF page == 'editor' ~%]
   [% PROCESS ReviewUsers
+     role = page
      users = editors %]
 [%~ END %]
 
@@ -218,11 +220,12 @@
 
 [%~ END #ReviewMembers %]
 
-[%~ BLOCK ReviewUsers # (users) ~%]
+[%~ BLOCK ReviewUsers # (role,users) ~%]
+
   <h2>
-  [% IF page == 'owner' ~%]
+  [% IF role == 'owner' ~%]
     [%|loc%]Owners[%END%]
-  [%~ ELSIF page == 'editor' ~%]
+  [%~ ELSIF role == 'editor' ~%]
     [%|loc%]Moderators[%END%]
   [%~ END %]
   </h2>
@@ -231,7 +234,7 @@
   <fieldset role="table">
   <input type="hidden" name="list" value="[% list %]" />
   <input type="hidden" name="action" value="review" />
-  <input type="hidden" name="page" value="[% page %]" />
+  <input type="hidden" name="page" value="[% role %]" />
 
   <div class="row" role="row">
   <div class="small-10 medium-11 columns">
@@ -278,16 +281,22 @@
       <div class="small-10 medium-11 columns" id="item.user.[% idx %]">
         <div class="small-6 medium-4 columns" role="cell">
           <span class="show-for-medium-up">
-          [%~ IF page == 'owner' && u.profile == 'privileged' ~%]
+          [%~ IF role == 'owner' && u.profile == 'privileged' ~%]
             <i class="fa fa-fw fa-star"
              title="[%|loc%]Privileged owner[%END%]"></i>
-          [%~ ELSIF page == 'owner' ~%]
+          [%~ ELSIF role == 'owner' ~%]
             <i class="fa fa-fw" title="[%|loc%]Owner[%END%]"></i>
-          [%~ ELSIF page == 'editor' ~%]
+          [%~ ELSIF role == 'editor' ~%]
             <i class="fa fa-fw" title="[%|loc%]Moderator[%END%]"></i>
           [%~ END %]
           </span>
-          [% u.email %]
+          [% IF is_privileged_owner ~%]
+            <a href="[% 'ajax/edit' | url_rel([list,role],{email=>u.email,previous_action=>action}) %]"
+             data-reveal-id="edit" data-reveal-ajax="true"
+             class="MainMenuLinks">[% u.email %]</a>
+          [%~ ELSE ~%]
+            [% u.email %]
+          [%~ END %]
         </div>
 
         <div class="small-6 medium-4 columns" role="cell">
@@ -333,26 +342,26 @@
   [%~ ELSE ~%]
     <p
      class="small-12 medium-8 medium-centered columns alert-box info text-center">
-    [% IF page == 'owner' ~%]
+    [% IF role == 'owner' ~%]
       [%|loc%]List has no owners[%END%]
-    [%~ ELSIF page == 'editor' ~%]
+    [%~ ELSIF role == 'editor' ~%]
       [%|loc%]List has no moderators[%END%]
     [%~ END %]
     </p>
   [%~ END %]
 
-  <h3>
-  [% IF page == 'owner' ~%]
-    [%|loc%]Add owners[%END%]
-  [%~ ELSIF page == 'editor' ~%]
-    [%|loc%]Add momderators[%END%]
-  [%~ END %]
-  </h3>
-
   [% IF is_privileged_owner ~%]
+    <h3>
+    [% IF role == 'owner' ~%]
+      [%|loc%]Add owners[%END%]
+    [%~ ELSIF role == 'editor' ~%]
+      [%|loc%]Add momderators[%END%]
+    [%~ END %]
+    </h3>
+
     <div class="row" id="item.user.0.new" role="row">
     <div class="small-10 medium-11 columns">
-      [% IF page == 'owner' ~%]
+      [% IF role == 'owner' ~%]
         <div class="columns show-for-medium-up" role="cell">
           <input type="checkbox"
            name="single_param.user.0.profile" id="param.user.0.profile"
@@ -401,6 +410,13 @@
 
   </fieldset>
   </form>
+
+  [%# AJAX modal dialog ~%]
+  <div id="edit" class="reveal-modal medium" data-reveal
+   aria-labelledby="[%|loc%]View user[%END%]" aria-hidden="true"
+   role="dialog">
+    [%# empty div that will display a content by AJAX. ~%]
+  </div>
 [%~ END#ReviewUsers ~%]
 
 <!-- end review.tt2 -->

--- a/default/web_tt2/review.tt2
+++ b/default/web_tt2/review.tt2
@@ -1,4 +1,17 @@
 <!-- review.tt2 -->
+
+[% IF page.match('^\d*$') ~%]
+  [% PROCESS ReviewMembers ~%]
+[%~ ELSIF page == 'owner' ~%]
+  [% PROCESS ReviewUsers
+     users = owners %]
+[%~ ELSIF page == 'editor' ~%]
+  [% PROCESS ReviewUsers
+     users = editors %]
+[%~ END %]
+
+[%~ BLOCK ReviewMembers # (members) ~%]
+
 [% IF is_owner %]
 <h2>[%|loc%]Manage list members[%END%] <a  href="[% 'nomenu/help/admin' | url_rel %]#manage_members" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=400,height=200')" target="wws_help"><i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i></a></h2>
 
@@ -202,4 +215,192 @@
 [% END %]
 
 [% END %]
+
+[%~ END #ReviewMembers %]
+
+[%~ BLOCK ReviewUsers # (users) ~%]
+  <h2>
+  [% IF page == 'owner' ~%]
+    [%|loc%]Owners[%END%]
+  [%~ ELSIF page == 'editor' ~%]
+    [%|loc%]Moderators[%END%]
+  [%~ END %]
+  </h2>
+
+  <form action="[% path_cgi %]" method="POST">
+  <fieldset role="table">
+  <input type="hidden" name="list" value="[% list %]" />
+  <input type="hidden" name="action" value="review" />
+  <input type="hidden" name="page" value="[% page %]" />
+
+  <div class="row" role="row">
+  <div class="small-10 medium-11 columns">
+    <div class="small-6 medium-4 columns" role="columnheader">
+      <label>[%|loc%]Email[%END%]</label>
+    </div>
+
+    <div class="small-6 medium-4 columns" role="columnheader">
+      <label>[%|loc%]Name[%END%]</label>
+    </div>
+
+    <div class="medium-2 columns show-for-medium-up" role="columnheader">
+      <label>[%|loc%]Reception[%END%]</label>
+    </div>
+
+    <div class="medium-2 columns show-for-medium-up" role="columnheader">
+      <label>[%|loc%]Visibility[%END%]</label>
+    </div>
+
+    [% IF is_privileged_owner ~%]
+      <div class="columns" role="columnheader">
+        <label>[%|loc%]private information[%END%]</label>
+      </div>
+    [%~ END %]
+
+    <div class="columns" role="separator"> 
+      <hr>
+    </div>
+  </div>
+
+  [% IF is_privileged_owner ~%]
+    <div class="small-2 medium-1 columns" role="columnheader">
+      <label title="[%|loc%]Delete[%END%]">
+        <i class="fa fa-user-times"></i>
+      </label>
+    </div>
+  [%~ END %]
+  </div>
+
+  [% IF users.size() ~%]
+    [% SET idx = 0 ~%]
+    [% FOREACH u = users ~%]
+      <div class="row" role="row">
+      <div class="small-10 medium-11 columns" id="item.user.[% idx %]">
+        <div class="small-6 medium-4 columns" role="cell">
+          <span class="show-for-medium-up">
+          [%~ IF page == 'owner' && u.profile == 'privileged' ~%]
+            <i class="fa fa-fw fa-star"
+             title="[%|loc%]Privileged owner[%END%]"></i>
+          [%~ ELSIF page == 'owner' ~%]
+            <i class="fa fa-fw" title="[%|loc%]Owner[%END%]"></i>
+          [%~ ELSIF page == 'editor' ~%]
+            <i class="fa fa-fw" title="[%|loc%]Moderator[%END%]"></i>
+          [%~ END %]
+          </span>
+          [% u.email %]
+        </div>
+
+        <div class="small-6 medium-4 columns" role="cell">
+          [% u.gecos || '&nbsp;' %]
+        </div>
+
+        <div class="medium-2 columns show-for-medium-up" role="cell">
+          [% u.reception | optdesc %]
+        </div>
+
+        <div class="medium-2 columns show-for-medium-up" role="cell">
+          [% u.visibility | optdesc %]
+        </div>
+
+        [% IF is_privileged_owner ~%]
+          <div class="columns" role="cell">
+            [% u.info %]
+          </div>
+        [%~ END %]
+
+        <div class="columns" role="separator"> 
+          <hr>
+        </div>
+      </div>
+
+      [% IF is_privileged_owner ~%]
+      <div class="small-2 medium-1 columns" role="cell">
+        [% IF u.subscribed ~%]
+          <input type="checkbox" name="del_emails"
+           id="del.user.[% idx %]"
+           class="fadeIfChecked" data-selector="#item\.user\.[% idx %]"
+           title="[%|loc%]Delete[%END%]"
+           value="[% u.email %]" />
+        [%~ ELSIF u.included ~%]
+          &nbspo;
+        [%~ END %]
+      </div>
+      [%~ END %]
+      </div>
+
+      [%~ SET idx = idx + 1 %]
+    [%~ END %]
+  [%~ ELSE ~%]
+    <p
+     class="small-12 medium-8 medium-centered columns alert-box info text-center">
+    [% IF page == 'owner' ~%]
+      [%|loc%]List has no owners[%END%]
+    [%~ ELSIF page == 'editor' ~%]
+      [%|loc%]List has no moderators[%END%]
+    [%~ END %]
+    </p>
+  [%~ END %]
+
+  <h3>
+  [% IF page == 'owner' ~%]
+    [%|loc%]Add owners[%END%]
+  [%~ ELSIF page == 'editor' ~%]
+    [%|loc%]Add momderators[%END%]
+  [%~ END %]
+  </h3>
+
+  [% IF is_privileged_owner ~%]
+    <div class="row" id="item.user.0.new" role="row">
+    <div class="small-10 medium-11 columns">
+      [% IF page == 'owner' ~%]
+        <div class="columns show-for-medium-up" role="cell">
+          <input type="checkbox"
+           name="single_param.user.0.profile" id="param.user.0.profile"
+           value="privileged" />
+          <label for="param.user.0.profile">[% 'privileged' | optdesc %]</label>
+        </div>
+      [%~ END %]
+
+      <div class="small-6 medium-4 columns" role="cell">
+        <label for="param.user.0.email">[%|loc%]Email[%END%]
+        <input type="text"
+         name="single_param.user.0.email" id="param.user.0.email" />
+      </div>
+
+      <div class="small-6 medium-4 columns" role="cell">
+        <label for="param.user.0.gecos">[%|loc%]Name[%END%]
+        <input name="single_param.user.0gecos" id="param.user.0.gecos" />
+      </div>
+
+      <div class="medium-2 columns show-for-medium-up" role="cell">
+        <input type="checkbox"
+         name="single_param.user.0.reception" id="param.user.0.reception"
+         value="nomail" />
+        <label for="param.user.0.reception">[% 'nomail' | optdesc %]</label>
+      </div>
+
+      <div class="medium-2 columns show-for-medium-up" role="cell">
+        <input type="checkbox"
+         name="single_param.user.0.visibility" id="param.user.0.visibility"
+         value="conceal" />
+        <label for="param.user.0.visibility">[% 'conceal' | optdesc %]</label>
+      </div>
+
+      <div class="columns" role="cell">
+        <label for="param.user.0.info">[%|loc%]private information[%END%]</label>
+        <input type="text"
+         name="single_param.user.0.info" id="param.user.0.info" />
+      </div>
+    </div>
+
+    </div>
+  [%~ END %]
+
+  <input class="MainMenuLInks" type="submit" name="action_review"
+   value="[%|loc%]Update[%END%]" />
+
+  </fieldset>
+  </form>
+[%~ END#ReviewUsers ~%]
+
 <!-- end review.tt2 -->

--- a/default/web_tt2/review.tt2
+++ b/default/web_tt2/review.tt2
@@ -10,9 +10,9 @@
   [% END %]
   <a class="actionMenuLinks" href="[% 'reviewbouncing' | url_rel([list]) %]">[%|loc%]Bounces[%END%]</a>
   [% IF action == 'search' %]
-     <a class="actionMenuLinks" href="[% 'dump' | url_rel([list,filter]) %]">[%|loc%]Dump[%END%]</a>
+     <a class="actionMenuLinks" href="[% 'export_member' | url_rel([list],{filter=>filter}) %]">[%|loc%]Dump[%END%]</a>
   [% ELSE %]
-     <a class="actionMenuLinks" href="[% 'dump' | url_rel([list,'light']) %]">[%|loc%]Dump[%END%]</a> 
+     <a class="actionMenuLinks" href="[% 'export_member' | url_rel([list,'light']) %]">[%|loc%]Dump[%END%]</a> 
   [% END %]
      <a class="actionMenuLinks" href="[% 'show_exclude' | url_rel([list]) %]">[%|loc%]Exclude[%END%]</a> 
   <br />

--- a/default/web_tt2/reviewbouncing.tt2
+++ b/default/web_tt2/reviewbouncing.tt2
@@ -2,7 +2,7 @@
 <h2>[%|loc%]Manage bouncing list members[%END%] <a  href="[% 'nomenu/help/admin' | url_rel %]#manage_bounces" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=400,height=200')" target="wws_help"><i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i></a></h2>
 <br />
 [% IF bounce_rate %]
-<a class="actionMenuLinks" href="[% 'dump' | url_rel([list,'bounce']) %]">[%|loc%]Dump[%END%]</a>
+<a class="actionMenuLinks" href="[% 'export_member' | url_rel([list,'bounce']) %]">[%|loc%]Dump[%END%]</a>
 
 <form action="[% path_cgi %]" method="post"> 
 <fieldset>

--- a/default/web_tt2/set_pending_list_request.tt2
+++ b/default/web_tt2/set_pending_list_request.tt2
@@ -51,6 +51,21 @@
 </pre>
 </div>
 
+<h2>[%|loc%]Users[%END%]</h2>
+
+<ul>
+  <li>
+  <a href="[% 'review' | url_rel([list,'owner']) %]">
+    [%|loc%]Owners[%END%]
+  </a>
+  </li>
+  <li>
+  <a href="[% 'review' | url_rel([list,'editor']) %]">
+    [%|loc%]Moderators[%END%]
+  </a>
+  </li>
+</ul>
+
 <div class="block">
 <h2>[%|loc%]Configuration file[%END%]</h2>
 [% IF is_listmaster ~%]

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -4787,7 +4787,7 @@ sub _review_user {
                         delegator  => $param->{'user'}{'email'}
                     }
                 );
-                Sympa::Report::notice_report_web('user_notified',
+                Sympa::WWW::Report::notice_report_web('user_notified',
                     {'notified_user' => $email},
                     $param->{'action'});
             }

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -279,7 +279,7 @@ our %comm = (
     'd_set_owner'          => 'do_d_set_owner',
     'd_admin'              => 'do_d_admin',
     'dump_scenario'        => 'do_dump_scenario',
-    'dump'                 => 'do_dump',
+    'export_member'        => 'do_export_member',
     'remind'               => 'do_remind',
     'move_user'            => 'do_move_user',
     'load_cert'            => 'do_load_cert',
@@ -338,6 +338,7 @@ my %comm_aliases = (
     'automatic_lists_request' => 'create_automatic_list_request',
     'change_email'            => 'move_user',
     'change_email_request'    => 'move_user',
+    'dump'                    => 'export_member',
     'ignoresig'               => 'decl_del',
     'ignoresub'               => 'decl_add',
     'del_fromsig'             => 'auth_del',
@@ -454,7 +455,7 @@ our %action_args = (
     'd_control'       => ['list', '@path'],
     'd_change_access' => ['list', '@path'],
     'd_set_owner'     => ['list', '@path'],
-    'dump'            => ['list', 'format'],
+    'export_member'   => ['list', 'format'],
     'search'          => ['list', 'filter'],
     'search_user'     => ['email'],
     'set_lang'        => ['lang'],
@@ -556,13 +557,13 @@ our %required_args = (
     'delete_pictures' => ['param.list', 'param.user.email'],
     'distribute'      => ['param.list', 'param.user.email', 'id|idspam'],
     'add_frommod'     => ['param.list', 'param.user.email', 'id'],
-    'dump'               => ['param.list'],
     'dump_scenario'      => ['param.list', 'pname'],
     'edit_list'          => ['param.user.email', 'param.list'],
     'edit_list_request'  => ['param.user.email', 'param.list'],
     'edit_template'      => ['webormail'],
     'editfile'           => ['param.user.email'],
     'editsubscriber'     => ['param.list', 'param.user.email', 'email'],
+    'export_member'      => ['param.list'],
     'get_closed_lists'   => ['param.user.email'],
     'get_inactive_lists' => ['param.user.email'],
     'get_latest_lists'   => ['param.user.email'],
@@ -750,8 +751,8 @@ my %action_type = (
     'd_admin'            => 'admin',
     'd_reject_shared'    => 'admin',
     'd_install_shared'   => 'admin',
+    'export_member'      => 'admin',
     'dump_scenario'      => 'admin',
-    'dump'               => 'admin',
     'open_list'          => 'admin',
     'remind'             => 'admin',
     #'subindex' => 'admin',
@@ -15903,87 +15904,103 @@ sub do_dump_scenario {
     return 1;
 }
 
-## Subscribers' list
-sub do_dump {
-    wwslog('info', '(%s)', $param->{'list'});
+# Subscribers' list
+# Old name: do_dump().
+sub do_export_member {
+    wwslog('info', '(%s, %s, %s)', $param->{'list'}, $in{'format'},
+        $in{'filter'});
 
-    ## Whatever the action return, it must never send a complex html page
-    $param->{'bypass'}       = 1;
-    $param->{'content_type'} = "text/plain";
-    $param->{'file'}         = undef;
-
-    ## Access control
-    unless (defined check_authz('do_dump', 'review')) {
-        undef $param->{'bypass'};
+    # Access control
+    unless (defined check_authz('do_export_member', 'review')) {
         return undef;
     }
 
-    $list->dump_user('member');
-    $param->{'file'} = $list->{'dir'} . '/member.dump';
+    my $format = $in{'format'} || 'full';
+    my $filter = $in{'filter'};
+    $filter = '' unless defined $filter;
 
-    if ($in{'format'} eq 'light') {
-        unless (open(DUMP, $param->{'file'})) {
-            Sympa::WWW::Report::reject_report_web('intern', 'cannot_open_file',
-                {'file' => $param->{'file'}},
-                $param->{'action'}, '', $param->{'user'}{'email'}, $robot);
-            wwslog('info', 'Unable to open file %s', $param->{'file'});
-            return undef;
-        }
-        unless (open(LIGHTDUMP, ">$param->{'file'}.light")) {
-            Sympa::WWW::Report::reject_report_web(
-                'intern',
-                'cannot_open_file',
-                {'file' => "$param->{'file'}.light"},
-                $param->{'action'},
-                '',
-                $param->{'user'}{'email'},
-                $robot
-            );
-            wwslog('err', 'Unable to create file %s.light', $param->{'file'});
-            return undef;
-        }
-        while (<DUMP>) {
-            next unless ($_ =~ /^email\s(.*)/);
-            print LIGHTDUMP "$1\n";
-        }
-        close LIGHTDUMP;
-        close DUMP;
-        $param->{'file'} = $list->{'dir'} . '/member.dump.light';
+    $param->{'bypass'} = 'extreme';
+    printf "Content-Type: text/plain; Charset=\"UTF-8\"; name=\"%s.txt\"\n"
+        . "Content-Disposition: attachment; filename=\"%s.txt\"\n"
+        . "Content-Transfer-Encoding: 8BIT\n" . "\n",
+        $list->get_id, $list->get_id;
 
+    if ($format eq 'bounce') {
+        print '# '
+            . join("\t",
+            'Email',
+            'Name',
+            'Bounce score',
+            'Bounce count',
+            'First bounce',
+            'Last bounce')
+            . "\n";
+    } elsif ($format eq 'light') {
+        ;
     } else {
-        $param->{'file'} = "$list->{'dir'}/select.dump";
-        wwslog('info', 'Opening %s', $param->{'file'});
-
-        unless (open(DUMP, ">$param->{'file'}")) {
-            Sympa::WWW::Report::reject_report_web('intern', 'file_update_failed',
-                {}, $param->{'action'}, '', $param->{'user'}{'email'},
-                $robot);
-            wwslog('err', 'Unable to create file %s', $param->{'file'});
-            return undef;
-        }
-
-        if ($in{'format'} eq 'bounce') {
-            $in{'size'} = 'all';
-            do_reviewbouncing();
-            print DUMP "# Exported bouncing subscribers\n";
-            print DUMP
-                "# Email\t\tName\tBounce score\tBounce count\tFirst bounce\tLast bounce\n";
-            foreach my $user (@{$param->{'members'}}) {
-                print DUMP
-                    "$user->{'email'}\t$user->{'gecos'}\t$user->{'bounce_score'}\t$user->{'bounce_count'}\t$user->{'first_bounce'}\t$user->{'last_bounce'}\n";
-            }
-        } else {
-            $in{'filter'} = $in{'format'};
-            do_search();
-            print DUMP
-                "# Exported subscribers with search filter \"$in{'format'}\"\n";
-            foreach my $user (@{$param->{'members'}}) {
-                print DUMP "$user->{'email'}\t$user->{'gecos'}\n";
-            }
-        }
-        close DUMP;
+        printf "# Exported subscribers with search filter \"%s\"\n", $filter;
     }
+    my $searchkey = Sympa::Tools::Text::foldcase($filter)
+        if defined $filter and length $filter;
+
+    for (
+        my $subscriber = _subscriber_first($list, type => $format);
+        $subscriber;
+        $subscriber = _subscriber_next($list, type => $format)
+        ) {
+        my $email = $subscriber->{email};
+        my $gecos = $subscriber->{gecos};
+        next unless defined $email and length $email;    # malformed record.
+
+        if (defined $searchkey and length $searchkey) {
+            my $e = Sympa::Tools::Text::foldcase($email);
+            my $g = Sympa::Tools::Text::foldcase($gecos);
+            next
+                unless 0 <= index $e, $searchkey
+                or 0 <= index $g, $searchkey;
+        }
+
+        if ($format eq 'bounce') {
+            print join "\t",
+                $email, $gecos,
+                @{$subscriber}
+                {qw(bounce_score bounce_count first_bounce last_bounce)};
+            print "\n";
+        } elsif ($format eq 'light') {
+            print "$email\n";
+        } else {
+            print join "\t", $email, $gecos;
+            print "\n";
+        }
+    }
+
     return 1;
+}
+
+sub _subscriber_first {
+    my $list    = shift;
+    my %options = @_;
+
+    if ($options{type} and $options{type} eq 'bounce') {
+        my $i = $list->get_first_bouncing_list_member;
+        $list->parse_list_member_bounce($i) if $i;
+        return $i;
+    } else {
+        return $list->get_first_list_member;
+    }
+}
+
+sub _subscriber_next {
+    my $list    = shift;
+    my %options = @_;
+
+    if ($options{type} and $options{type} eq 'bounce') {
+        my $i = $list->get_next_bouncing_list_member;
+        $list->parse_list_member_bounce($i) if $i;
+        return $i;
+    } else {
+        return $list->get_next_list_member;
+    }
 }
 
 ## returns a mailto according to list spam protection parameter

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -828,7 +828,7 @@ our %in_regexp = (
     'blacklist'            => '.*',
 
     ## Integer
-    'page' => '\d+',
+    'page' => '\d+|owner|editor',
     'size' => '\d+',
 
     ## Free data
@@ -905,6 +905,7 @@ our %in_regexp = (
     'new_email'  => Sympa::Regexps::email(),
     'sender'     => Sympa::Regexps::email(),
     'fromaddr'   => Sympa::Regexps::email(),
+    'del_emails' => '.*',
     'to' => '(([\w\-\_\.\/\+\=\']+|\".*\")\s[\w\-]+(\.[\w\-]+)+(,?))*',
     'automatic_list_part_*' => '[\w\-\.\+]*',
 
@@ -4737,6 +4738,75 @@ sub do_subscriber_count {
 ## Subscribers' list
 sub do_review {
     wwslog('info', '(%s)', $in{'page'});
+
+    $param->{'page'} = $in{'page'} || 1;
+    if ($param->{'page'} eq 'owner') {
+        return _review_user('owner');
+    } elsif ($in{'page'} eq 'editor') {
+        return _review_user('editor');
+    } else {
+        return _review_member();
+    }
+}
+
+# List of owners / editors
+sub _review_user {
+    wwslog('info', '(%s)', @_);
+    my $role = shift;
+
+    # Access control
+    return undef
+        unless Sympa::is_listmaster($list, $param->{'user'}{'email'})
+            or $list->is_admin('owner', $param->{'user'}{'email'});
+
+    # Delete/add users.
+    my @del_users = grep {$_} map { Sympa::Tools::Text::canonic_email($_) }
+        split /\0/, $in{'del_emails'};
+    my $new_users = [
+        grep { $_ and $_->{email} }
+        @{(_deserialize_changes() || {})->{user} || []}
+    ];
+    foreach my $email (@del_users) {
+        next if grep {$email eq $_->{email}} @$new_users;
+        $list->delete_list_admin($role, $email);
+    }
+    foreach my $user (@{(ref $new_users eq 'ARRAY') ? $new_users : []}) {
+        my $email = $user->{email};
+        if (grep {$email eq $_} @del_users) {
+            ; #FIXME: Update user?
+        } else {
+            unless ($list->add_list_admin($role, $user)) {
+                #FIXME: Report error
+            } else {
+                # Notify the new list owner/editor
+                Sympa::send_notify_to_user(
+                    $list,
+                    'added_as_listadmin',
+                    $email,
+                    {   admin_type => $role,
+                        delegator  => $param->{'user'}{'email'}
+                    }
+                );
+                Sympa::Report::notice_report_web('user_notified',
+                    {'notified_user' => $email},
+                    $param->{'action'});
+            }
+        }
+    }
+
+    # Users list
+    my $users =
+        [grep { $_->{role} eq $role } @{$list->get_current_admins || []}];
+    foreach my $user (@$users) {
+        $user->{sources} = $list->get_datasource_name($user->{id})
+            if $user->{id};
+    }
+    $param->{($role eq 'owner') ? 'owners' : 'editors'} = $users;
+
+    return 1;
+}
+
+sub _review_member {
     my $record;
     my @users;
     my $size;

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -15918,8 +15918,8 @@ sub do_dump {
         return undef;
     }
 
-    $list->dump();
-    $param->{'file'} = $list->{'dir'} . '/subscribers.db.dump';
+    $list->dump_user('member');
+    $param->{'file'} = $list->{'dir'} . '/member.dump';
 
     if ($in{'format'} eq 'light') {
         unless (open(DUMP, $param->{'file'})) {
@@ -15948,7 +15948,7 @@ sub do_dump {
         }
         close LIGHTDUMP;
         close DUMP;
-        $param->{'file'} = "$list->{'dir'}/subscribers.db.dump.light";
+        $param->{'file'} = $list->{'dir'} . '/member.dump.light';
 
     } else {
         $param->{'file'} = "$list->{'dir'}/select.dump";

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -249,6 +249,7 @@ our %comm = (
     'edit_config'              => 'do_edit_config',
     #XXX'submit_list' => 'do_submit_list',
     'editsubscriber'       => 'do_editsubscriber',
+    'edit'                 => 'do_edit',
     'viewbounce'           => 'do_viewbounce',
     'redirect'             => 'do_redirect',
     'rename_list_request'  => 'do_rename_list_request',
@@ -403,6 +404,7 @@ our %action_args = (
     #    ['list', 'email', 'previous_action', 'custom_attribute'],
     #'editsubscriber' => ['list', 'email', 'previous_action'],
     'editsubscriber' => ['list'],
+    'edit'           => ['list', 'role'],
     #'viewbounce' => ['list', 'email', '@file'],
     'viewbounce' => ['list', 'dir', '@file'],
     #'resetbounce'    => ['list', 'email'],
@@ -558,6 +560,7 @@ our %required_args = (
     'distribute'      => ['param.list', 'param.user.email', 'id|idspam'],
     'add_frommod'     => ['param.list', 'param.user.email', 'id'],
     'dump_scenario'      => ['param.list', 'pname'],
+    'edit'            => ['param.list', 'param.user.email', 'role', 'email'],
     'edit_list'          => ['param.user.email', 'param.list'],
     'edit_list_request'  => ['param.user.email', 'param.list'],
     'edit_template'      => ['webormail'],
@@ -666,6 +669,7 @@ our %required_privileges = (
     'distribute'        => ['editor', 'owner', 'listmaster'],
     'add_frommod'       => ['editor', 'owner'],
     'dump_scenario'     => ['listmaster'],
+    'edit'              => ['editor', 'owner', 'listmaster'],
     'edit_list'         => ['owner'],
     'edit_list_request' => ['owner'],
     'edit_template'     => ['listmaster'],
@@ -741,6 +745,7 @@ my %action_type = (
     'savefile'           => 'admin',
     'rebuildallarc'      => 'admin',    #FIXME: serveradmin?
     'reviewbouncing'     => 'admin',
+    'edit'               => 'admin',
     'edit_list_request'  => 'admin',
     'edit_list'          => 'admin',
     'editsubscriber'     => 'admin',
@@ -751,8 +756,8 @@ my %action_type = (
     'd_admin'            => 'admin',
     'd_reject_shared'    => 'admin',
     'd_install_shared'   => 'admin',
-    'export_member'      => 'admin',
     'dump_scenario'      => 'admin',
+    'export_member'      => 'admin',
     'open_list'          => 'admin',
     'remind'             => 'admin',
     #'subindex' => 'admin',
@@ -961,6 +966,9 @@ our %in_regexp = (
 
     ## Authentication/moderation key
     'authkey' => '\w+',
+
+    # Role
+    'role' => 'member|editor|owner',
 );
 
 ## Regexp applied on incoming parameters (%in)
@@ -4947,6 +4955,83 @@ sub _review_member {
     }
 
     return 1;
+}
+
+sub do_edit {
+    wwslog('info', '(%s, %s)', $in{'role'}, $in{'email'});
+
+    my $role  = $in{'role'};
+    my $email = $in{'email'};
+
+    $param->{'role'} = $role;
+    $param->{'page'} = $role;   # For review action
+
+    my @keys = qw(gecos profile info reception visibility);
+
+    #FIXME: Provide config schema including privileges by Family.
+    my $schema = {};
+    my ($role_p, $priv_p) = $list->may_edit($role, $param->{'user'}{'email'});
+    foreach my $key (@keys) {
+        my ($role, $priv) =
+            $list->may_edit("$role.$key", $param->{'user'}{'email'});
+        my $pitem = $schema->{$key} = {};
+        $priv = $priv_p
+            if not $priv
+                or ($priv_p and $priv_p lt $priv);
+        $pitem->{privilege} = $priv
+            if not $pitem->{privilege}
+                or ($priv and $priv lt $pitem->{privilege});
+        $pitem->{privilege} ||= 'hidden';    # Implicit default
+    }
+
+    # Initial access. show current value.
+    unless ($in{'submit'}) {
+        $param->{'config_schema'} = $schema;
+        my ($user) =
+            grep { $_ and $_->{email} eq $email and $_->{role} eq $role }
+            @{$list->get_current_admins || []};
+        $param->{'config_values'} = {$role => [$user]} if $user;
+
+        $param->{'previous_action'} = $in{'previous_action'} || 'review';
+        return 1;
+    } else {
+        # Start parsing the data sent by the edition form.
+        my $new_config = _deserialize_changes();
+        my $new = $new_config->{$role}->[0] || {} if $new_config;
+
+        my $values = {};
+        foreach my $key (@keys) {
+            next unless $schema->{$key}{privilege}
+                and $schema->{$key}{privilege} eq 'write';
+
+            if ($key eq 'gecos') {
+                $values->{gecos} = (defined $new->{gecos}) ? $new->{gecos} : ''
+                    if exists $new->{gecos};
+            } elsif ($key eq 'reception') {
+                $values->{reception} = $new->{reception}
+                    if $new->{reception}
+                        and grep {$new->{reception} eq $_} qw(mail nomail);
+            } elsif ($key eq 'visibility') {
+                $values->{visibility} = $new->{visibility}
+                    if $new->{visibility}
+                        and grep {$new->{visibility} eq $_}
+                            qw(conceal noconceal);
+            } elsif ($key eq 'profile') {
+                $values->{profile} = $new->{profile}
+                    if $new->{profile}
+                        and grep {$new->{profile} eq $_} qw(normal privileged);
+            } elsif ($key eq 'info') {
+                $values->{info} = (defined $new->{info}) ? $new->{info} : ''
+                    if exists $new->{info};
+            }
+        }
+        $list->update_list_admin($email, $role, $values)
+            if $values and %$values;
+
+        $in{'page'} = $role;    # For review.
+        return $in{'previous_action'} || 'review';
+    }
+
 }
 
 ## Show the table of exclude
@@ -10803,29 +10888,6 @@ sub do_edit_list_request {
     wwslog('info', '(%s)', $in{'group'});
 
     return 1 unless $in{'group'};
-
-    # Sync owner/editor in list config with database.
-    # FIXME: TENTATIVE FIX.
-    my @static_admins =
-        grep {$_ and $_->{'subscribed'}} @{$list->_get_admins || []};
-    my @subparams;
-    # Current static owners.
-    my $static_owner =
-        [grep { $_->{'role'} and $_->{'role'} eq 'owner' } @static_admins];
-    @subparams = qw(email gecos info profile reception visibility);
-    foreach my $u (@$static_owner) {
-        $u = {map { $_ => $u->{$_} } @subparams};
-    }
-    $list->{'admin'}{'owner'} = $static_owner;
-    # Current static editors.
-    my $static_editor =
-        [grep { $_->{'role'} and $_->{'role'} eq 'editor' } @static_admins];
-    @subparams = qw(email gecos info reception visibility);
-    foreach my $u (@$static_editor) {
-        $u = {map { $_ => $u->{$_} } @subparams};
-    }
-    $list->{'admin'}{'editor'} = $static_editor;
-    # FIXME: END OF TENTATIVE FIX.
 
     my $config = Sympa::List::Config->new($list, config => $list->{'admin'});
     my $schema = $config->get_schema($param->{'user'}{'email'});

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -2799,6 +2799,7 @@ sub get_next_list_member {
 # Mapping between var and field names.
 sub _map_list_admin_cols {
     my %map_field = (
+        date        => 'date_epoch_admin',
         update_date => 'update_epoch_admin',
         gecos       => 'comment_admin',
         email       => 'user_admin',
@@ -2832,12 +2833,7 @@ sub _list_admin_cols {
 
     my %map_field = _map_list_admin_cols();
     return join ', ', map {
-        my $col;
-        if ($_ eq 'date') {
-            $col = $sdm->get_canonical_read_date($map_field{$_});
-        } else {
-            $col = $map_field{$_};
-        }
+        my $col = $map_field{$_};
         ($col eq $_) ? $col : sprintf('%s AS "%s"', $col, $_);
     } sort keys %map_field;
 }
@@ -7118,21 +7114,18 @@ sub _sync_include_user {
             unless (
                 $sdm
                 and $sth = $sdm->do_prepared_query(
-                    sprintf(
-                        q{INSERT INTO admin_table
-                          (user_admin, comment_admin,
-                           list_admin, robot_admin,
-                           date_admin, update_epoch_admin,
-                           reception_admin, visibility_admin,
-                           subscribed_admin, included_admin,
-                           include_sources_admin,
-                           role_admin, info_admin, profile_admin)
-                          VALUES (?, ?, ?, ?, %s, ?, ?, ?, 0, 1, ?, ?, ?, ?)},
-                        $sdm->get_canonical_write_date($time)
-                    ),
+                    q{INSERT INTO admin_table
+                      (user_admin, comment_admin,
+                       list_admin, robot_admin,
+                       date_epoch_admin, update_epoch_admin,
+                       reception_admin, visibility_admin,
+                       subscribed_admin, included_admin,
+                       include_sources_admin,
+                       role_admin, info_admin, profile_admin)
+                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 1, ?, ?, ?, ?)},
                     $user->{email},     $user->{gecos},
                     $self->{'name'},    $self->{'domain'},
-                    $time,
+                    $time,              $time,
                     $user->{reception}, $user->{visibility},
                     $user->{id},
                     $role, $user->{info}, $user->{profile}

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -144,7 +144,7 @@ Delete the indicated users from the list.
 Delete the indicated admin user with the predefined role from the list.
 ROLE may be C<'owner'> or C<'editor'>.
 
-=item dump_user ( ROLE )
+=item dump_users ( ROLE )
 
 Dump user information in user store into file C<I<$role>.dump> under
 list directory. ROLE may be C<'member'>, C<'owner'> or C<'editor'>.
@@ -204,7 +204,7 @@ the list.
 OBSOLETED.
 Use get_admins().
 
-=item suck_user ( ROLE )
+=item restore_users ( ROLE )
 
 Import user information into user store from file C<I<$role>.dump> under
 list directory. ROLE may be C<'member'>, C<'owner'> or C<'editor'>.
@@ -708,7 +708,7 @@ sub _cache_put {
 
 # Dumps a copy of list users to disk, in text format.
 # Old name: Sympa::List::dump() which dumped only members.
-sub dump_user {
+sub dump_users {
     $log->syslog('debug2', '(%s, %s)', @_);
     my $self = shift;
     my $role = shift;
@@ -4368,7 +4368,7 @@ sub load_data_sources_list {
 
 ## Loads the list of users.
 # Old name:: Sympa::List::_load_list_members_file($file) which loaded members.
-sub suck_user {
+sub restore_users {
     $log->syslog('debug2', '(%s, %s)', @_);
     my $self = shift;
     my $role = shift;
@@ -7416,7 +7416,7 @@ sub _inclusion_loop {
 #sub _load_total_db;
 
 ## Writes the user list to disk
-# Depreceted.  Use Sympa::List::dump_user().
+# Depreceted.  Use Sympa::List::dump_users().
 #sub _save_list_members_file;
 
 ## Does the real job : stores the message given as an argument into

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -7416,35 +7416,8 @@ sub _inclusion_loop {
 #sub _load_total_db;
 
 ## Writes the user list to disk
-sub _save_list_members_file {
-    my ($self, $file) = @_;
-    $log->syslog('debug3', '(%s)', $file);
-
-    my ($k, $s);
-
-    $log->syslog('debug2', 'Saving user file %s', $file);
-
-    rename("$file", "$file.old");
-    open my $fh, '>', $file or return undef;
-
-    for (
-        $s = $self->get_first_list_member();
-        $s;
-        $s = $self->get_next_list_member()
-        ) {
-        foreach $k (
-            'date',      'update_date', 'email', 'gecos',
-            'reception', 'visibility'
-            ) {
-            printf $fh "%s %s\n", $k, $s->{$k}
-                if defined $s->{$k} and length $s->{$k};
-
-        }
-        print $fh "\n";
-    }
-    close $fh;
-    return 1;
-}
+# Depreceted.  Use Sympa::List::dump_user().
+#sub _save_list_members_file;
 
 ## Does the real job : stores the message given as an argument into
 ## the digest of the list.

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -142,6 +142,12 @@ Delete the indicated users from the list.
 =item delete_list_admin ( ROLE, ARRAY )
 
 Delete the indicated admin user with the predefined role from the list.
+ROLE may be C<'owner'> or C<'editor'>.
+
+=item dump_user ( ROLE )
+
+Dump user information in user store into file C<I<$role>.dump> under
+list directory. ROLE may be C<'member'>, C<'owner'> or C<'editor'>.
 
 =item get_cookie ()
 
@@ -197,6 +203,11 @@ the list.
 
 OBSOLETED.
 Use get_admins().
+
+=item suck_user ( ROLE )
+
+Import user information into user store from file C<I<$role>.dump> under
+list directory. ROLE may be C<'member'>, C<'owner'> or C<'editor'>.
 
 =item update_list_member ( $email, key =E<gt> value, ... )
 
@@ -695,24 +706,61 @@ sub _cache_put {
 # Moved to: Sympa::Spindle::DistributeMessage::_extract_verp_rcpt().
 #sub _extract_verp_rcpt;
 
-## Dumps a copy of lists to disk, in text format
-sub dump {
+# Dumps a copy of list users to disk, in text format.
+# Old name: Sympa::List::dump() which dumped only members.
+sub dump_user {
+    $log->syslog('debug2', '(%s, %s)', @_);
     my $self = shift;
-    $log->syslog('debug2', '(%s)', $self->{'name'});
+    my $role = shift;
 
-    unless (defined $self) {
-        $log->syslog('err', 'Unknown list');
+    die 'bug in logic. Ask developer'
+        unless grep {$role eq $_} qw(member owner editor);
+
+    my $file = $self->{'dir'} . '/' . $role . '.dump';
+
+    unlink $file . '.old' if -e $file . '.old';
+    rename $file, $file . '.old' if -e $file;
+    my $lock_fh = Sympa::LockedFile->new($file, 5, '>');
+    unless ($lock_fh) {
+        $log->syslog('err', 'Failed to save file %s.new: %s', $file,
+            Sympa::LockedFile->last_error);
         return undef;
     }
 
-    my $user_file_name = "$self->{'dir'}/subscribers.db.dump";
-
-    unless ($self->_save_list_members_file($user_file_name)) {
-        $log->syslog('err', 'Failed to save file %s', $user_file_name);
-        return undef;
+    if ($role eq 'member') {
+        my $user;
+        for (
+            $user = $self->get_first_list_member();
+            $user;
+            $user = $self->get_next_list_member()
+            ) {
+            foreach my $k (
+                qw(date update_date email gecos
+                reception visibility)) {
+                printf $lock_fh "%s %s\n", $k, $user->{$k}
+                    if defined $user->{$k} and length $user->{$k};
+    
+            }
+            print $lock_fh "\n";
+        }
+    } else {
+        foreach my $user (@{$self->_get_admins || []}) {
+            next unless $user->{role} eq $role;
+            foreach my $k (
+                qw(date update_date email gecos profile
+                reception visibility info
+                subscribed included id)
+                ) {
+                printf $lock_fh "%s %s\n", $k, $user->{$k}
+                    if defined $user->{$k} and length $user->{$k};
+    
+            }
+            print $lock_fh "\n";
+        }
     }
 
-    # Note: "subscribers" file was deprecated. No need to load "stats" file.
+    $lock_fh->close;
+
     # FIXME:Are these lines required?
     $self->{'_mtime'}{'config'} =
         Sympa::Tools::File::get_mtime($self->{'dir'} . '/config');
@@ -4319,37 +4367,96 @@ sub load_data_sources_list {
 # No longer used.
 #sub _load_stats_file;
 
-## Loads the list of subscribers.
-sub _load_list_members_file {
-    my $file = shift;
-    $log->syslog('debug2', '(%s)', $file);
+## Loads the list of users.
+# Old name:: Sympa::List::_load_list_members_file($file) which loaded members.
+sub suck_user {
+    $log->syslog('debug2', '(%s, %s)', @_);
+    my $self = shift;
+    my $role = shift;
 
-    ## Open the file and switch to paragraph mode.
-    open(L, $file) || return undef;
+    die 'bug in logic. Ask developer'
+        unless grep {$role eq $_} qw(member owner editor);
 
-    ## Process the lines
-    local $RS;
-    my $data = <L>;
+    my $file = $self->{'dir'} . '/' . $role . '.dump';
 
-    my @users;
-    foreach (split /\n\n/, $data) {
-        my (%user, $email);
-        $user{'email'} = $email = $1 if (/^\s*email\s+(.+)\s*$/om);
-        $user{'gecos'}       = $1 if (/^\s*gecos\s+(.+)\s*$/om);
-        $user{'date'}        = $1 if (/^\s*date\s+(\d+)\s*$/om);
-        $user{'update_date'} = $1 if (/^\s*update_date\s+(\d+)\s*$/om);
-        $user{'reception'}   = $1
-            if (
-            /^\s*reception\s+(digest|nomail|summary|notice|txt|html|urlize|not_me)\s*$/om
-            );
-        $user{'visibility'} = $1
-            if (/^\s*visibility\s+(conceal|noconceal)\s*$/om);
+    # Open the file and switch to paragraph mode.
+    my $lock_fh = Sympa::LockedFile->new($file, 5, '<') or return;
+    local $RS = '';
 
-        push @users, \%user;
+    my $user;
+    while (my $para = <$lock_fh>) {
+        if ($role eq 'member') {
+            $user = {
+                map {
+                    #FIMXE:Define appropriate schema.
+                    if (/^\s*email\s+(.+)\s*$/) {
+                        (email => $1);
+                    } elsif (/^\s*gecos\s+(.+)\s*$/) {
+                        (gecos => $1);
+                    } elsif (/^\s*date\s+(\d+)\s*$/) {
+                        (date => $1);
+                    } elsif (/^\s*update_date\s+(\d+)\s*$/) {
+                        (update_date => $1);
+                    } elsif (
+                        /^\s*reception\s+(digest|nomail|summary|notice|txt|html|urlize|not_me)\s*$/
+                        ) {
+                        (reception => $1);
+                    } elsif (/^\s*visibility\s+(conceal|noconceal)\s*$/) {
+                        (visibility => $1);
+                    } else {
+                        ();
+                    }
+                    } split /\n/, $para
+            };
+        } else {
+            my $r;
+            $user = {
+                map {
+                    #FIMXE:Define appropriate schema.
+                    if (/^\s*role\s+(owner|editor)\s*$/) {
+                        $r = $1;
+                        ();
+                    } elsif (/^\s*email\s+(.+)\s*$/) {
+                        (email => $1);
+                    } elsif (/^\s*gecos\s+(.+)\s*$/) {
+                        (gecos => $1);
+                    } elsif (/^\s*profile\s+(normal|privileged)\s*$/) {
+                        (gecos => $1);
+                    } elsif (/^\s*date\s+(\d+)\s*$/) {
+                        (date => $1);
+                    } elsif (/^\s*update_date\s+(\d+)\s*$/) {
+                        (update_date => $1);
+                    } elsif (
+                        /^\s*reception\s+(mail|nomail)\s*$/
+                        ) {
+                        (reception => $1);
+                    } elsif (/^\s*visibility\s+(conceal|noconceal)\s*$/) {
+                        (visibility => $1);
+                    } elsif (/^\s*info\s+(.+)\s*$/) {
+                        (info => $1);
+                    } elsif (/^\s*subscribed\s+(\S+)\s*$/) {
+                        (subscribed => !!$1);
+                    } elsif (/^\s*included\s+(\S+)*$/) {
+                        (included => !!$1);
+                    } elsif (/^\s*id\s+(.+)*$/) {
+                        (id => $1);
+                    } else {
+                        ();
+                    }
+                    } split /\n/, $para
+            };
+            next unless $r and $r eq $role;
+        }
+        next unless %$user;
+
+        if ($role eq 'member') {
+            $self->add_list_member($user);
+        } else {
+            $self->add_list_admin($role, $user);
+        }
     }
-    close(L);
+    $lock_fh->close;
 
-    return @users;
 }
 
 ## include a remote sympa list as subscribers.

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -7019,277 +7019,13 @@ sub on_the_fly_sync_include {
 }
 
 sub sync_include_admin {
-    my ($self) = shift;
-    my $option = shift;
+    $log->syslog('debug2', '(%s)', @_);
+    my $self = shift;
 
-    my $name = $self->{'name'};
-    $log->syslog('debug2', '(%s)', $name);
-
-    ## don't care about listmaster role
+    # don't care about listmaster role.
     foreach my $role ('owner', 'editor') {
-        # Load a hash with the old admin users.
-        my $old_admin_users = {
-            map { ($_->{'email'} => $_) }
-                grep { $_ and $_->{'role'} and $_->{'role'} eq $role }
-                @{$self->_get_admins || []}
-        };
-
-        ## Load a hash with the new admin user list from an include source(s)
-        my $new_admin_users_include;
-        ## Load a hash with the new admin user users from the list config
-        my $new_admin_users_config;
-        unless ($option and $option eq 'purge') {
-            my $result = $self->_load_list_admin_from_include($role) || {};
-            $new_admin_users_include = $result->{users};
-            my @depend_on = @{$result->{depend_on} || []};
-
-            ## If include sources were not available, do not update admin
-            ## users
-            ## Use DB cache instead
-            unless (defined $new_admin_users_include) {
-                $log->syslog('err',
-                    'Could not get %ss from an include source for list %s',
-                    $role, $self);
-                Sympa::send_notify_to_listmaster($self,
-                    'sync_include_admin_failed', {});
-                return undef;
-            }
-
-            $new_admin_users_config =
-                $self->_load_list_admin_from_config($role);
-
-            unless (defined $new_admin_users_config) {
-                $log->syslog('err',
-                    'Could not get %ss from config for list %s',
-                    $role, $name);
-                return undef;
-            }
-
-            # Update inclusion dependency (added on 6.2.16).
-            $self->_update_inclusion_table($role, @depend_on);
-        }
-
-        my @add_tab;
-        my $admin_users_added   = 0;
-        my $admin_users_updated = 0;
-
-        ## Get an Exclusive lock
-        my $lock_fh =
-            Sympa::LockedFile->new($self->{'dir'} . '/include_admin_user',
-            20, '+');
-        unless ($lock_fh) {
-            $log->syslog('err', 'Could not create new lock');
-            return undef;
-        }
-
-        ## Go through new admin_users_include
-        foreach my $email (keys %{$new_admin_users_include}) {
-
-            # included and subscribed
-            if (defined $new_admin_users_config->{$email}) {
-                my $param;
-                foreach my $p ('reception', 'visibility', 'gecos', 'info',
-                    'profile') {
-                    #  config parameters have priority on include parameters
-                    #  in case of conflict
-                    $param->{$p} = $new_admin_users_config->{$email}{$p}
-                        if (defined $new_admin_users_config->{$email}{$p});
-                    $param->{$p} ||= $new_admin_users_include->{$email}{$p};
-                }
-
-                #Admin User was already in the DB
-                if (defined $old_admin_users->{$email}) {
-
-                    $param->{'included'} = 1;
-                    $param->{'id'} = $new_admin_users_include->{$email}{'id'};
-                    $param->{'subscribed'} = 1;
-
-                    my $param_update =
-                        is_update_param($param, $old_admin_users->{$email});
-
-                    # updating
-                    if (defined $param_update) {
-                        if (%{$param_update}) {
-                            $log->syslog('debug', 'Updating %s %s to list %s',
-                                $role, $email, $name);
-                            $param_update->{'update_date'} = time;
-
-                            unless (
-                                $self->update_list_admin(
-                                    $email, $role, $param_update
-                                )
-                                ) {
-                                $log->syslog('err',
-                                    '(%s) Failed to update %s %s',
-                                    $name, $role, $email);
-                                next;
-                            }
-                            $admin_users_updated++;
-                        }
-                    }
-                    # for the next foreach (sort of new_admin_users_config
-                    # that are not included)
-                    delete($new_admin_users_config->{$email});
-
-                    # add a new included and subscribed admin user
-                } else {
-                    $log->syslog('debug2', 'Adding %s %s to list %s',
-                        $email, $role, $name);
-
-                    foreach my $key (keys %{$param}) {
-                        $new_admin_users_config->{$email}{$key} =
-                            $param->{$key};
-                    }
-                    $new_admin_users_config->{$email}{'included'}   = 1;
-                    $new_admin_users_config->{$email}{'subscribed'} = 1;
-                    push(@add_tab, $new_admin_users_config->{$email});
-
-                    # for the next foreach (sort of new_admin_users_config
-                    # that are not included)
-                    delete($new_admin_users_config->{$email});
-                }
-
-                # only included
-            } else {
-                my $param = $new_admin_users_include->{$email};
-
-                #Admin User was already in the DB
-                if (defined($old_admin_users->{$email})) {
-
-                    $param->{'included'} = 1;
-                    $param->{'id'} = $new_admin_users_include->{$email}{'id'};
-                    $param->{'subscribed'} = 0;
-
-                    my $param_update =
-                        is_update_param($param, $old_admin_users->{$email});
-
-                    # updating
-                    if (defined $param_update) {
-                        if (%{$param_update}) {
-                            $log->syslog('debug', 'Updating %s %s to list %s',
-                                $role, $email, $name);
-                            $param_update->{'update_date'} = time;
-
-                            unless (
-                                $self->update_list_admin(
-                                    $email, $role, $param_update
-                                )
-                                ) {
-                                $log->syslog('err',
-                                    '(%s) Failed to update %s %s',
-                                    $name, $role, $email);
-                                next;
-                            }
-                            $admin_users_updated++;
-                        }
-                    }
-                    # add a new included admin user
-                } else {
-                    $log->syslog('debug2', 'Adding %s %s to list %s',
-                        $role, $email, $name);
-
-                    foreach my $key (keys %{$param}) {
-                        $new_admin_users_include->{$email}{$key} =
-                            $param->{$key};
-                    }
-                    $new_admin_users_include->{$email}{'included'} = 1;
-                    push(@add_tab, $new_admin_users_include->{$email});
-                }
-            }
-        }
-
-        ## Go through new admin_users_config (that are not included : only
-        ## subscribed)
-        foreach my $email (keys %{$new_admin_users_config}) {
-
-            my $param = $new_admin_users_config->{$email};
-
-            #Admin User was already in the DB
-            if (defined($old_admin_users->{$email})) {
-
-                $param->{'included'}   = 0;
-                $param->{'id'}         = '';
-                $param->{'subscribed'} = 1;
-                my $param_update =
-                    is_update_param($param, $old_admin_users->{$email});
-
-                # updating
-                if (defined $param_update) {
-                    if (%{$param_update}) {
-                        $log->syslog('debug', 'Updating %s %s to list %s',
-                            $role, $email, $name);
-                        $param_update->{'update_date'} = time;
-
-                        unless (
-                            $self->update_list_admin(
-                                $email, $role, $param_update
-                            )
-                            ) {
-                            $log->syslog('err', '(%s) Failed to update %s %s',
-                                $name, $role, $email);
-                            next;
-                        }
-                        $admin_users_updated++;
-                    }
-                }
-                # add a new subscribed admin user
-            } else {
-                $log->syslog('debug2', 'Adding %s %s to list %s',
-                    $role, $email, $name);
-
-                foreach my $key (keys %{$param}) {
-                    $new_admin_users_config->{$email}{$key} = $param->{$key};
-                }
-                $new_admin_users_config->{$email}{'subscribed'} = 1;
-                push(@add_tab, $new_admin_users_config->{$email});
-            }
-        }
-
-        if ($#add_tab >= 0) {
-            unless ($admin_users_added =
-                $self->add_list_admin($role, @add_tab)) {
-                $log->syslog('err', 'Failed to add new %s(s) to list %s',
-                    $role, $self);
-                return undef;
-            }
-        }
-
-        if ($admin_users_added) {
-            $log->syslog('debug', '(%s) %d %s(s) added',
-                $name, $admin_users_added, $role);
-        }
-
-        $log->syslog('debug', '(%s) %d %s(s) updated',
-            $name, $admin_users_updated, $role);
-
-        ## Go though old list of admin users
-        my $admin_users_removed = 0;
-        my @deltab;
-
-        foreach my $email (keys %$old_admin_users) {
-            unless (defined($new_admin_users_include->{$email})
-                || defined($new_admin_users_config->{$email})) {
-                $log->syslog('debug2', 'Removing %s %s to list %s',
-                    $role, $email, $name);
-                push(@deltab, $email);
-            }
-        }
-
-        if ($#deltab >= 0) {
-            unless ($admin_users_removed =
-                $self->delete_list_admin($role, @deltab)) {
-                $log->syslog('err', '(%s) Failed to delete %s %s',
-                    $name, $role, $admin_users_removed);
-                return undef;
-            }
-            $log->syslog('debug', '(%s) %d %s(s) removed',
-                $name, $admin_users_removed, $role);
-        }
-
-        ## Release lock
-        unless ($lock_fh->close()) {
-            return undef;
-        }
+        return undef
+            unless $self->_sync_include_user($role);
     }
 
     $self->_cache_publish_expiry('admin_user');
@@ -7298,30 +7034,156 @@ sub sync_include_admin {
     return scalar @{$self->get_admins('owner')};
 }
 
-## Load param admin users from the config of the list
-sub _load_list_admin_from_config {
+sub _sync_include_user {
     my $self = shift;
     my $role = shift;
-    my $name = $self->{'name'};
-    my %admin_users;
 
-    $log->syslog('debug2', '(%s) For list %s', $role, $name);
+    # Load a hash with the new users.
+    my $result    = $self->_load_list_admin_from_include($role) || {};
+    my $new_users = $result->{users};
+    my @depend_on = @{$result->{depend_on} || []};
 
-    foreach my $entry (@{$self->{'admin'}{$role}}) {
-        my $email = lc($entry->{'email'});
-        my %u;
-
-        $u{'email'}      = $email;
-        $u{'reception'}  = $entry->{'reception'};
-        $u{'visibility'} = $entry->{'visibility'};
-        $u{'gecos'}      = $entry->{'gecos'};
-        $u{'info'}       = $entry->{'info'};
-        $u{'profile'}    = $entry->{'profile'} if ($role eq 'owner');
-
-        $admin_users{$email} = \%u;
+    # If include sources were not available, do not update users.
+    # Use DB cache instead and warn the listmaster.
+    unless (defined $new_users) {
+        $log->syslog('err',
+            'Could not get %ss from an include source for list %s',
+            $role, $self);
+        Sympa::send_notify_to_listmaster($self, 'sync_include_admin_failed',
+            {});
+        return undef;
     }
-    return \%admin_users;
+
+    # Update inclusion dependency (added on 6.2.16).
+    $self->_update_inclusion_table($role, @depend_on);
+
+    # Get an Exclusive lock.
+    my $lock_fh =
+        Sympa::LockedFile->new($self->{'dir'} . '/include_admin_user',
+        20, '+');
+    unless ($lock_fh) {
+        $log->syslog('err', 'Could not create new lock');
+        return undef;
+    }
+
+    my (%users_added, %users_updated, $users_deleted);
+    my $time = time;
+    my $sdm  = Sympa::DatabaseManager->instance;
+    my $sth;
+
+    # Go through new admin_users_include
+    foreach my $user (values %$new_users) {
+        if ($users_added{$user->{email}} or $users_updated{$user->{email}}) {
+            next;
+        }
+
+        unless (
+            $sdm
+            and $sth = $sdm->do_prepared_query(
+                q{UPDATE admin_table
+                  SET included_admin = 1, include_sources_admin = ?,
+                      update_epoch_admin = ?
+                  WHERE role_admin = ? AND user_admin = ? AND
+                        list_admin = ? AND robot_admin = ?},
+                $user->{id},     $time,
+                $role,           $user->{email},
+                $self->{'name'}, $self->{'domain'}
+            )
+            and $sth->rows
+            ) {
+            unless (
+                $sdm
+                and $sth = $sdm->do_prepared_query(
+                    sprintf(
+                        q{INSERT INTO admin_table
+                          (user_admin, comment_admin,
+                           list_admin, robot_admin,
+                           date_admin, update_epoch_admin,
+                           reception_admin, visibility_admin,
+                           subscribed_admin, included_admin,
+                           include_sources_admin,
+                           role_admin, info_admin, profile_admin)
+                          VALUES (?, ?, ?, ?, %s, ?, ?, ?, 0, 1, ?, ?, ?, ?)},
+                        $sdm->get_canonical_write_date($time)
+                    ),
+                    $user->{email},     $user->{gecos},
+                    $self->{'name'},    $self->{'domain'},
+                    $time,
+                    $user->{reception}, $user->{visibility},
+                    $user->{id},
+                    $role, $user->{info}, $user->{profile}
+                )
+                and $sth->rows
+                ) {
+                $log->syslog('err', '(%s) Failed to update %s %s',
+                    $self, $role, $user->{email});
+            } else {
+                $users_added{$user->{email}} = 1;
+            }
+        } else {
+            $users_updated{$user->{email}} = 1;
+        }
+    }
+
+    $log->syslog(
+        'debug', '(%s) %d %s(s) added, %d %s(s) updated',
+        $self, scalar keys %users_added,
+        $role, scalar keys %users_updated, $role
+    );
+
+    # Go though old list of admin users.
+    $users_deleted = 0;
+    unless (
+        $sdm
+        and $sth = $sdm->do_prepared_query(
+            q{DELETE FROM admin_table
+              WHERE role_admin = ? AND list_admin = ? AND robot_admin = ? AND
+                    (subscribed_admin IS NULL OR subscribed_admin = 0) AND
+                    NOT (included_admin IS NULL OR included_admin = 0) AND
+                    (update_epoch_admin IS NULL OR update_epoch_admin < ?)},
+            $role, $self->{'name'}, $self->{'domain'},
+            $time
+        )
+        ) {
+        $log->syslog('err', '(%s) Failed to delete %s', $self, $role);
+    } else {
+        $users_deleted += $sth->rows;
+    }
+    unless (
+        $sdm
+        and $sth = $sdm->do_prepared_query(
+            q{UPDATE admin_table
+              SET included_admin = 0, include_sources_admin = NULL,
+                  update_epoch_admin = ?
+              WHERE role_admin = ? AND list_admin = ? AND robot_admin = ? AND
+                    subscribed_admin = 1 AND
+                    (update_epoch_admin IS NULL OR update_epoch_admin < ?)},
+            $time,
+            $role, $self->{'name'}, $self->{'domain'},
+            $time
+        )
+        ) {
+        $log->syslog('err', '(%s) Failed to delete %s', $self, $role);
+    } else {
+        $users_deleted += $sth->rows;
+    }
+
+    if ($users_deleted) {
+        $log->syslog('debug', '(%s) %d %s(s) removed',
+            $self, $users_deleted, $role);
+    }
+
+    # Release lock.
+    unless ($lock_fh->close()) {
+        return undef;
+    }
+
+    return 1;
 }
+
+## Load param admin users from the config of the list
+# No longer used.
+#sub _load_list_admin_from_config;
 
 ## return true if new_param has changed from old_param
 #  $new_param is changed to return only entries that need to

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -728,18 +728,17 @@ sub dump_user {
     }
 
     if ($role eq 'member') {
+        my %map_field = _map_list_member_cols();
+
         my $user;
         for (
             $user = $self->get_first_list_member();
             $user;
             $user = $self->get_next_list_member()
             ) {
-            foreach my $k (
-                qw(date update_date email gecos
-                reception visibility)) {
+            foreach my $k (sort keys %map_field) {
                 printf $lock_fh "%s %s\n", $k, $user->{$k}
                     if defined $user->{$k} and length $user->{$k};
-    
             }
             print $lock_fh "\n";
         }
@@ -4383,80 +4382,54 @@ sub suck_user {
     my $lock_fh = Sympa::LockedFile->new($file, 5, '<') or return;
     local $RS = '';
 
-    my $user;
-    while (my $para = <$lock_fh>) {
-        if ($role eq 'member') {
-            $user = {
-                map {
-                    #FIMXE:Define appropriate schema.
-                    if (/^\s*email\s+(.+)\s*$/) {
-                        (email => $1);
-                    } elsif (/^\s*gecos\s+(.+)\s*$/) {
-                        (gecos => $1);
-                    } elsif (/^\s*date\s+(\d+)\s*$/) {
-                        (date => $1);
-                    } elsif (/^\s*update_date\s+(\d+)\s*$/) {
-                        (update_date => $1);
-                    } elsif (
-                        /^\s*reception\s+(digest|nomail|summary|notice|txt|html|urlize|not_me)\s*$/
-                        ) {
-                        (reception => $1);
-                    } elsif (/^\s*visibility\s+(conceal|noconceal)\s*$/) {
-                        (visibility => $1);
-                    } else {
-                        ();
-                    }
-                    } split /\n/, $para
-            };
-        } else {
-            my $r;
-            $user = {
-                map {
-                    #FIMXE:Define appropriate schema.
-                    if (/^\s*role\s+(owner|editor)\s*$/) {
-                        $r = $1;
-                        ();
-                    } elsif (/^\s*email\s+(.+)\s*$/) {
-                        (email => $1);
-                    } elsif (/^\s*gecos\s+(.+)\s*$/) {
-                        (gecos => $1);
-                    } elsif (/^\s*profile\s+(normal|privileged)\s*$/) {
-                        (gecos => $1);
-                    } elsif (/^\s*date\s+(\d+)\s*$/) {
-                        (date => $1);
-                    } elsif (/^\s*update_date\s+(\d+)\s*$/) {
-                        (update_date => $1);
-                    } elsif (
-                        /^\s*reception\s+(mail|nomail)\s*$/
-                        ) {
-                        (reception => $1);
-                    } elsif (/^\s*visibility\s+(conceal|noconceal)\s*$/) {
-                        (visibility => $1);
-                    } elsif (/^\s*info\s+(.+)\s*$/) {
-                        (info => $1);
-                    } elsif (/^\s*subscribed\s+(\S+)\s*$/) {
-                        (subscribed => !!$1);
-                    } elsif (/^\s*included\s+(\S+)*$/) {
-                        (included => !!$1);
-                    } elsif (/^\s*id\s+(.+)*$/) {
-                        (id => $1);
-                    } else {
-                        ();
-                    }
-                    } split /\n/, $para
-            };
-            next unless $r and $r eq $role;
-        }
-        next unless %$user;
+    if ($role eq 'member') {
+        my %map_field = _map_list_member_cols();
 
-        if ($role eq 'member') {
+        while (my $para = <$lock_fh>) {
+            my $user = {
+                map {
+                    #FIMXE: Define appropriate schema.
+                    if (/^\s*(suspend|subscribed|included)\s+(\S+)\s*$/) {
+                        ($1 => !!$2);
+                    } elsif (/^\s*(date|update_date|startdate|enddate|bounce_score|number_messages)\s+(\d+)\s*$/
+                        or /^\s*(reception)\s+(mail|digest|nomail|summary|notice|txt|html|urlize|not_me)\s*$/
+                        or /^\s*(visibility)\s+(conceal|noconceal)\s*$/
+                        or (/^\s*(\w+)\s+(.+)\s*$/ and $map_field{$1})) {
+                        ($1 => $2);
+                    } else {
+                        ();
+                    }
+                    } split /\n/, $para
+            };
+            next unless $user->{email};
+
             $self->add_list_member($user);
-        } else {
+        }
+    } else {
+        while (my $para = <$lock_fh>) {
+            my $user = {
+                map {
+                    #FIMXE:Define appropriate schema.
+                    if (/^\s*(subscribed|included)\s+(\S+)\s*$/) {
+                        ($1 => !!$2);
+                    } elsif (/^\s*(email|gecos|info|id)\s+(.+)\s*$/
+                        or /^\s*(profile)\s+(normal|privileged)\s*$/
+                        or /^\s*(date|update_date)\s+(\d+)\s*$/
+                        or /^\s*(reception)\s+(mail|nomail)\s*$/
+                        or /^\s*(visibility)\s+(conceal|noconceal)\s*$/) {
+                        ($1 => $2);
+                    } else {
+                        ();
+                    }
+                    } split /\n/, $para
+            };
+            next unless $user->{email};
+
             $self->add_list_admin($role, $user);
         }
     }
-    $lock_fh->close;
 
+    $lock_fh->close;
 }
 
 ## include a remote sympa list as subscribers.

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -74,54 +74,31 @@ our %pinfo = (
     },
 
     'owner' => {
-        order        => 10.03,
-        'group'      => 'description',
-        'gettext_id' => "Owner",
-        'gettext_comment' =>
-            'Owners are managing subscribers of the list. They may review subscribers and add or delete email addresses from the mailing list. If you are a privileged owner of the list, you can choose other owners for the mailing list. Privileged owners may edit a few more options than other owners. ',
-        'format'     => {
+        obsolete => 1,
+        'format' => {
             'email' => {
-                'order'      => 1,
-                'gettext_id' => "email address",
-                format_s     => '$email',
-                'occurrence' => '1',
-                'length'     => 30,
-                filters      => ['canonic_email'],
-                validations =>
-                    [qw(list_special_addresses unique_paragraph_key)],
+                obsolete => 1,
+                format_s => '$email',
             },
             'gecos' => {
-                'order'      => 2,
-                'gettext_id' => "name",
-                'format'     => '.+',
-                'length'     => 30
+                obsolete => 1,
+                'format' => '.+',
             },
             'info' => {
-                'order'      => 3,
-                'gettext_id' => "private information",
-                'format'     => '.+',
-                'length'     => 30
+                obsolete => 1,
+                'format' => '.+',
             },
             'profile' => {
-                'order'      => 4,
-                'gettext_id' => "profile",
-                'format'     => ['privileged', 'normal'],
-                'occurrence' => '1',
-                'default'    => 'normal'
+                obsolete => 1,
+                'format' => ['privileged', 'normal'],
             },
             'reception' => {
-                'order'      => 5,
-                'gettext_id' => "reception mode",
-                'format'     => ['mail', 'nomail'],
-                'occurrence' => '1',
-                'default'    => 'mail'
+                obsolete => 1,
+                'format' => ['mail', 'nomail'],
             },
             'visibility' => {
-                'order'      => 6,
-                'gettext_id' => "visibility",
-                'format'     => ['conceal', 'noconceal'],
-                'occurrence' => '1',
-                'default'    => 'noconceal'
+                obsolete => 1,
+                'format' => ['conceal', 'noconceal'],
             }
         },
         'occurrence' => '1-n'
@@ -170,46 +147,27 @@ our %pinfo = (
     },
 
     'editor' => {
-        order        => 10.05,
-        'group'      => 'description',
-        'gettext_id' => "Moderators",
-        'gettext_comment' =>
-            "Editors are responsible for moderating messages. If the mailing list is moderated, messages posted to the list will first be passed to the editors, who will decide whether to distribute or reject it.\nFYI: Defining editors will not make the list moderated; you will have to set the \"send\" parameter.\nFYI: If the list is moderated, any editor can distribute or reject a message without the knowledge or consent of the other editors. Messages that have not been distributed or rejected will remain in the moderation spool until they are acted on.",
-        'format'     => {
+        obsolete => 1,
+        'format' => {
             'email' => {
-                'order'      => 1,
-                'gettext_id' => "email address",
-                format_s     => '$email',
-                'occurrence' => '1',
-                'length'     => 30,
-                filters      => ['canonic_email'],
-                validations => [qw(list_editor_address unique_paragraph_key)],
+                obsolete => 1,
+                format_s => '$email',
             },
             'reception' => {
-                'order'      => 4,
-                'gettext_id' => "reception mode",
-                'format'     => ['mail', 'nomail'],
-                'occurrence' => '1',
-                'default'    => 'mail'
+                obsolete => 1,
+                'format' => ['mail', 'nomail'],
             },
             'visibility' => {
-                'order'      => 5,
-                'gettext_id' => "visibility",
-                'format'     => ['conceal', 'noconceal'],
-                'occurrence' => '1',
-                'default'    => 'noconceal'
+                obsolete => 1,
+                'format' => ['conceal', 'noconceal'],
             },
             'gecos' => {
-                'order'      => 2,
-                'gettext_id' => "name",
-                'format'     => '.+',
-                'length'     => 30
+                obsolete => 1,
+                'format' => '.+',
             },
             'info' => {
-                'order'      => 3,
-                'gettext_id' => "private information",
-                'format'     => '.+',
-                'length'     => 30
+                obsolete => 1,
+                'format' => '.+',
             }
         },
         'occurrence' => '0-n'
@@ -2522,12 +2480,187 @@ our %pinfo = (
     }
 );
 
+our %user_info = (
+    owner => {
+        order      => 10.03,
+        group      => 'description',
+        gettext_id => "Owner",
+        gettext_comment =>
+            'Owners are managing subscribers of the list. They may review subscribers and add or delete email addresses from the mailing list. If you are a privileged owner of the list, you can choose other owners for the mailing list. Privileged owners may edit a few more options than other owners. ',
+        format => {
+            email => {
+                order      => 1,
+                gettext_id => "email address",
+                format_s   => '$email',
+                occurrence => '1',
+                length     => 30,
+                filters    => ['canonic_email'],
+                validations =>
+                    [qw(list_special_addresses unique_paragraph_key)],
+            },
+            gecos => {
+                order      => 2,
+                gettext_id => "name",
+                format     => '.+',
+                length     => 30
+            },
+            info => {
+                order      => 3,
+                gettext_id => "private information",
+                format     => '.+',
+                length     => 30
+            },
+            profile => {
+                order      => 4,
+                gettext_id => "profile",
+                format     => ['privileged', 'normal'],
+                occurrence => '1',
+                default    => 'normal'
+            },
+            reception => {
+                order      => 5,
+                gettext_id => "reception mode",
+                format     => ['mail', 'nomail'],
+                occurrence => '1',
+                default    => 'mail'
+            },
+            visibility => {
+                order      => 6,
+                gettext_id => "visibility",
+                format     => ['conceal', 'noconceal'],
+                occurrence => '1',
+                default    => 'noconceal'
+            },
+            subscribed => {
+                order      => 11,
+                gettext_id => 'subscribed',
+                format     => ['0', '1'],
+                occurrence => '1',
+                default    => '1',
+                internal   => 1,
+            },
+            included => {
+                order      => 12,
+                gettext_id => 'included',
+                format     => ['0', '1'],
+                occurrence => '1',
+                default    => '0',
+                internal   => 1,
+            },
+            id => {
+                order      => 13,
+                gettext_id => 'name of external datasource',
+                internal   => 1,
+            },
+            date => {
+                order      => 14,
+                gettext_id => 'date this user become a list admin',
+                format     => '\d+',
+                field_type => 'unixtime',
+                internal   => 1,
+            },
+            update_date => {
+                order      => 15,
+                gettext_id => 'last update time',
+                format     => '\d+',
+                field_type => 'unixtime',
+                internal   => 1,
+            },
+        },
+        occurrence => '1-n'
+    },
+
+    editor => {
+        order      => 10.05,
+        group      => 'description',
+        gettext_id => "Moderators",
+        gettext_comment =>
+            "Editors are responsible for moderating messages. If the mailing list is moderated, messages posted to the list will first be passed to the editors, who will decide whether to distribute or reject it.\nFYI: Defining editors will not make the list moderated; you will have to set the \"send\" parameter.\nFYI: If the list is moderated, any editor can distribute or reject a message without the knowledge or consent of the other editors. Messages that have not been distributed or rejected will remain in the moderation spool until they are acted on.",
+        format => {
+            email => {
+                order       => 1,
+                gettext_id  => "email address",
+                format_s    => '$email',
+                occurrence  => '1',
+                length      => 30,
+                filters     => ['canonic_email'],
+                validations => [qw(list_editor_address unique_paragraph_key)],
+            },
+            gecos => {
+                order      => 2,
+                gettext_id => "name",
+                format     => '.+',
+                length     => 30
+            },
+            info => {
+                order      => 3,
+                gettext_id => "private information",
+                format     => '.+',
+                length     => 30
+            },
+            reception => {
+                order      => 4,
+                gettext_id => "reception mode",
+                format     => ['mail', 'nomail'],
+                occurrence => '1',
+                default    => 'mail'
+            },
+            visibility => {
+                order      => 5,
+                gettext_id => "visibility",
+                format     => ['conceal', 'noconceal'],
+                occurrence => '1',
+                default    => 'noconceal'
+            },
+            subscribed => {
+                order      => 11,
+                gettext_id => 'subscribed',
+                format     => ['0', '1'],
+                occurrence => '1',
+                default    => '1',
+                internal   => 1,
+            },
+            included => {
+                order      => 12,
+                gettext_id => 'included',
+                format     => ['0', '1'],
+                occurrence => '1',
+                default    => '0',
+                internal   => 1,
+            },
+            id => {
+                order      => 13,
+                gettext_id => 'name of external datasource',
+                internal   => 1,
+            },
+            date => {
+                order      => 14,
+                gettext_id => 'date this user become a list admin',
+                format     => '\d+',
+                field_type => 'unixtime',
+                internal   => 1,
+            },
+            update_date => {
+                order      => 15,
+                gettext_id => 'last update time',
+                format     => '\d+',
+                field_type => 'unixtime',
+                internal   => 1,
+            },
+        },
+        occurrence => '0-n'
+    },
+);
+
 _apply_defaults();
 
 ## Apply defaults to parameters definition (%pinfo)
 sub _apply_defaults {
     foreach my $p (keys %pinfo) {
         cleanup($p, $pinfo{$p});
+    }
+    foreach my $p (keys %user_info) {
+        cleanup($p, $user_info{$p});
     }
 }
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -105,8 +105,8 @@ our %pinfo = (
     },
 
     'owner_include' => {
-        order        => 10.04,
-        'group'      => 'description',
+        order        => 60.02_1,
+        'group'      => 'data_source',
         'gettext_id' => 'Owners defined in an external data source',
         'format'     => {
             'source' => {
@@ -174,8 +174,8 @@ our %pinfo = (
     },
 
     'editor_include' => {
-        order        => 10.06,
-        'group'      => 'description',
+        order        => 60.02_2,
+        'group'      => 'data_source',
         'gettext_id' => 'Moderators defined in an external data source',
         'format'     => {
             'source' => {

--- a/src/lib/Sympa/Request/Handler/close_list.pm
+++ b/src/lib/Sympa/Request/Handler/close_list.pm
@@ -154,9 +154,10 @@ sub _close {
         Conf::get_robot_conf($list->{'domain'}, 'alias_manager'));
     $aliases->del($list) if $aliases;
 
-    # Dump subscribers.
-    $list->_save_list_members_file(
-        $list->{'dir'} . '/subscribers.closed.dump');
+    # Dump users.
+    $list->dump_user('member');
+    $list->dump_user('owner');
+    $list->dump_user('editor');
 
     ## Delete users
     my @users;

--- a/src/lib/Sympa/Request/Handler/close_list.pm
+++ b/src/lib/Sympa/Request/Handler/close_list.pm
@@ -155,9 +155,9 @@ sub _close {
     $aliases->del($list) if $aliases;
 
     # Dump users.
-    $list->dump_user('member');
-    $list->dump_user('owner');
-    $list->dump_user('editor');
+    $list->dump_users('member');
+    $list->dump_users('owner');
+    $list->dump_users('editor');
 
     ## Delete users
     my @users;

--- a/src/lib/Sympa/Request/Handler/create_list.pm
+++ b/src/lib/Sympa/Request/Handler/create_list.pm
@@ -211,7 +211,22 @@ sub _twist {
         return undef;
     }
 
-    print $lock_fh $config;
+    # Write config.
+    # - Write out initial permanent owners/editors in <role>.dump files.
+    # - Write reminder to config file.
+    $config =~ s/(\A|\n)[\t ]+(?=\n)/$1/g;      # normalize empty lines
+    open my $ifh, '<', \$config;                # open "in memory" file
+    my @config = do { local $RS = ''; <$ifh> };
+    close $ifh;
+    foreach my $role (qw(owner editor)) {
+        my $file = $list_dir . '/' . $role . '.dump';
+        if (!-e $file and open my $ofh, '>', $file) {
+            my $admins = join '', grep {/\A\s*$role\b/} @config;
+            print $ofh $admins;
+            close $ofh;
+        }
+    }
+    print $lock_fh join '', grep { !/\A\s*(owner|editor)\b/ } @config;
 
     ## Unlock config file
     $lock_fh->close;
@@ -234,11 +249,17 @@ sub _twist {
 
     # Create list object.
     my $list;
-    unless ($list = Sympa::List->new($listname, $robot_id)) {
+    unless ($list =
+        Sympa::List->new($listname, $robot_id, {skip_sync_admin => 1})) {
         $log->syslog('err', 'Unable to create list %s', $listname);
         $self->add_stash($request, 'intern');
         return undef;
     }
+
+    # Store initial permanent list users.
+    $list->restore_users('member');
+    $list->restore_users('owner');
+    $list->restore_users('editor');
 
     if ($listname ne $request->{listname}) {
         $self->add_stash($request, 'notice', 'listname_lowercased');

--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -221,9 +221,9 @@ sub _move {
     my $aliases = Sympa::Aliases->new(
         Conf::get_robot_conf($current_list->{'domain'}, 'alias_manager'));
     $aliases->del($current_list) if $aliases;
-    $current_list->dump_user('member');
-    $current_list->dump_user('owner');
-    $current_list->dump_user('editor');
+    $current_list->dump_users('member');
+    $current_list->dump_users('owner');
+    $current_list->dump_users('editor');
 
     # Set list status to pending if creation list is moderated.
     # Save config file for the new() later to reload it.

--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -221,8 +221,9 @@ sub _move {
     my $aliases = Sympa::Aliases->new(
         Conf::get_robot_conf($current_list->{'domain'}, 'alias_manager'));
     $aliases->del($current_list) if $aliases;
-    $current_list->_save_list_members_file(
-        $current_list->{'dir'} . '/subscribers.closed.dump');
+    $current_list->dump_user('member');
+    $current_list->dump_user('owner');
+    $current_list->dump_user('editor');
 
     # Set list status to pending if creation list is moderated.
     # Save config file for the new() later to reload it.

--- a/src/lib/Sympa/Request/Handler/open_list.pm
+++ b/src/lib/Sympa/Request/Handler/open_list.pm
@@ -100,9 +100,9 @@ sub _twist {
         }
     }
     # Load permanent users.
-    $list->suck_user('member');
-    $list->suck_user('owner');
-    $list->suck_user('editor');
+    $list->restore_users('member');
+    $list->restore_users('owner');
+    $list->restore_users('editor');
     # Load initial transitional owners/editors from external data sources.
     if ($mode eq 'install') {
         $list->sync_include_admin;

--- a/src/lib/Sympa/Request/Handler/open_list.pm
+++ b/src/lib/Sympa/Request/Handler/open_list.pm
@@ -25,6 +25,7 @@ package Sympa::Request::Handler::open_list;
 
 use strict;
 use warnings;
+use English qw(-no_match_vars);
 use File::Path qw();
 
 use Sympa;
@@ -80,16 +81,32 @@ sub _twist {
         return undef;
     }
 
-    unless (-f $list->{'dir'} . '/subscribers.closed.dump') {
-        $log->syslog('notice', 'No subscribers to restore');
-    }
-    my @users = Sympa::List::_load_list_members_file(
-        $list->{'dir'} . '/subscribers.closed.dump');
-    # Insert users in database.
-    $list->add_list_member(@users);
+    # Dump initial permanent owners/editors in config file.
+    if ($mode eq 'install') {
+        my ($fh, $fh_config);
+        foreach my $role (qw(owner editor)) {
+            my $file   = $list->{'dir'} . '/' . $role . '.dump';
+            my $config = $list->{'dir'} . '/config';
 
-    # Restore admins
-    $list->sync_include_admin;
+            if (    !-e $file
+                and open($fh,        '>', $file)
+                and open($fh_config, '<', $config)) {
+                local $RS = '';    # read paragraph by each
+                my $admins = join '', grep {/\A\s*$role\b/} <$fh_config>;
+                print $fh $admins;
+                close $fh;
+                close $fh_config;
+            }
+        }
+    }
+    # Load permanent users.
+    $list->suck_user('member');
+    $list->suck_user('owner');
+    $list->suck_user('editor');
+    # Load initial transitional owners/editors from external data sources.
+    if ($mode eq 'install') {
+        $list->sync_include_admin;
+    }
 
     # Install new aliases.
     my $aliases = Sympa::Aliases->new(

--- a/src/lib/Sympa/Request/Handler/open_list.pm
+++ b/src/lib/Sympa/Request/Handler/open_list.pm
@@ -81,30 +81,15 @@ sub _twist {
         return undef;
     }
 
-    # Dump initial permanent owners/editors in config file.
-    if ($mode eq 'install') {
-        my ($fh, $fh_config);
-        foreach my $role (qw(owner editor)) {
-            my $file   = $list->{'dir'} . '/' . $role . '.dump';
-            my $config = $list->{'dir'} . '/config';
-
-            if (    !-e $file
-                and open($fh,        '>', $file)
-                and open($fh_config, '<', $config)) {
-                local $RS = '';    # read paragraph by each
-                my $admins = join '', grep {/\A\s*$role\b/} <$fh_config>;
-                print $fh $admins;
-                close $fh;
-                close $fh_config;
-            }
-        }
-    }
-    # Load permanent users.
-    $list->restore_users('member');
-    $list->restore_users('owner');
-    $list->restore_users('editor');
-    # Load initial transitional owners/editors from external data sources.
-    if ($mode eq 'install') {
+    if ($mode eq 'open') {
+        # Restore permanent/transitional list users dumped by close_list.
+        $list->restore_users('member');
+        $list->restore_users('owner');
+        $list->restore_users('editor');
+    } elsif ($mode eq 'install') {
+        # Since initial poermanent list users have been stored by create_list
+        # or create_automatic_list, add transitional owners/editors from
+        # external data sources.
         $list->sync_include_admin;
     }
 

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -751,7 +751,7 @@ sub upgrade {
                     and rename $list->{'dir'} . '/subscribers',
                     $list->{'dir'} . '/member.dump'
                     ) {
-                    $list->suck_user('member');
+                    $list->restore_users('member');
 
                     my $total = $list->{'add_outcome'}{'added_members'};
                     if (defined $list->{'add_outcome'}{'errors'}) {

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -746,30 +746,29 @@ sub upgrade {
                     $list->{'name'}
                 );
 
-                my @users = Sympa::List::_load_list_members_file(
-                    "$list->{'dir'}/subscribers");
+                # Load <list dir>/subscribers to the DB
+                if (-e $list->{'dir'} . '/subscribers'
+                    and rename $list->{'dir'} . '/subscribers',
+                    $list->{'dir'} . '/member.dump'
+                    ) {
+                    $list->suck_user('member');
+
+                    my $total = $list->{'add_outcome'}{'added_members'};
+                    if (defined $list->{'add_outcome'}{'errors'}) {
+                        $log->syslog('err', 'Failed to add users: %s',
+                            $list->{'add_outcome'}{'errors'}
+                                {'error_message'});
+                    }
+                    $log->syslog('notice',
+                        '%d subscribers have been loaded into the database',
+                        $total);
+                }
 
                 $list->{'admin'}{'user_data_source'} = 'include2';
 
-                ## Add users to the DB
-                $list->add_list_member(@users);
-                my $total = $list->{'add_outcome'}{'added_members'};
-                if (defined $list->{'add_outcome'}{'errors'}) {
-                    $log->syslog(
-                        'err',
-                        'Failed to add users: %s',
-                        $list->{'add_outcome'}{'errors'}{'error_message'}
-                    );
-                }
-
-                $log->syslog('notice',
-                    '%d subscribers have been loaded into the database',
-                    $total);
-
                 unless ($list->save_config('automatic')) {
                     $log->syslog('err',
-                        'Failed to save config file for list %s',
-                        $list->{'name'});
+                        'Failed to save config file for list %s', $list);
                 }
             } elsif ($list->{'admin'}{'user_data_source'} eq 'database') {
 
@@ -943,7 +942,7 @@ sub upgrade {
             'task_manager_pidfile' => 'No more used',
             'archived_pidfile'     => 'No more used',
             'bounced_pidfile'      => 'No more used',
-            'use_fast_cgi'         => 'No longer used', # 6.2.25b deprecated
+            'use_fast_cgi'         => 'No longer used',   # 6.2.25b deprecated
         );
 
         ## Set language of new file content
@@ -1773,6 +1772,38 @@ sub upgrade {
                 _get_canonical_read_date($sdm, 'update_admin')
             )
         );
+
+        $log->syslog('notice', 'Upgrading user dumps of closed lists.');
+        # Upgrading user dumps of closed lists.
+        my $lists =
+            Sympa::List::get_lists('*',
+            filter => [status => 'closed|family_closed']);
+        foreach my $list (@{$lists || []}) {
+            my $dir = $list->{'dir'};
+
+            if (-e $dir . '/subscribers.closed.dump') {
+                unlink $dir . '/member.dump.old';
+                rename $dir . '/member.dump', $dir . '/member.dump.old';
+                rename $dir . '/subscribers.closed.dump',
+                    $dir . '/member.dump';
+            }
+
+            my ($fh, $fh_config);
+            foreach my $role (qw(owner editor)) {
+                my $file   = $list->{'dir'} . '/' . $role . '.dump';
+                my $config = $list->{'dir'} . '/config';
+
+                if (!-e $file
+                    and open($fh, '>', $file)
+                    and open($fh_config, '<', $config)) {
+                    local $RS = '';     # read paragraph by each
+                    my $admins = join '', grep {/\A\s*$role\b/} <$fh_config>;
+                    print $fh $admins;
+                    close $fh;
+                    close $fh_config;
+                }
+            }
+        }
     }
 
     # GH Issue #240: PostgreSQL: Unable to edit owners/subscribers.

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -60,7 +60,7 @@ srand(time());
 my %options;
 unless (
     GetOptions(
-        \%main::options,        'dump=s',
+        \%main::options,        'dump:s',
         'debug|d',              'log_level=s',
         'config|f=s',           'lang|l=s',
         'mail|m',               'help|h',
@@ -83,6 +83,7 @@ unless (
         'conf_2_db',            'export_list',
         'health_check',         'send_digest',
         'keep_digest',          'upgrade_config_location',
+        'role=s',               'suck',
     )
     ) {
     pod2usage(-exitval => 1, -output => \*STDERR);
@@ -280,33 +281,114 @@ unless (Conf::checkfiles()) {
 }
 
 # Daemon called for dumping subscribers list
-if ($main::options{'dump'}) {
+if (defined $main::options{'dump'}) {
+    my $all_lists;
 
-    my ($all_lists, $list);
-    if ($main::options{'dump'} eq 'ALL') {
-        $all_lists = Sympa::List::get_lists('*');
-    } else {
+    # Compat. for old style "--dump=LIST".
+    my $list_id =
+        (length $main::options{'dump'})
+        ? $main::options{'dump'}
+        : $main::options{'list'};
 
-        ## The parameter can be a list address
-        unless ($main::options{'dump'} =~ /\@/) {
-            $log->syslog('err', 'Incorrect list address %s',
-                $main::options{'dump'});
-
-            exit;
+    if (defined $list_id and $list_id eq 'ALL') {
+        $all_lists =
+            Sympa::List::get_lists('*', filter => [status => 'open']);
+    } elsif (defined $list_id and length $list_id) {
+        # The parameter is list ID and list have to be open.
+        unless (0 < index $list_id, '@') {
+            $log->syslog('err', 'Incorrect list address %s', $list_id);
+            exit 1;
         }
-
-        my $list = Sympa::List->new($main::options{'dump'});
+        my $list = Sympa::List->new($list_id);
         unless (defined $list) {
-            $log->syslog('err', 'Unknown list %s', $main::options{'dump'});
-
-            exit;
+            $log->syslog('err', 'Unknown list %s', $list_id);
+            exit 1;
         }
-        push @$all_lists, $list;
+        unless ($list->{'admin'}{'status'} eq 'open') {
+            $log->syslog('err', 'List is not open: %s', $list);
+            exit 1;
+        }
+
+        $all_lists = [$list];
+    } else {
+        $log->syslog('err', 'No lists specified');
+        exit 1;
+    }
+
+    my @roles = qw(member);
+    if ($main::options{'role'}) {
+        my %roles = map { ($_ => 1) }
+            ($main::options{'role'} =~ /\b(member|owner|editor)\b/g);
+        @roles = sort keys %roles;
+        unless (@roles) {
+            $log->syslog('err', 'Unknown role %s', $main::options{'role'});
+            exit 1;
+        }
     }
 
     foreach my $list (@$all_lists) {
-        unless ($list->dump_user('member')) {
-            print STDERR "Could not dump list(s)\n";
+        foreach my $role (@roles) {
+            unless ($list->dump_user($role)) {
+                printf STDERR "%s: Could not dump list users (%s)\n",
+                    $list->get_id, $role;
+            } else {
+                printf STDERR "%s: Dumped list users (%s)\n",
+                    $list->get_id, $role;
+            }
+        }
+    }
+
+    exit 0;
+} elsif ($main::options{'suck'}) {
+    my $all_lists;
+
+    my $list_id = $main::options{'list'};
+
+    if (defined $list_id and $list_id eq 'ALL') {
+        $all_lists =
+            Sympa::List::get_lists('*', filter => [status => 'open']);
+    } elsif (defined $list_id and length $list_id) {
+        # The parameter is list ID and list have to be open.
+        unless (0 < index $list_id, '@') {
+            $log->syslog('err', 'Incorrect list address %s', $list_id);
+            exit 1;
+        }
+        my $list = Sympa::List->new($list_id);
+        unless (defined $list) {
+            $log->syslog('err', 'Unknown list %s', $list_id);
+            exit 1;
+        }
+        unless ($list->{'admin'}{'status'} eq 'open') {
+            $log->syslog('err', 'List is not open: %s', $list);
+            exit 1;
+        }
+
+        $all_lists = [$list];
+    } else {
+        $log->syslog('err', 'No lists specified');
+        exit 1;
+    }
+
+    my @roles = qw(member);
+    if ($main::options{'role'}) {
+        my %roles = map { ($_ => 1) }
+            ($main::options{'role'} =~ /\b(member|owner|editor)\b/g);
+        @roles = sort keys %roles;
+        unless (@roles) {
+            $log->syslog('err', 'Unknown role %s', $main::options{'role'});
+            exit 1;
+        }
+    }
+
+    foreach my $list (@$all_lists) {
+        foreach my $role (@roles) {
+            unless ($list->suck_user($role)) {
+                printf STDERR "%s: Could not suck list users (%s)\n",
+                    $list->get_id, $role;
+            } else {
+                printf STDERR "%s: Sucked list users (%s)\n",
+                    $list->get_id, $role;
+            }
         }
     }
 
@@ -1080,7 +1162,8 @@ S<[ C<--import>=I<listname> ]>
 S<[ C<--close_list>=I<list>[I<@robot>] ]>
 S<[ C<--purge_list>=I<list>[I<@robot>] ]>
 S<[ C<--lowercase> ]> S<[ C<--make_alias_file> ]>
-S<[ C<--dump>=I<listname> | ALL ]>
+S<[ C<--dump> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
+S<[ C<--suck> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
 
 =head1 DESCRIPTION
 
@@ -1151,13 +1234,19 @@ C<--input_file=>I</path/to/file.xml >
 
 Create a list with the XML file under robot robot_name.
 
-=item C<--dump=>I<list>@I<dom>|C<ALL>
+=item C<--dump> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
 
-Dumps subscribers of for `listname' list or all lists. Subscribers are 
-dumped in F<member.dump>.
+Dumps users of a list or all lists.
 
-Note: On Sympa prior to 6.2.25b.2, subscribers were dumped in
-F<subscribers.db.dump>.
+C<--role> may specify C<member>, C<owner>, C<editor> or any of them separated
+by comma (C<,>). Only C<member> is chosen by default.
+
+Users are dumped in files I<role>C<.dump> in each list directory.
+
+Note: On Sympa prior to 6.2.31b.1, subscribers were dumped in
+F<subscribers.db.dump> file, and owners and moderators could not be dumped.
+
+See also C<--suck>.
 
 =begin comment
 
@@ -1237,6 +1326,12 @@ Renames a list or move it to another virtual robot.
 
 Send digest right now.
 If C<--keep_digest> is specified, stocked digest will not be removed.
+
+=item C<--suck> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
+
+Restore users from files dumped by C<--dump>.
+
+Note: This option was added on Sympa 6.2.32.
 
 =item C<--sync_include=>I<listname>@I<robot>
 

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -305,7 +305,7 @@ if ($main::options{'dump'}) {
     }
 
     foreach my $list (@$all_lists) {
-        unless ($list->dump()) {
+        unless ($list->dump_user('member')) {
             print STDERR "Could not dump list(s)\n";
         }
     }
@@ -1154,7 +1154,10 @@ Create a list with the XML file under robot robot_name.
 =item C<--dump=>I<list>@I<dom>|C<ALL>
 
 Dumps subscribers of for `listname' list or all lists. Subscribers are 
-dumped in subscribers.db.dump.
+dumped in F<member.dump>.
+
+Note: On Sympa prior to 6.2.25b.2, subscribers were dumped in
+F<subscribers.db.dump>.
 
 =begin comment
 

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -60,7 +60,7 @@ srand(time());
 my %options;
 unless (
     GetOptions(
-        \%main::options,        'dump:s',
+        \%main::options,        'dump=s',
         'debug|d',              'log_level=s',
         'config|f=s',           'lang|l=s',
         'mail|m',               'help|h',
@@ -83,7 +83,8 @@ unless (
         'conf_2_db',            'export_list',
         'health_check',         'send_digest',
         'keep_digest',          'upgrade_config_location',
-        'role=s',               'suck',
+        'role=s',               'dump_users',
+        'restore_users',
     )
     ) {
     pod2usage(-exitval => 1, -output => \*STDERR);
@@ -281,14 +282,11 @@ unless (Conf::checkfiles()) {
 }
 
 # Daemon called for dumping subscribers list
-if (defined $main::options{'dump'}) {
+if ($main::options{'dump'} or $main::options{'dump_users'}) {
     my $all_lists;
 
     # Compat. for old style "--dump=LIST".
-    my $list_id =
-        (length $main::options{'dump'})
-        ? $main::options{'dump'}
-        : $main::options{'list'};
+    my $list_id = $main::options{'dump'} || $main::options{'list'};
 
     if (defined $list_id and $list_id eq 'ALL') {
         $all_lists =
@@ -328,7 +326,7 @@ if (defined $main::options{'dump'}) {
 
     foreach my $list (@$all_lists) {
         foreach my $role (@roles) {
-            unless ($list->dump_user($role)) {
+            unless ($list->dump_users($role)) {
                 printf STDERR "%s: Could not dump list users (%s)\n",
                     $list->get_id, $role;
             } else {
@@ -339,7 +337,7 @@ if (defined $main::options{'dump'}) {
     }
 
     exit 0;
-} elsif ($main::options{'suck'}) {
+} elsif ($main::options{'restore_users'}) {
     my $all_lists;
 
     my $list_id = $main::options{'list'};
@@ -382,11 +380,11 @@ if (defined $main::options{'dump'}) {
 
     foreach my $list (@$all_lists) {
         foreach my $role (@roles) {
-            unless ($list->suck_user($role)) {
-                printf STDERR "%s: Could not suck list users (%s)\n",
+            unless ($list->restore_users($role)) {
+                printf STDERR "%s: Could not restore list users (%s)\n",
                     $list->get_id, $role;
             } else {
-                printf STDERR "%s: Sucked list users (%s)\n",
+                printf STDERR "%s: Restored list users (%s)\n",
                     $list->get_id, $role;
             }
         }
@@ -1162,8 +1160,8 @@ S<[ C<--import>=I<listname> ]>
 S<[ C<--close_list>=I<list>[I<@robot>] ]>
 S<[ C<--purge_list>=I<list>[I<@robot>] ]>
 S<[ C<--lowercase> ]> S<[ C<--make_alias_file> ]>
-S<[ C<--dump> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
-S<[ C<--suck> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
+S<[ C<--dump_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
+S<[ C<--restore_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
 
 =head1 DESCRIPTION
 
@@ -1234,7 +1232,11 @@ C<--input_file=>I</path/to/file.xml >
 
 Create a list with the XML file under robot robot_name.
 
-=item C<--dump> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
+=item C<--dump=>I<list>@I<domain>|C<ALL>
+
+Obsoleted option.  Use C<--dump_users>.
+
+=item C<--dump_users> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
 
 Dumps users of a list or all lists.
 
@@ -1246,7 +1248,9 @@ Users are dumped in files I<role>C<.dump> in each list directory.
 Note: On Sympa prior to 6.2.31b.1, subscribers were dumped in
 F<subscribers.db.dump> file, and owners and moderators could not be dumped.
 
-See also C<--suck>.
+See also C<--restore_users>.
+
+Note: This option replaced C<--dump> on Sympa 6.2.34.
 
 =begin comment
 
@@ -1327,11 +1331,11 @@ Renames a list or move it to another virtual robot.
 Send digest right now.
 If C<--keep_digest> is specified, stocked digest will not be removed.
 
-=item C<--suck> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
+=item C<--restore_users> C<--list=>I<list>@I<domain>|C<ALL> [ C<--role=>I<roles> ]
 
-Restore users from files dumped by C<--dump>.
+Restore users from files dumped by C<--dump_users>.
 
-Note: This option was added on Sympa 6.2.32.
+Note: This option was added on Sympa 6.2.34.
 
 =item C<--sync_include=>I<listname>@I<robot>
 

--- a/www/js/sympa.js
+++ b/www/js/sympa.js
@@ -529,7 +529,8 @@ $(function() {
 
 /* Add "Close" button to popup showing bounce. */
 $(function() {
-    $('#mainviewbounce, #mainviewmod').on('opened.fndtn.reveal', function(){
+    $('#edit, #mainviewbounce, #mainviewmod')
+    .on('opened.fndtn.reveal', function(){
         var closeButton =
             $('<a class="close-reveal-modal" aria-label="' + sympa.closeText
                 + '">&#215;</a>');


### PR DESCRIPTION
This PR depends on PR #267.

----
Bug fix:
  - Issue #11: Spurious error on duplicate keys with admin sync
      - Now sync_include_admin() passes cache and updates admin_table directly.
      - It no longer reload owner/editor in list config.

Changes/improvements:
  - Form to edit owners and moderators are removed from list config page: They have their own menus.
    ![2018-04-22 19 00 04](https://user-images.githubusercontent.com/5743546/39093758-b33bec80-465f-11e8-8fe3-d8f8fd3bd110.png)
  - When a list is created, initial owners and moderators are importd from dump file in list directory: `owner` and `editor` parameters in `config` file are no longer loaded.
      - However, when list is created using list creation template, `owner` and `editor` are split into dump files automatically: users need not update `config.tt2`.
      - And however, when administrator manually creates a list by creating list directory and `config` file, they also have to put dump files and have to run `sympa.pl --restore_users`.

Known bugs:
  - Big data source consumes large memory, because entire records are read at once when users are synchronized.
  - Owner/editor edition pages do not respect privileges defined by `edit_list.conf`.  This will be fixed later.
