### PR TITLE
Add copyright notice to sympa.js

### DIFF
--- a/www/js/sympa.js
+++ b/www/js/sympa.js
@@ -1,4 +1,7 @@
-/* $Id$ */
+/*
+ * Copyright 2010-2018 The Sympa Community. Licensed under GNU GPL v2
+ * See license text at https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+ */
 
 // To confirm on a link (A HREF)
 function refresh_mom_and_die() {


### PR DESCRIPTION
sympa.js is missing a copyright notice.
I traced back the code to 2010 : https://github.com/sympa-community/sympa/commits/8af6368fe8acec2caa0c66298e6614eed969d6b3/src/etc/script/js/sympa.js
@dverdin and @ikedas are the ones who significantly touched the code.
I chose to use a short copyright notice rather than the full GPL boilerplate in order to not add too much to the transfer size of the javascript to the client.
@dverdin , @ikedas,  do you both agree to the licensing (same as sympa itself) and the shape of the copyright notice ?
