### PR TITLE
Binary cache files for sympa.conf/rebot.conf are useless

### DIFF
--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -2426,17 +2426,7 @@ sub _save_config_hash_to_binary {
     }
 }
 
-sub _source_has_not_changed {
-    my $file = shift;
-
-    my $file_bin = $file . $binary_file_extension;
-    return 1
-        if -r $file
-        and -r $file_bin
-        and Sympa::Tools::File::get_mtime($file) <
-        Sympa::Tools::File::get_mtime($file_bin);
-    return 0;
-}
+sub _source_has_not_changed {0}
 
 sub _store_source_file_name {
     my $param = shift;

--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -184,62 +184,59 @@ sub load {
     my $config_err = 0;
     my %line_numbered_config;
 
-        $log->syslog('debug3',
-            'File %s has changed since the last cache. Loading file',
+    $log->syslog('debug3',
+        'File %s has changed since the last cache. Loading file',
+        $config_file);
+    # Will force the robot.conf reloading, as sympa.conf is the default.
+    $force_reload = 1;
+    ## Loading the Sympa main config file.
+    if (my $config_loading_result =
+        _load_config_file_to_hash({'path_to_config_file' => $config_file})) {
+        %line_numbered_config =
+            %{$config_loading_result->{'numbered_config'}};
+        %Conf       = %{$config_loading_result->{'config'}};
+        $config_err = $config_loading_result->{'errors'};
+    } else {
+        return undef;
+    }
+    # Returning the config file content if this is what has been asked.
+    return (\%line_numbered_config) if ($return_result);
+
+    # Users may define parameters with a typo or other errors. Check that
+    # the parameters
+    # we found in the config file are all well defined Sympa parameters.
+    $config_err += _detect_unknown_parameters_in_config(
+        {   'config_hash'                          => \%Conf,
+            'config_file_line_numbering_reference' => \%line_numbered_config,
+        }
+    );
+
+    # Some parameter values are hardcoded. In that case, ignore what was
+    #  set in the config file and simply use the hardcoded value.
+    %Ignored_Conf =
+        %{_set_hardcoded_parameter_values({'config_hash' => \%Conf,})};
+
+    _set_listmasters_entry({'config_hash' => \%Conf, 'main_config' => 1});
+
+    ## Some parameters must have a value specifically defined in the
+    ## config. If not, it is an error.
+    $config_err += _detect_missing_mandatory_parameters(
+        {'config_hash' => \%Conf, 'file_to_check' => $config_file});
+
+    # Some parameters need special treatments to get their final values.
+    _infer_server_specific_parameter_values({'config_hash' => \%Conf,});
+
+    _infer_robot_parameter_values({'config_hash' => \%Conf});
+
+    if ($config_err) {
+        $log->syslog('err', 'Errors while parsing main config file %s',
             $config_file);
-        # Will force the robot.conf reloading, as sympa.conf is the default.
-        $force_reload = 1;
-        ## Loading the Sympa main config file.
-        if (my $config_loading_result = _load_config_file_to_hash(
-                {'path_to_config_file' => $config_file}
-            )
-            ) {
-            %line_numbered_config =
-                %{$config_loading_result->{'numbered_config'}};
-            %Conf       = %{$config_loading_result->{'config'}};
-            $config_err = $config_loading_result->{'errors'};
-        } else {
-            return undef;
-        }
-        # Returning the config file content if this is what has been asked.
-        return (\%line_numbered_config) if ($return_result);
+        return undef;
+    }
 
-        # Users may define parameters with a typo or other errors. Check that
-        # the parameters
-        # we found in the config file are all well defined Sympa parameters.
-        $config_err += _detect_unknown_parameters_in_config(
-            {   'config_hash' => \%Conf,
-                'config_file_line_numbering_reference' =>
-                    \%line_numbered_config,
-            }
-        );
-
-        # Some parameter values are hardcoded. In that case, ignore what was
-        #  set in the config file and simply use the hardcoded value.
-        %Ignored_Conf =
-            %{_set_hardcoded_parameter_values({'config_hash' => \%Conf,})};
-
-        _set_listmasters_entry({'config_hash' => \%Conf, 'main_config' => 1});
-
-        ## Some parameters must have a value specifically defined in the
-        ## config. If not, it is an error.
-        $config_err += _detect_missing_mandatory_parameters(
-            {'config_hash' => \%Conf, 'file_to_check' => $config_file});
-
-        # Some parameters need special treatments to get their final values.
-        _infer_server_specific_parameter_values({'config_hash' => \%Conf,});
-
-        _infer_robot_parameter_values({'config_hash' => \%Conf});
-
-        if ($config_err) {
-            $log->syslog('err', 'Errors while parsing main config file %s',
-                $config_file);
-            return undef;
-        }
-
-        _store_source_file_name(
-            {'config_hash' => \%Conf, 'config_file' => $config_file});
-        #XXX_save_config_hash_to_binary({'config_hash' => \%Conf,});
+    _store_source_file_name(
+        {'config_hash' => \%Conf, 'config_file' => $config_file});
+    #XXX_save_config_hash_to_binary({'config_hash' => \%Conf,});
 
     if (my $missing_modules_count =
         _check_cpan_modules_required_by_config({'config_hash' => \%Conf,})) {
@@ -827,7 +824,7 @@ sub checkfiles {
                 $pictures_dir);
             $config_err++;
         } else {
-            chmod 0775, $pictures_dir;  # set masked bits.
+            chmod 0775, $pictures_dir;    # set masked bits.
 
             my $index_path = $pictures_dir . '/index.html';
             my $fh;
@@ -942,11 +939,11 @@ sub _load_auth {
             'alternative_email_attribute' => Sympa::Regexps::ldap_attrdesc()
                 . '(\s*,\s*'
                 . Sympa::Regexps::ldap_attrdesc() . ')*',
-            'scope'                       => 'base|one|sub',
-            'authentication_info_url'     => 'http(s)?:/.*',
-            'use_tls'                     => 'starttls|ldaps|none',
-            'use_ssl'                     => '1',                  # Obsoleted
-            'use_start_tls'               => '1',                  # Obsoleted
+            'scope'                   => 'base|one|sub',
+            'authentication_info_url' => 'http(s)?:/.*',
+            'use_tls'                 => 'starttls|ldaps|none',
+            'use_ssl'                 => '1',                     # Obsoleted
+            'use_start_tls'           => '1',                     # Obsoleted
             'ssl_version' => 'sslv2/3|sslv2|sslv3|tlsv1|tlsv1_1|tlsv1_2',
             'ssl_ciphers' => '[\w:]+',
             'ssl_cert'    => '.+',
@@ -981,8 +978,8 @@ sub _load_auth {
             'get_email_by_uid_filter' => '.+',
             'email_attribute'         => Sympa::Regexps::ldap_attrdesc(),
             'use_tls'                 => 'starttls|ldaps|none',
-            'use_ssl'                 => '1',                     # Obsoleted
-            'use_start_tls'           => '1',                     # Obsoleted
+            'use_ssl'       => '1',    # Obsoleted
+            'use_start_tls' => '1',    # Obsoleted
             'ssl_version' => 'sslv2/3|sslv2|sslv3|tlsv1|tlsv1_1|tlsv1_2',
             'ssl_ciphers' => '[\w:]+',
             'ssl_cert'    => '.+',
@@ -1008,8 +1005,8 @@ sub _load_auth {
             'get_email_by_uid_filter' => '.+',
             'email_attribute'         => Sympa::Regexps::ldap_attrdesc(),
             'use_tls'                 => 'starttls|ldaps|none',
-            'use_ssl'                 => '1',                     # Obsoleted
-            'use_start_tls'           => '1',                     # Obsoleted
+            'use_ssl'       => '1',    # Obsoleted
+            'use_start_tls' => '1',    # Obsoleted
             'ssl_version' => 'sslv2/3|sslv2|sslv3|tlsv1|tlsv1_1|tlsv1_2',
             'ssl_ciphers' => '[\w:]+',
             'ssl_cert'    => '.+',
@@ -1368,8 +1365,11 @@ sub load_automatic_lists_description {
         },
     );
     # find appropriate automatic_lists_description.conf file
-    my $config = Sympa::search_fullpath($robot,
-        'automatic_lists_description.conf', subdir => ('families/' . $family));
+    my $config = Sympa::search_fullpath(
+        $robot,
+        'automatic_lists_description.conf',
+        subdir => ('families/' . $family)
+    );
     return undef unless $config;
     my $description =
         load_generic_conf_file($config, \%automatic_lists_params);
@@ -1969,10 +1969,10 @@ sub _infer_robot_parameter_values {
     # even if the doc requires domain.
     $param->{'config_hash'}{'domain'} = $param->{'config_hash'}{'host'}
         if not defined $param->{'config_hash'}{'domain'}
-            and defined $param->{'config_hash'}{'host'};
+        and defined $param->{'config_hash'}{'host'};
 
-    $param->{'config_hash'}{'wwsympa_url'} ||=
-        sprintf 'http://%s/sympa', $param->{'config_hash'}{'domain'};
+    $param->{'config_hash'}{'wwsympa_url'} ||= sprintf 'http://%s/sympa',
+        $param->{'config_hash'}{'domain'};
 
     $param->{'config_hash'}{'static_content_url'} ||=
         $Conf{'static_content_url'};
@@ -2139,49 +2139,47 @@ sub _load_single_robot_config {
     my $robot_conf;
 
     my $config_err;
-    my $config_file  = "$Conf{'etc'}/$robot/robot.conf";
+    my $config_file = "$Conf{'etc'}/$robot/robot.conf";
 
-        if (my $config_loading_result = _load_config_file_to_hash(
-                {'path_to_config_file' => $config_file}
-            )
-            ) {
-            $robot_conf = $config_loading_result->{'config'};
-            $config_err = $config_loading_result->{'errors'};
-        } else {
-            $log->syslog('err', 'Unable to load %s. Aborting', $config_file);
-            return undef;
-        }
+    if (my $config_loading_result =
+        _load_config_file_to_hash({'path_to_config_file' => $config_file})) {
+        $robot_conf = $config_loading_result->{'config'};
+        $config_err = $config_loading_result->{'errors'};
+    } else {
+        $log->syslog('err', 'Unable to load %s. Aborting', $config_file);
+        return undef;
+    }
 
-        # Remove entries which are not supposed to be defined at the robot
-        # level.
-        _dump_non_robot_parameters(
-            {'config_hash' => $robot_conf, 'robot' => $robot});
+    # Remove entries which are not supposed to be defined at the robot
+    # level.
+    _dump_non_robot_parameters(
+        {'config_hash' => $robot_conf, 'robot' => $robot});
 
-        #FIXME: They may be no longer used.  Kept for possible compatibility.
-        $robot_conf->{'host'}       ||= $robot;
-        $robot_conf->{'robot_name'} ||= $robot;
+    #FIXME: They may be no longer used.  Kept for possible compatibility.
+    $robot_conf->{'host'}       ||= $robot;
+    $robot_conf->{'robot_name'} ||= $robot;
 
-        unless ($robot_conf->{'dkim_signer_domain'}) {
-            $robot_conf->{'dkim_signer_domain'} = $robot;
-        }
+    unless ($robot_conf->{'dkim_signer_domain'}) {
+        $robot_conf->{'dkim_signer_domain'} = $robot;
+    }
 
-        my @dmarc = split /[,\s]+/,
-            ($robot_conf->{'dmarc_protection_mode'} || '');
-        if (@dmarc) {
-            $robot_conf->{'dmarc_protection_mode'} = \@dmarc;
-        } else {
-            delete $robot_conf->{'dmarc_protection_mode'};
-        }
+    my @dmarc = split /[,\s]+/,
+        ($robot_conf->{'dmarc_protection_mode'} || '');
+    if (@dmarc) {
+        $robot_conf->{'dmarc_protection_mode'} = \@dmarc;
+    } else {
+        delete $robot_conf->{'dmarc_protection_mode'};
+    }
 
-        _set_listmasters_entry({'config_hash' => $robot_conf});
+    _set_listmasters_entry({'config_hash' => $robot_conf});
 
-        _infer_robot_parameter_values({'config_hash' => $robot_conf});
+    _infer_robot_parameter_values({'config_hash' => $robot_conf});
 
-        _store_source_file_name(
-            {'config_hash' => $robot_conf, 'config_file' => $config_file});
-        #XXX_save_config_hash_to_binary(
-        #XXX    {'config_hash' => $robot_conf, 'source_file' => $config_file});
-        return undef if ($config_err);
+    _store_source_file_name(
+        {'config_hash' => $robot_conf, 'config_file' => $config_file});
+    #XXX_save_config_hash_to_binary(
+    #XXX    {'config_hash' => $robot_conf, 'source_file' => $config_file});
+    return undef if ($config_err);
 
     _replace_file_value_by_db_value({'config_hash' => $robot_conf})
         unless $param->{'no_db'};

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -126,8 +126,8 @@ sub upgrade {
         return undef;
     }
 
-    ## Always update config.bin files while upgrading
-    Conf::delete_binaries();
+    #XXX# Always update config.bin files while upgrading
+    #XXXConf::delete_binaries();
 
     ## Always update config.bin files while upgrading
     ## This is especially useful for character encoding reasons


### PR DESCRIPTION
As sympa.conf/robot.conf won't be reloaded by current version, binary cache for these files are useless. Fixed by not checking updates on these files.  Worse, even if a new parameter was added, cached configuration will be used and new parameter will be undefined instead of default value.

For example see issue #280.

This PR removes feature of binary cache for sympa.conf/robot.conf.
