### PR TITLE
[cpanfile] Drop MHonArc::UTF8 version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -65,7 +65,7 @@ requires 'List::Util::XS', '>= 1.20';
 requires 'Locale::Messages', '>= 1.20';
 
 # MHonArc is used to build Sympa web archives
-requires 'MHonArc::UTF8', '>= 2.6.18';
+requires 'MHonArc::UTF8';
 
 # Required to compute digest for password and emails
 requires 'MIME::Base64', '>= 3.03';


### PR DESCRIPTION
As discussed on the [ML](https://listes.renater.fr/sympa/arc/sympa-developpers/2018-05/msg00065.html), we should drop MHonArc::UTF8 version in cpanfile since it prevents to install dependencies with `cpanm --installdeps`.