### PR TITLE
Support for spam reporting in bulk. Moved the bulk moderation controls.

### DIFF
--- a/default/web_tt2/modindex.tt2
+++ b/default/web_tt2/modindex.tt2
@@ -7,26 +7,6 @@
    method="POST">
   <fieldset class="toggleContainer" data-toggle-selector="input[name='id']">
     <input type="hidden" name="list" value="[% list %]" form="moderate_mails" />
-  <p>
-    <input class="MainMenuLinks" type="submit" form="moderate_mails" name="action_distribute" value="[%|loc%]Distribute[%END%]" />
-  </p>
-  <p>
-    <input class="MainMenuLinks" type="submit" form="moderate_mails" name="action_reject" value="[%|loc%]Reject[%END%]" />
-    <input type="hidden" name="from_modindex" value="from_modindex" form="moderate_mails" />
-      <select  name="message_template" form="moderate_mails">
-       <option  value="reject_quiet"[%- IF msg.value.spam_status == 'spam' -%] [% one_template_is_selected = '1' %]selected="selected"[% END %]>[%|loc %]No notification[%END%]</option>
-       <option  value="reject">[%|loc %]Server default rejection message[%END%]</option>
-       [% FOREACH file = available_files %]
-       <option  value="reject_[%  file  %]" [% IF file == default_reject_template %] selected="selected" [%END%] > [% file  %]</option>
-       [%- END- %]
-      </select>
-   <br />
-  </p>
-  <p>
-    <input type=checkbox name="blacklist" form="moderate_mails" /> [%|loc %]Add to blacklist[%END%]
-  </p>
-
-  <h3>[%|loc%]Listing messages to moderate[%END%]</h3>
 
   <div class="row">
     <div class="small-2 medium-1 columns">
@@ -55,7 +35,7 @@
     <div class="row">
       <div class="small-2 medium-1 columns">
         <input type="checkbox" name="id" value="[% msg.key %]"
-         form="moderate_mails" />
+         form="moderate_mails" />&nbsp;&nbsp;
 
         [%~# Button to load AJAX content into reveal modal with Foundation ~%]
         <a href="[% 'ajax/viewmod' | url_rel([list,msg.key]) %]"
@@ -102,11 +82,34 @@
         [% msg.value.size %] [%|loc%]Kbytes[%END%]
       </div>
     </div>
-  [% END %] 
+  [% END %]
 
+  <h3>[%|loc%]Bulk moderation[%END%]</h3>
   <p>
     <input class="MainMenuLinks toggleButton" type="button"
      value="[%|loc%]Toggle Selection[%END%]" form="moderate_mails" />
+  </p>
+  <p>
+    <input class="MainMenuLinks" type="submit" form="moderate_mails" name="action_distribute" value="[%|loc%]Distribute selected emails[%END%]" />
+  </p>
+  <p>
+    <input class="MainMenuLinks" type="submit" form="moderate_mails" name="action_reject" value="[%|loc%]Reject selected emails[%END%]" />
+    <input type="hidden" name="from_modindex" value="from_modindex" form="moderate_mails" />
+      <select  name="message_template" form="moderate_mails">
+       <option  value="reject_quiet"[%- IF msg.value.spam_status == 'spam' -%] [% one_template_is_selected = '1' %]selected="selected"[% END %]>[%|loc %]No notification[%END%]</option>
+       <option  value="reject">[%|loc %]Server default rejection message[%END%]</option>
+       [% FOREACH file = available_files %]
+       <option  value="reject_[%  file  %]" [% IF file == default_reject_template %] selected="selected" [%END%] > [% file  %]</option>
+       [%- END- %]
+      </select>
+   <br />
+  </p>
+  <p>
+  [% IF conf.reporting_spam_script_path %]
+    <input type=checkbox name="signal_spam" form="moderate_mails"/> [%|loc %]Report messages as undetected spam[%END%]</label>
+    <br />
+  [% END %]
+    <input type=checkbox name="blacklist" form="moderate_mails" /> [%|loc %]Add to blacklist[%END%]
   </p>
 
   </fieldset>
@@ -117,6 +120,8 @@
     [%|loc%]No messages to moderate[%END%]
   </p>
 [%~ END %]
+
+<hr>
 
 <h2>[%|loc%]Moderation management[%END%] <a  href="[% 'nomenu/help/admin' | url_rel %]#moderate" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=400,height=200')" target="wws_help"><i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i></a></h2>
 


### PR DESCRIPTION
Added the missing button for reporting spam i bulk. This fix ignores the ham/spam status off the messages. All will be delivered to the script. 

Tried to tidy the page up a bit by moving the bulk control buttons to the bottom off the "messages for moderation" table. The table itself should probably be changed to match the other tables in sympa (see the subscriber table)