### PR TITLE
[-bug] Title of send.confidential and send.private are the same.

### DIFF
--- a/default/scenari/send.confidential
+++ b/default/scenari/send.confidential
@@ -1,4 +1,4 @@
-title.gettext restricted to subscribers
+title.gettext restricted to subscribers, messages from others are discarded
 
 is_subscriber([listname],[sender])             smtp,dkim,smime,md5    -> do_it
 is_editor([listname],[sender])                 smtp,dkim,smime,md5    -> do_it


### PR DESCRIPTION
This may fix issue #175.
