### PR TITLE
SympaSOAP: closeList crashes.

### DIFF
--- a/src/lib/Sympa/WWW/SOAP.pm
+++ b/src/lib/Sympa/WWW/SOAP.pm
@@ -706,7 +706,7 @@ sub closeList {
     }
 
     my $spindle = Sympa::Spindle::ProcessRequest->new(
-        context          => $list,
+        context          => $list->{'domain'},
         action           => 'close_list',
         current_list     => $list,
         mode =>


### PR DESCRIPTION
This may fix issue #339.
