### PR TITLE
added expire tasks (2,3,4,6,9 months)

### DIFF
--- a/default/list_task_models/expire.2month.task
+++ b/default/list_task_models/expire.2month.task
@@ -1,0 +1,17 @@
+title.gettext expiration routine run every 2 months
+
+/STEP1
+@selection = select_subs (older ([creation_date]-2m))
+send_msg (@selection, expire_warning1)
+next ([execution_date]+3w, STEP2)
+
+/STEP2
+@selection = select_subs (older ([creation_date]-2m))
+send_msg (@selection, expire_warning2)
+next ([execution_date]+1w, STEP3)
+
+/STEP3
+@selection = select_subs (older ([creation_date]-2m))
+@deleted = delete (@selection)
+send_msg (@deleted, expire_deletion)
+stop ()

--- a/default/list_task_models/expire.3month.task
+++ b/default/list_task_models/expire.3month.task
@@ -1,0 +1,17 @@
+title.gettext expiration routine run every 3 months
+
+/STEP1
+@selection = select_subs (older ([creation_date]-3m))
+send_msg (@selection, expire_warning1)
+next ([execution_date]+3w, STEP2)
+
+/STEP2
+@selection = select_subs (older ([creation_date]-3m))
+send_msg (@selection, expire_warning2)
+next ([execution_date]+1w, STEP3)
+
+/STEP3
+@selection = select_subs (older ([creation_date]-3m))
+@deleted = delete (@selection)
+send_msg (@deleted, expire_deletion)
+stop ()

--- a/default/list_task_models/expire.4month.task
+++ b/default/list_task_models/expire.4month.task
@@ -1,0 +1,17 @@
+title.gettext expiration routine run every 4 months
+
+/STEP1
+@selection = select_subs (older ([creation_date]-4m))
+send_msg (@selection, expire_warning1)
+next ([execution_date]+3w, STEP2)
+
+/STEP2
+@selection = select_subs (older ([creation_date]-4m))
+send_msg (@selection, expire_warning2)
+next ([execution_date]+1w, STEP3)
+
+/STEP3
+@selection = select_subs (older ([creation_date]-4m))
+@deleted = delete (@selection)
+send_msg (@deleted, expire_deletion)
+stop ()

--- a/default/list_task_models/expire.6month.task
+++ b/default/list_task_models/expire.6month.task
@@ -1,0 +1,17 @@
+title.gettext expiration routine run every 6 months
+
+/STEP1
+@selection = select_subs (older ([creation_date]-6m))
+send_msg (@selection, expire_warning1)
+next ([execution_date]+3w, STEP2)
+
+/STEP2
+@selection = select_subs (older ([creation_date]-6m))
+send_msg (@selection, expire_warning2)
+next ([execution_date]+1w, STEP3)
+
+/STEP3
+@selection = select_subs (older ([creation_date]-6m))
+@deleted = delete (@selection)
+send_msg (@deleted, expire_deletion)
+stop ()

--- a/default/list_task_models/expire.9month.task
+++ b/default/list_task_models/expire.9month.task
@@ -1,0 +1,17 @@
+title.gettext expiration routine run every 9 months
+
+/STEP1
+@selection = select_subs (older ([creation_date]-9m))
+send_msg (@selection, expire_warning1)
+next ([execution_date]+3w, STEP2)
+
+/STEP2
+@selection = select_subs (older ([creation_date]-9m))
+send_msg (@selection, expire_warning2)
+next ([execution_date]+1w, STEP3)
+
+/STEP3
+@selection = select_subs (older ([creation_date]-9m))
+@deleted = delete (@selection)
+send_msg (@deleted, expire_deletion)
+stop ()


### PR DESCRIPTION
Adds expire tasks for 2,3,4,6 and 9 months under the "default list_task_models".

Currently only the yearly expire task is available.