### PR TITLE
Reference to map file causes HTTP 404 errors

### DIFF
--- a/www/js/foundation/css/foundation-float.css
+++ b/www/js/foundation/css/foundation-float.css
@@ -4456,4 +4456,3 @@ a.thumbnail {
 .clearfix::after {
   clear: both; }
 
-/*# sourceMappingURL=foundation-float.css.map */


### PR DESCRIPTION
Fix about #170.
This occurs at leaset with recent versions of Chrome and Firefox enabling developer tools.
