### PR TITLE
Remove tabs in default tt2 templates + some indentation changes

### DIFF
--- a/default/mhonarc-ressources.tt2
+++ b/default/mhonarc-ressources.tt2
@@ -20,11 +20,11 @@ CALENDAR
         <div>
         <ul class="calendar">
         <li class="calendarLinksInactive">($tag$% year.key %$tag$)</li>
-   	($tag$% FOREACH month = ['01' '02' '03' '04' '05' '06' '07' '08' '09' '10' '11' '12'] %$tag$)
+        ($tag$% FOREACH month = ['01' '02' '03' '04' '05' '06' '07' '08' '09' '10' '11' '12'] %$tag$)
           ($tag$% IF year.value.item(month) %$tag$)
-                 ($tag$% IF  year.key == '$yyyy$' && month == '$mois$'%$tag$) <li class="calendarLinksCurrentPage"><a href="($tag$% path_cgi %$tag$)/arc/($tag$% list %$tag$)/($tag$% year.key %$tag$)-($tag$% month %$tag$)/" title="($tag$%|loc(year.value.item(month))%$tag$)%1 message(s)($tag$%END%$tag$)">($tag$% month %$tag$)</a></li>
-                 ($tag$% ELSE %$tag$)<li class="calendarLinks"><a href="($tag$% path_cgi %$tag$)/arc/($tag$% list %$tag$)/($tag$% year.key %$tag$)-($tag$% month %$tag$)/" title="($tag$%|loc(year.value.item(month))%$tag$)%1 message(s)($tag$%END%$tag$)">($tag$% month %$tag$)</a></li>
-		 ($tag$% END %$tag$)
+            ($tag$% IF  year.key == '$yyyy$' && month == '$mois$'%$tag$) <li class="calendarLinksCurrentPage"><a href="($tag$% path_cgi %$tag$)/arc/($tag$% list %$tag$)/($tag$% year.key %$tag$)-($tag$% month %$tag$)/" title="($tag$%|loc(year.value.item(month))%$tag$)%1 message(s)($tag$%END%$tag$)">($tag$% month %$tag$)</a></li>
+            ($tag$% ELSE %$tag$)<li class="calendarLinks"><a href="($tag$% path_cgi %$tag$)/arc/($tag$% list %$tag$)/($tag$% year.key %$tag$)-($tag$% month %$tag$)/" title="($tag$%|loc(year.value.item(month))%$tag$)%1 message(s)($tag$%END%$tag$)">($tag$% month %$tag$)</a></li>
+            ($tag$% END %$tag$)
           ($tag$% ELSE %$tag$)<li class="calendarLinksInactive">($tag$% month %$tag$)</li>
           ($tag$% END %$tag$)
         ($tag$% END %$tag$)
@@ -36,22 +36,22 @@ CALENDAR
 
 <DefineVar>
 SEARCH_FORM
-     <div class="search_form">
-	<form method="post" action="($tag$% path_cgi %$tag$)">
-	<input name="list" type="hidden" value="($tag$% list %$tag$)" />
-	<input name="archive_name" type="hidden" value="($tag$% archive_name %$tag$)" />
-	<input name="how"   type="hidden" value="phrase" />
-	<input name="age"   type="hidden" value="new" />
-	<input name="case"  type="hidden" value="off" /> 
-	<input name="match" type="hidden" value="partial" />
-	<input name="limit" type="hidden" value="10" /> 
-	<input name="body"  type="hidden" value="true" />
-	<input name="subj"  type="hidden" value="true" />
-	<input id="key_word" name="key_word" type="text" size="12" />
-	<input name="action"  type="hidden" value="arcsearch" />
-	<input type="submit" class="MainMenuLinks disableIfEmpty" data-selector="#key_word" name="action_arcsearch" value="($tag$%|loc%$tag$)Search($tag$%END%$tag$)" />
-	<input type="submit" class="MainMenuLinks" name="action_arcsearch_form" value="($tag$%|loc%$tag$)Advanced search($tag$%END%$tag$)" />
-	</form>
+    <div class="search_form">
+        <form method="post" action="($tag$% path_cgi %$tag$)">
+            <input name="list" type="hidden" value="($tag$% list %$tag$)" />
+            <input name="archive_name" type="hidden" value="($tag$% archive_name %$tag$)" />
+            <input name="how"   type="hidden" value="phrase" />
+            <input name="age"   type="hidden" value="new" />
+            <input name="case"  type="hidden" value="off" /> 
+            <input name="match" type="hidden" value="partial" />
+            <input name="limit" type="hidden" value="10" /> 
+            <input name="body"  type="hidden" value="true" />
+            <input name="subj"  type="hidden" value="true" />
+            <input id="key_word" name="key_word" type="text" size="12" />
+            <input name="action"  type="hidden" value="arcsearch" />
+            <input type="submit" class="MainMenuLinks disableIfEmpty" data-selector="#key_word" name="action_arcsearch" value="($tag$%|loc%$tag$)Search($tag$%END%$tag$)" />
+            <input type="submit" class="MainMenuLinks" name="action_arcsearch_form" value="($tag$%|loc%$tag$)Advanced search($tag$%END%$tag$)" />
+        </form>
     </div>
 </DefineVar>
 
@@ -469,7 +469,7 @@ $POWERED_BY$
       ($tag$% IF list_conf.reply_to_header.value == 'all' %$tag$)
           <input type="hidden" name="to" value="$FROMADDRNAME:J$ $FROMADDRDOMAIN$,($tag$% list %$tag$) ($tag$% domain %$tag$)" />
       ($tag$% ELSIF list_conf.reply_to_header.value == 'other_email' %$tag$)
-	  ($tag$% SET oemail = list_conf.reply_to_header.other_email %$tag$)
+        ($tag$% SET oemail = list_conf.reply_to_header.other_email %$tag$)
           <input type="hidden" name="to" value="($tag$% oemail.replace('@',' ') %$tag$)" />
       ($tag$% ELSIF list_conf.reply_to_header.value == 'list' %$tag$)
           <input type="hidden" name="to" value="($tag$% list %$tag$) ($tag$% domain %$tag$)" />
@@ -480,21 +480,21 @@ $POWERED_BY$
       ($tag$%|loc%$tag$)Reply to($tag$%END%$tag$)
       <input id="to_sender" type="radio" name="to"
        value="$FROMADDRNAME:J$ $FROMADDRDOMAIN$"
-       ($tag$% IF list_conf.reply_to_header.value == 'sender' %$tag$)
-	checked
-	($tag$%END%$tag$) />
+        ($tag$% IF list_conf.reply_to_header.value == 'sender' %$tag$)
+          checked
+        ($tag$%END%$tag$) />
       <label class="inlineLabel" for="to_sender">($tag$%|loc%$tag$)sender($tag$%END%$tag$)</label>
       <input id="to_list" type="radio" name="to"
        value="($tag$% list %$tag$) ($tag$% domain %$tag$)"
        ($tag$% IF list_conf.reply_to_header.value == 'list' %$tag$)
-	checked
-	($tag$%END%$tag$) />
+          checked
+       ($tag$%END%$tag$) />
       <label class="inlineLabel" for="to_list">($tag$%|loc%$tag$)list($tag$%END%$tag$)</label>
       <input id="to_both" type="radio" name="to"
        value="$FROMADDRNAME:J$ $FROMADDRDOMAIN$,($tag$% list %$tag$) ($tag$% domain %$tag$)"
        ($tag$% IF list_conf.reply_to_header.value == 'all' %$tag$)
-	checked
-	($tag$%END%$tag$) />
+          checked
+       ($tag$%END%$tag$) />
       <label class="inlineLabel" for="to_both">($tag$%|loc%$tag$)both($tag$%END%$tag$)</label>
   ($tag$% END %$tag$)
   <input class="MainMenuLinks" type="submit" name="action_compose_mail" value="($tag$%|loc%$tag$)Reply($tag$%END%$tag$)" /><br />

--- a/default/web_tt2/active_lists.tt2
+++ b/default/web_tt2/active_lists.tt2
@@ -2,23 +2,23 @@
 
 <h2 class="block"> <strong>
  [% IF count %]
-   [%|loc(count)%] The %1 most active lists [%END%] 
+   [%|loc(count)%] The %1 most active lists [%END%]
  [% ELSE %]
-   [%|loc%] Active lists [%END%] 
+   [%|loc%] Active lists [%END%]
  [% END %]
 
  [% IF for %]
-   [%|loc(for)%] for %1 days [%END%] 	
+   [%|loc(for)%] for %1 days [%END%]
  [% END %]
-</strong> </h2> 	
+</strong> </h2>
 
-<br /> 
+<br />
 
 <table class="responsive listOfItems" >
 <caption>[%|loc(count)%] The %1 most active lists [%END%][%|loc(for)%] for %1 days [%END%]</caption>
 <tr class="color_light">
    <th id="list_name"><strong>[%|loc%]List name[%END%]</strong></th>
-   <th id="message"><strong>[%|loc%]Number of messages[%END%]</strong></th>	
+   <th id="message"><strong>[%|loc%]Number of messages[%END%]</strong></th>
    <th id="average"><strong>[%|loc%]Average by day[%END%]</strong></th>
    <th id="date"><strong>[%|loc%]Creation date[%END%]</strong></th>
    <th id="subject"><strong>[%|loc%]Subject[%END%]</strong></th>
@@ -36,9 +36,9 @@
   <td headers="date"> [% l.date %] </td>
   <td headers="subject"> [% l.subject %] </td>
  </tr>
- 
- [% END %] 
- 
+
+ [% END %]
+
 </table>
 
 <!-- end active_lists.tt2 -->

--- a/default/web_tt2/admin.tt2
+++ b/default/web_tt2/admin.tt2
@@ -2,12 +2,12 @@
 <h2>[%|loc%]Casual administration[%END%]</h2>
 <ul>
 [% IF is_listmaster || is_owner %]
-	  <li><strong><a href="[% 'edit_list_request' | url_rel([list]) %]">[%|loc%]Edit List Config:[%END%]</a></strong>  [%|loc%]It must be used with care. It allows you to modify some of the list parameters. The list of parameters you can modify depends on your privilege.[%END%]</li>
+          <li><strong><a href="[% 'edit_list_request' | url_rel([list]) %]">[%|loc%]Edit List Config:[%END%]</a></strong>  [%|loc%]It must be used with care. It allows you to modify some of the list parameters. The list of parameters you can modify depends on your privilege.[%END%]</li>
 [% END %]
 [% IF is_listmaster || is_owner || may_del %]
           <li><strong><a href="[% 'review' | url_rel([list]) %]">[%|loc%]Manage Subscribers:[%END%]</a></strong> [%|loc%]Allows you to add or delete list members, moderate subscriptions, and so on.[%END%]</li>
   [% IF conf.use_blacklist != 'none' %]
-     	  <li><strong><a href="[% 'blacklist' | url_rel([list]) %]" >[%|loc%]Blacklist:[%END%]</a></strong> [%|loc%]Handles the set of black-listed mail addresses for this list.[%END%]</li>
+          <li><strong><a href="[% 'blacklist' | url_rel([list]) %]" >[%|loc%]Blacklist:[%END%]</a></strong> [%|loc%]Handles the set of black-listed mail addresses for this list.[%END%]</li>
   [% END %]
 [% END %]
 [% IF is_listmaster || is_owner %]

--- a/default/web_tt2/arcsearch.tt2
+++ b/default/web_tt2/arcsearch.tt2
@@ -14,23 +14,23 @@
 <em>
 
 [% IF how == 'phrase' %]
-	[%|loc%](This sentence,[%END%] 
+    [%|loc%](This sentence,[%END%] 
 [% ELSIF how == 'any' %]
-	[%|loc%](All of these words,[%END%] 
+    [%|loc%](All of these words,[%END%] 
 [% ELSE %]
-	[%|loc%](Each of these words,[%END%] 
+    [%|loc%](Each of these words,[%END%] 
 [% END %]
 
 [% IF case == 'off' %]
-	[%|loc%]case insensitive[%END%] 
+    [%|loc%]case insensitive[%END%] 
 [% ELSE %]
-	[%|loc%]case sensitive[%END%] 
+    [%|loc%]case sensitive[%END%] 
 [% END %]
 
 [% IF match == 'partial' %]
-	[%|loc%]and checking on part of word)[%END%]
+    [%|loc%]and checking on part of word)[%END%]
 [% ELSE %]
-	[%|loc%]and checking on entire word)[%END%]
+    [%|loc%]and checking on entire word)[%END%]
 [% END %]
 </em>
 </p>
@@ -38,9 +38,9 @@
 <hr />
 
 [% IF age == 'new' %]
-	<p><strong>[%|loc%]Newest messages first[%END%]</strong></p>
+    <p><strong>[%|loc%]Newest messages first[%END%]</strong></p>
 [% ELSE %]
-	<p><strong>[%|loc%]Oldest messages first[%END%]</strong></p>
+    <p><strong>[%|loc%]Oldest messages first[%END%]</strong></p>
 [% END %]
 
 <dl>
@@ -76,19 +76,19 @@
 <dl>
 
 [% IF body %]
-	<dd>[%|loc(body_count)%]%1 hits on message Body[%END%]<br /></dd>
+    <dd>[%|loc(body_count)%]%1 hits on message Body[%END%]<br /></dd>
 [% END %]
 
 [% IF subj %]
-	<dd>[%|loc(subj_count)%]%1 hits on message Subject field[%END%]<br /></dd>
+    <dd>[%|loc(subj_count)%]%1 hits on message Subject field[%END%]<br /></dd>
 [% END %]
 
 [% IF from %]
-	<dd>[%|loc(from_count)%] %1 hits on message From field[%END%]<br /></dd>
+    <dd>[%|loc(from_count)%] %1 hits on message From field[%END%]<br /></dd>
 [% END %]
 
 [% IF date %]
-	<dd>[%|loc(date_count)%]%1 hits on message Date field[%END%]<br /></dd>
+    <dd>[%|loc(date_count)%]%1 hits on message Date field[%END%]<br /></dd>
 [% END %]
 
 </dl>
@@ -110,27 +110,27 @@
 <input type="hidden" name="previous" value="[% searched %]" />
 
 [% IF body %]
-	<input type="hidden" name="body" value="[% body %]" />
+    <input type="hidden" name="body" value="[% body %]" />
 [% END %]
 
 [% IF subj %]
-	<input type="hidden" name="subj" value="[% subj %]" />
+    <input type="hidden" name="subj" value="[% subj %]" />
 [% END %]
 
 [% IF from %]
-	<input type="hidden" name="from" value="[% from %]" />
+    <input type="hidden" name="from" value="[% from %]" />
 [% END %]
 
 [% IF date %]
-	<input type="hidden" name="date" value="[% date %]" />
+    <input type="hidden" name="date" value="[% date %]" />
 [% END %]
 
 [% FOREACH u = directories %]
-	<input type="hidden" name="directories" value="[% u %]" />
+    <input type="hidden" name="directories" value="[% u %]" />
 [% END %]
 
 [% IF continue %]
-	<input class="MainMenuLinks" name="action_arcsearch" type="submit" value="[%|loc%]Continue search[%END%]" />
+    <input class="MainMenuLinks" name="action_arcsearch" type="submit" value="[%|loc%]Continue search[%END%]" />
 [% END %]
 <p class="text_center" >
 <input style="padding:0.1em 5em!important;" class="MainMenuLinks" name="action_arcsearch_form" type="submit" value="[%|loc%]New search[%END%]" />

--- a/default/web_tt2/compose_mail.tt2
+++ b/default/web_tt2/compose_mail.tt2
@@ -1,78 +1,78 @@
 <!-- compose_mail.tt2 -->
 <form class="noborder" action="[% path_cgi %]" method="post" name="compose_mail" enctype="multipart/form-data">
     <fieldset>
-	[%|loc(user.email)%]From: %1[%END%]<br />
-	[% mailto = BLOCK ~%]
-	  [% to | mailto(to) | obfuscate(listconf.spam_protection) %]
-	[%~END~%]
-	[%|loc(mailto)%]To: %1[%END%]<br />
-	<label for="subject">[%|loc%]Subject:[%END%] <input id="subject" type="text" size="45" name="subject" value="[% subject %]" /></label>
-	[% IF subaction == "html_news_letter" %]
-		<input type="hidden" name="html_news_letter" value="[% subaction %]" />
-	[% END %]
-	<input type="hidden" name="action" value="send_mail"/>
-		<input class="MainMenuLinks" type="submit" name="sub_action_sendmailtolist" value="[%|loc%]Send to list[%END%]" [%- IF topic_required -%] onclick="return checkbox_check_topic(compose_mail)" [% END %]/>
-		<input class="MainMenuLinks" type="submit" name="sub_action_sendmailtome" value="[%|loc%]Send to me[%END%]" [%- IF topic_required -%] onclick="return checkbox_check_topic(compose_mail)" [% END %]/>
-	<br />
+    [%|loc(user.email)%]From: %1[%END%]<br />
+    [% mailto = BLOCK ~%]
+      [% to | mailto(to) | obfuscate(listconf.spam_protection) %]
+    [%~END~%]
+    [%|loc(mailto)%]To: %1[%END%]<br />
+    <label for="subject">[%|loc%]Subject:[%END%] <input id="subject" type="text" size="45" name="subject" value="[% subject %]" /></label>
+    [% IF subaction == "html_news_letter" %]
+    <input type="hidden" name="html_news_letter" value="[% subaction %]" />
+    [% END %]
+    <input type="hidden" name="action" value="send_mail"/>
+    <input class="MainMenuLinks" type="submit" name="sub_action_sendmailtolist" value="[%|loc%]Send to list[%END%]" [%- IF topic_required -%] onclick="return checkbox_check_topic(compose_mail)" [% END %]/>
+    <input class="MainMenuLinks" type="submit" name="sub_action_sendmailtome" value="[%|loc%]Send to me[%END%]" [%- IF topic_required -%] onclick="return checkbox_check_topic(compose_mail)" [% END %]/>
+    <br />
 
-	<input type="hidden" name="in_reply_to" value="[% in_reply_to %]" />
-	<input type="hidden" name="message_id" value="[% message_id %]" />
-	<input type="hidden" name="list" value="[% list %]" />	
-	[% SET counter = 0 %]
-	[% SET stringto = '' %]
-	[% FOREACH r = recipients %]
-    		[% IF counter == 0 %]
-        		[% stringto = r.value.local_to _ ' ' _ r.value.domain_to %]
-			[% counter = 1 %]
-    		[% ELSE %]
-        		[% stringto = stringto _ ',' _ r.value.local_to _ ' ' _ r.value.domain_to %]
-    		[% END %]
-	[% END %]
-	<input type="hidden" name="to" value="[% stringto %]" />
+    <input type="hidden" name="in_reply_to" value="[% in_reply_to %]" />
+    <input type="hidden" name="message_id" value="[% message_id %]" />
+    <input type="hidden" name="list" value="[% list %]" />
+    [% SET counter = 0 %]
+    [% SET stringto = '' %]
+    [% FOREACH r = recipients %]
+        [% IF counter == 0 %]
+            [% stringto = r.value.local_to _ ' ' _ r.value.domain_to %]
+            [% counter = 1 %]
+        [% ELSE %]
+            [% stringto = stringto _ ',' _ r.value.local_to _ ' ' _ r.value.domain_to %]
+        [% END %]
+    [% END %]
+    <input type="hidden" name="to" value="[% stringto %]" />
 
- 	[% IF request_topic %]
-   		<br />
-   		[%|loc%]This list is configured to require topic(s).[%END%]
-   		<br />
-   		[%|loc%]Please select one or more topic(s) that corresponds to your message:[%END%]
-   		<br />
-   		[% FOREACH t = available_topics %] 
-     			<input id="topic_[%t.name%]" type="checkbox" name="topic_[%t.name%]" value="1"/> <label for="topic_[%t.name%]">[% t.title %]</label>
-     			<br />
-   		[% END %]
-   		<br />
- 	[%  END %]
+    [% IF request_topic %]
+        <br />
+        [%|loc%]This list is configured to require topic(s).[%END%]
+        <br />
+        [%|loc%]Please select one or more topic(s) that corresponds to your message:[%END%]
+        <br />
+        [% FOREACH t = available_topics %] 
+            <input id="topic_[%t.name%]" type="checkbox" name="topic_[%t.name%]" value="1"/> <label for="topic_[%t.name%]">[% t.title %]</label>
+            <br />
+        [% END %]
+        <br />
+    [%  END %]
 
-	[% IF !subaction %]
-		[% balise_email = '['_'%'_' user.email '_'%'_']' %]
-		[% balise_fingerprint = '['_'%'_' user.fingerprint '_'%'_']' %]
-  		<textarea name="body" id="body" cols="80" rows="25">[% body %]</textarea>
-		<br />
+    [% IF !subaction %]
+        [% balise_email = '['_'%'_' user.email '_'%'_']' %]
+        [% balise_fingerprint = '['_'%'_' user.fingerprint '_'%'_']' %]
+        <textarea name="body" id="body" cols="80" rows="25">[% body %]</textarea>
+        <br />
 
-		[% IF merge_feature %]
-		<br />
-		<b>[%|loc%]Messages customization: use the template syntax:[%END%] <a href="http://www.tt2.org">TT2</a></b><br />
-		[%|loc%]Below are some examples of TT2 parameters usable in messages.[%END%]<br/>
-		<ul>
-			<li> <b>[&#37; listname &#37;]</b>[%|loc%]: the list name; always available.[%END%]</li>
-			<li> <b>[&#37; robot &#37;]</b>[%|loc%]: the name of the host the list is intalled on; always available.[%END%]</li>
-			<li> <b>[&#37; user.email &#37;]</b>[%|loc%]: the user email; always available.[%END%]</li>
-			<li> <b>[&#37; user.gecos &#37;]</b>[%|loc%]: the user name associated to her email; always available.[%END%]</li>
-			<li> <b>[&#37; user.friendly_date &#37;]</b>[%|loc%]: the - human readable - user's subscription date; always available.[%END%]</li>
-			<li> <b>[&#37; user.custom_attribute.title.value &#37;]</b>[%|loc%]: can be anything you like; available if you defined a user custom attribute named "title" (see the list configuration, section "Miscellaneous").[%END%]</li>
-			<li> <b>[&#37; user.custom_attribute.name.value &#37;]</b>[%|loc%]: can be anything you like; available if you defined a user custom attribute named "name".[%END%]</li>
-			<li> <b>[&#37; user.custom_attribute.organization.value &#37;]</b>[%|loc%]: can be anything you like; available if you defined a user custom attribute named "organization".[%END%]</li>
-		</ul>
-		[% END %]
-	[%  END %]
-	[% IF subaction == "html_news_letter" %]
-		<br /><h3>[%|loc%]Select the source of your HTML newsletter[%END%]</h3>
-		<label for="url"><strong>[%|loc%]Send the page from the following URL:[%END%] </strong></label>
-		<input id="url" type="text" size="55" name="url" value="[% url %]" />		
-		<p><strong>[%|loc%]OR[%END%]</strong></p>
-		<label for="uploaded_file">[%|loc%]<strong>Send an HTML file from your computer:[%END%] </strong></label>
-		<input id="uploaded_file" type="file" size="45" name="uploaded_file"/>
-	[%  END %]
+        [% IF merge_feature %]
+            <br />
+            <b>[%|loc%]Messages customization: use the template syntax:[%END%] <a href="http://www.tt2.org">TT2</a></b><br />
+            [%|loc%]Below are some examples of TT2 parameters usable in messages.[%END%]<br/>
+            <ul>
+                <li> <b>[&#37; listname &#37;]</b>[%|loc%]: the list name; always available.[%END%]</li>
+                <li> <b>[&#37; robot &#37;]</b>[%|loc%]: the name of the host the list is intalled on; always available.[%END%]</li>
+                <li> <b>[&#37; user.email &#37;]</b>[%|loc%]: the user email; always available.[%END%]</li>
+                <li> <b>[&#37; user.gecos &#37;]</b>[%|loc%]: the user name associated to her email; always available.[%END%]</li>
+                <li> <b>[&#37; user.friendly_date &#37;]</b>[%|loc%]: the - human readable - user's subscription date; always available.[%END%]</li>
+                <li> <b>[&#37; user.custom_attribute.title.value &#37;]</b>[%|loc%]: can be anything you like; available if you defined a user custom attribute named "title" (see the list configuration, section "Miscellaneous").[%END%]</li>
+                <li> <b>[&#37; user.custom_attribute.name.value &#37;]</b>[%|loc%]: can be anything you like; available if you defined a user custom attribute named "name".[%END%]</li>
+                <li> <b>[&#37; user.custom_attribute.organization.value &#37;]</b>[%|loc%]: can be anything you like; available if you defined a user custom attribute named "organization".[%END%]</li>
+            </ul>
+        [% END %]
+    [%  END %]
+    [% IF subaction == "html_news_letter" %]
+        <br /><h3>[%|loc%]Select the source of your HTML newsletter[%END%]</h3>
+        <label for="url"><strong>[%|loc%]Send the page from the following URL:[%END%] </strong></label>
+        <input id="url" type="text" size="55" name="url" value="[% url %]" />
+        <p><strong>[%|loc%]OR[%END%]</strong></p>
+        <label for="uploaded_file">[%|loc%]<strong>Send an HTML file from your computer:[%END%] </strong></label>
+        <input id="uploaded_file" type="file" size="45" name="uploaded_file"/>
+    [%  END %]
     </fieldset>
 </form>
 <!-- end compose_mail.tt2 -->

--- a/default/web_tt2/copy_template.tt2
+++ b/default/web_tt2/copy_template.tt2
@@ -35,21 +35,21 @@
   <label for="template_name_out">[%|loc%]New template name: [%END%] </label><input id="template_name_out" type="text" name="template_name_out" value="[% template_name %]" /><br />
   <label for="scope_out">[%|loc%]Scope: [%END%] </label>
     <select id="scope_out" name="scope_out">
-	<option value="site" [% IF scope == 'site' %]selected[% END %]>[%|loc%]site[%END%]</option>
-	[% UNLESS default_robot %]<option value="robot" [% IF scope == 'robot' %]selected[% END %]>[%|loc%]robot[%END%]</option>[%END%]
+        <option value="site" [% IF scope == 'site' %]selected[% END %]>[%|loc%]site[%END%]</option>
+        [% UNLESS default_robot %]<option value="robot" [% IF scope == 'robot' %]selected[% END %]>[%|loc%]robot[%END%]</option>[%END%]
         <option value="list" [% IF scope == 'list' %]selected[% END %]>[%|loc%]list[%END%]</option>
     </select><br />
   <label for="tpl_lang_out">[%|loc%]Language: [%END%] </label>
     <select id="tpl_lang_out" name="tpl_lang_out" class="neutral">
-	<option value="default">[%|loc%]default[%END%]</option>
-	[% FOREACH lg = languages %]
-        <option lang="[%lg.key%]" xml:lang="[%lg.key%]"
-         value="[%lg.key%]"
-         [%~ IF tpl_lang_lang == lg.key %] selected="selected"[% END %]>
-        [%~ lg.key | optdesc('lang') ~%]
-        </option>
-	[%END%]
-	</select><br />
+        <option value="default">[%|loc%]default[%END%]</option>
+        [% FOREACH lg = languages %]
+            <option lang="[%lg.key%]" xml:lang="[%lg.key%]"
+             value="[%lg.key%]"
+             [%~ IF tpl_lang_lang == lg.key %] selected="selected"[% END %]>
+            [%~ lg.key | optdesc('lang') ~%]
+            </option>
+        [%END%]
+    </select><br />
   <label for="list_out">[%|loc%]Enter list name: [%END%] </label><input id="list_out" type="text" name="list_out" size="20" value="[% list %]" /><br />
 
     <input type="hidden" name="template_name" value="[% template_name %]" />
@@ -57,8 +57,8 @@
     <input type="hidden" name="scope" value="[% scope %]" />
     <input type="hidden" name="tpl_lang" value="[% tpl_lang %]" />
     <input type="hidden" name="webormail" value="[% webormail %]" />
-    [% IF scope == 'list' %]	
-      <input type="hidden" name="list" value="[% list %]" />	
+    [% IF scope == 'list' %]
+      <input type="hidden" name="list" value="[% list %]" />
     [% END %]
 </fieldset>
 <br/>

--- a/default/web_tt2/css.tt2
+++ b/default/web_tt2/css.tt2
@@ -80,38 +80,38 @@ article, aside, canvas, details, embed,
 figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	-webkit-text-size-adjust: 100%;
-	-ms-text-size-adjust: 100%;
-	font: inherit;
-	vertical-align: baseline;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    -webkit-text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+    font: inherit;
+    vertical-align: baseline;
 }
 
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure,
 footer, header, hgroup, nav, section {
-	display: block;
+    display: block;
 }
 
 body {
-	line-height: 1;
+    line-height: 1;
 }
 
 ol, ul {
-	list-style: none;
+    list-style: none;
 }
 
 blockquote, q {
-	quotes: none;
+    quotes: none;
 }
 
 blockquote:before, blockquote:after,
 q:before, q:after {
-	content: '';
-	content: none;
+    content: '';
+    content: none;
 }
 
 /***
@@ -147,7 +147,8 @@ q:before, q:after {
 /****/
 
 
-* {		/* Proportional fonts */
+/* Proportional fonts */
+* {
     font-family: 'Raleway', sans-serif;
     font-size: 1em;
 }
@@ -168,145 +169,145 @@ body {
 /* Selection */
 
 ::-moz-selection {
-	background: [% color_15 %];
-	color: [% color_7 %];
-	text-shadow: none;
+    background: [% color_15 %];
+    color: [% color_7 %];
+    text-shadow: none;
 }
 
 ::selection {
-	background: [% color_15 %];
-	color: [% color_7 %];
-	text-shadow: none;
+    background: [% color_15 %];
+    color: [% color_7 %];
+    text-shadow: none;
 }
 
 /* Links */
 
 a {
-	color: [% color_5 %];
-	text-decoration: none;
+    color: [% color_5 %];
+    text-decoration: none;
         transition: background-color 300ms ease-out;
 }
 
 a:visited {
-	text-decoration: none;
+    text-decoration: none;
 }
 
 a:focus {
-	outline: 0;
-	text-decoration: none;
+    outline: 0;
+    text-decoration: none;
 }
 
 a:hover, a:active {
-	color: [% color_6 %];
-	outline: 0;
-	text-decoration: none;
+    color: [% color_6 %];
+    outline: 0;
+    text-decoration: none;
 }
 
 /* Misc */
 
 abbr[title] {
-	border-bottom: 1px dotted;
+    border-bottom: 1px dotted;
 }
 
 b, strong {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 blockquote {
-	margin: 1em 40px;
+    margin: 1em 40px;
 }
 
 dfn {
-	font-style: italic;
+    font-style: italic;
 }
 
 hr {
-	display: block;
-	height: 1px;
-	border-bottom: 1px solid [% color_9 %];
-	margin: 1em 0;
+    display: block;
+    height: 1px;
+    border-bottom: 1px solid [% color_9 %];
+    margin: 1em 0;
 }
 
 ins {
-	background: [% color_14 %];
-	color: [% color_1 %];
-	text-decoration: none;
+    background: [% color_14 %];
+    color: [% color_1 %];
+    text-decoration: none;
 }
 
 mark {
-	background: [% color_14 %];
-	color: [% color_1 %];
-	font-style: italic;
-	font-weight: bold;
+    background: [% color_14 %];
+    color: [% color_1 %];
+    font-style: italic;
+    font-weight: bold;
 }
 
 pre, code, kbd, samp {
-	font-family: monospace, serif;
-	_font-family: 'courier new', monospace;
-	font-size: 1em;
+    font-family: monospace, serif;
+    _font-family: 'courier new', monospace;
+    font-size: 1em;
 }
 
 pre {
-	white-space: pre;
-	white-space: pre-wrap;
-	word-wrap: break-word;
+    white-space: pre;
+    white-space: pre-wrap;
+    word-wrap: break-word;
 }
 
 q {
-	quotes: none;
+    quotes: none;
 }
 
 q:before, q:after {
-	content: "";
-	content: none;
+    content: "";
+    content: none;
 }
 
 small {
-	font-size: 85%;
+    font-size: 85%;
 }
 
 sub, sup {
-	font-size: 75%;
-	line-height: 0;
-	position: relative;
-	vertical-align: baseline;
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
 }
 
 sup {
-	top: -0.5em;
+    top: -0.5em;
 }
 
 sub {
-	bottom: -0.25em;
+    bottom: -0.25em;
 }
 
 ul, ol, dl {
-	margin: 1em 0;
-	padding: 0 0 0 1rem;
-	font-size: 13px;
-	color: [% color_3 %];
-	list-style-position: outside;
+    margin: 1em 0;
+    padding: 0 0 0 1rem;
+    font-size: 13px;
+    color: [% color_3 %];
+    list-style-position: outside;
 }
 
 nav ul, nav ol {
-	list-style: none;
-	list-style-image: none;
+    list-style: none;
+    list-style-image: none;
 }
 
 img {
-	-ms-interpolation-mode: bicubic;
-	vertical-align: middle;
+    -ms-interpolation-mode: bicubic;
+    vertical-align: middle;
 }
 
 address {
-	font-style:normal;
+    font-style:normal;
 }
 
 p {
-	color: [% color_3 %];
-	line-height: 1.6em;
-	margin: 0.5em 0px 1em;
-	padding: 0.2em 0 0;
+    color: [% color_3 %];
+    line-height: 1.6em;
+    margin: 0.5em 0px 1em;
+    padding: 0.2em 0 0;
 }
 
 /* Forms */
@@ -325,54 +326,54 @@ main form form{
 }
 
 label {
-	color: [% color_4 %];
-	margin-top:0.5rem;
-	/*display: inline-block;*/    padding-left:0!important;
-	font-weight:700;
-	cursor: pointer;
+    color: [% color_4 %];
+    margin-top:0.5rem;
+    /*display: inline-block;*/    padding-left:0!important;
+    font-weight:700;
+    cursor: pointer;
 }
 
 label.inlineLabel {
-	display: inline !important;
-	font: inherit;
-	padding: 0;
-	line-height: normal;
-	width: auto !important;
-	float: none !important;
+    display: inline !important;
+    font: inherit;
+    padding: 0;
+    line-height: normal;
+    width: auto !important;
+    float: none !important;
 }
 label[for="connected_only"] {
-	display: inline;
+    display: inline;
 }
 
 input {
-	/*border: 1px solid [% color_12 %];
-	border-radius: 3px;
-	font-size: 16px;
-	padding: 10px 9px;
-	margin-right: 10px;
-	outline:none;*/
+    /*border: 1px solid [% color_12 %];
+    border-radius: 3px;
+    font-size: 16px;
+    padding: 10px 9px;
+    margin-right: 10px;
+    outline:none;*/
 }
 
 input[type="checkbox"], input[type="radio"] {
-	border: none;
-	box-sizing: border-box;
-	*width: 13px;
-	*height: 13px;
+    border: none;
+    box-sizing: border-box;
+    *width: 13px;
+    *height: 13px;
 }
 table input[type="checkbox"], table input[type="radio"] {
     margin-bottom:0
 }
 input[type="file"]{
-	display: block;
+    display: block;
         margin-top:0.5rem;
 }
 select {
-	/*border: 1px solid [% color_12 %];
-	border-radius: 3px;
-	font-size: 16px;
-	padding: 6px 4px;
-	margin-right: 10px;
-	outline:none;*/
+    /*border: 1px solid [% color_12 %];
+    border-radius: 3px;
+    font-size: 16px;
+    padding: 6px 4px;
+    margin-right: 10px;
+    outline:none;*/
 }
 [%# 641px ~%]
 @media only screen and (min-width: 40em) {
@@ -384,30 +385,30 @@ select[name="size"] {
    max-width: 60px;
 }
 textarea {
-	/*font-size: 13px;
-	color: [% color_4 %];
-	min-height: 60px;
-	padding: 6px 9px;
-	border: 1px solid [% color_12 %];
-	border-radius: 3px;
-	width: 94%;
-	line-height: 20px;
-	outline:none;*/
+    /*font-size: 13px;
+    color: [% color_4 %];
+    min-height: 60px;
+    padding: 6px 9px;
+    border: 1px solid [% color_12 %];
+    border-radius: 3px;
+    width: 94%;
+    line-height: 20px;
+    outline:none;*/
 }
 
 legend {
-	*margin-left: -7px;
-	white-space: normal;
+    *margin-left: -7px;
+    white-space: normal;
 }
 
 button, input, select, textarea {
-	font-size: 100%;
-	vertical-align: baseline;
-	*vertical-align: middle;
+    font-size: 100%;
+    vertical-align: baseline;
+    *vertical-align: middle;
 }
 
 button, input {
-	line-height: normal;
+    line-height: normal;
 }
 
 button[type="button"],
@@ -417,17 +418,17 @@ input[type="button"],
 input[type="reset"],
 input[type="submit"],
 a.button {
-	cursor: pointer;
-	*overflow: visible;
-	display: inline-block;
-	color: [% color_7 %];
-	border-radius: 4px;
-	background: [% color_6 %] none no-repeat scroll top left;
-	font-size: 12px;
-	font-weight: 200;
-	padding: 5px 9px;
-	border: 0;
-	margin: 0.25em;
+    cursor: pointer;
+    *overflow: visible;
+    display: inline-block;
+    color: [% color_7 %];
+    border-radius: 4px;
+    background: [% color_6 %] none no-repeat scroll top left;
+    font-size: 12px;
+    font-weight: 200;
+    padding: 5px 9px;
+    border: 0;
+    margin: 0.25em;
         transition: background-color 300ms ease-out;
 }
 
@@ -438,43 +439,43 @@ input[type="button"]:hover,
 input[type="submit"]:hover,
 input[type="reset"]:hover,
 a.button:hover {
-	background: [% color_5 %] none no-repeat scroll bottom left;
+    background: [% color_5 %] none no-repeat scroll bottom left;
 }
 
 input[type="button"]:disabled, input[type="submit"]:disabled, input[type="reset"]:disabled {
-	background: none repeat scroll 0 0 [% color_12 %];
+    background: none repeat scroll 0 0 [% color_12 %];
 }
 
 button[disabled], input[disabled] {
-	cursor: default;
+    cursor: default;
 }
 
 input[type="search"] {
-	-webkit-appearance: textfield;
-	-moz-box-sizing: content-box;
-	-webkit-box-sizing: content-box;
-	box-sizing: content-box;
+    -webkit-appearance: textfield;
+    -moz-box-sizing: content-box;
+    -webkit-box-sizing: content-box;
+    box-sizing: content-box;
 }
 
 input[type="search"]::-webkit-search-decoration,
 input[type="search"]::-webkit-search-cancel-button {
-	-webkit-appearance: none;
+    -webkit-appearance: none;
 }
 
 textarea {
-	overflow: auto;
-	vertical-align: top;
-	resize: vertical;
+    overflow: auto;
+    vertical-align: top;
+    resize: vertical;
 }
 
 input:invalid, textarea:invalid {
-	background-color: [% color_13 %];
-	opacity:0.5;
+    background-color: [% color_13 %];
+    opacity:0.5;
 }
 
 [%# To align buttons in messages moderate form in reveal modal. ~%]
 div.reveal form[id*="moderate_"] {
-	display: inline-block;
+    display: inline-block;
 }
 
 div.columns {
@@ -487,40 +488,40 @@ h1,h2,h3,h4,h5,h6{
     font-family: 'Raleway', sans-serif;
 }
 h1 {
-	color: [% color_2 %];
-	font-weight: 100;
-	font-size: 1.9em;
-	margin: 0px 0px 0.6em;
+    color: [% color_2 %];
+    font-weight: 100;
+    font-size: 1.9em;
+    margin: 0px 0px 0.6em;
 }
 h2 {
-	color: [% color_2 %];
-	font-size: 1.6em;
-	font-weight: 100;
-	margin: 1rem 0px 0.2rem;
+    color: [% color_2 %];
+    font-size: 1.6em;
+    font-weight: 100;
+    margin: 1rem 0px 0.2rem;
 }
 h3 {
-	margin: 0px 0px 0.6em;
-	color: [% color_2 %];
-	font-weight: 100;
-	font-size: 1.3em;
+    margin: 0px 0px 0.6em;
+    color: [% color_2 %];
+    font-weight: 100;
+    font-size: 1.3em;
 }
 h4 {
-	color: [% color_2 %];
-	font-size: 1.2em;
-	margin: 1em 0px 0px;
-	font-weight: 100;
+    color: [% color_2 %];
+    font-size: 1.2em;
+    margin: 1em 0px 0px;
+    font-weight: 100;
 }
 h5 {
-	color: [% color_3 %];
-	font-size: 1.1em;
-	margin: 2em 0px 0.2em;
-	font-weight: 100;
+    color: [% color_3 %];
+    font-size: 1.1em;
+    margin: 2em 0px 0.2em;
+    font-weight: 100;
 }
 h6 {
     font-size: 1em;
 }
 h1 a, h2 a, h3 a {
-	color:[% color_2 %];
+    color:[% color_2 %];
 }
 main h1, main h2, main h3, main h4, main h5, main h6, main article, main p, main form {
     padding:0 1rem!important;
@@ -615,17 +616,17 @@ table.listOfItems td form, table.listOfItems td form fieldset{
     padding:0!important;
 }
 table.listOfItems td form fieldset button.action, table.listOfItems td button.action {
-	display: inline-block;
-	color: [% color_5 %];
-	border: none;
-	background: none;
-	font-size: inherit;
-	font-weight: inherit;
-	padding: 0;
-	margin: 0;
+    display: inline-block;
+    color: [% color_5 %];
+    border: none;
+    background: none;
+    font-size: inherit;
+    font-weight: inherit;
+    padding: 0;
+    margin: 0;
 }
 table.listOfItems td form fieldset button.action:hover, table.listOfItems td button.action:hover {
-	color: [% color_6 %];
+    color: [% color_6 %];
 }
 table.ls_template th{
     border-right: 1px solid [% color_7 %];
@@ -692,43 +693,43 @@ table tr th, table tr td {
     text-align: center;
 }
 #logo img{
-	max-width: 100%;
+    max-width: 100%;
 }
 
 [% IF 0 # No longer used ~%]
 #nav {
-	position:relative;
-	top:-1px;
+    position:relative;
+    top:-1px;
 }
 
 #nav li {
-	list-style: none;
-	float:left;
-	height:32px;
-	margin-right:5px;
-   background-image:none; /*overrides Massey default */
+    list-style: none;
+    float:left;
+    height:32px;
+    margin-right:5px;
+    background-image:none; /*overrides Massey default */
 }
 
 #nav a span {
-	display:block;
-	font-weight:bold;
-	padding:7px 15px 2px 15px;
+    display:block;
+    font-weight:bold;
+    padding:7px 15px 2px 15px;
 }
 
 #nav a {
-	display:block;
-	height:32px;
+    display:block;
+    height:32px;
     background-image:none;
     background-color: transparent;
-	border:1px solid [% color_9 %];
+    border:1px solid [% color_9 %];
     color: [% color_7 %];
     border: none;
-	border-radius: 3px 3px 0px 0px;
+    border-radius: 3px 3px 0px 0px;
 }
 [%~ END # IF 0 ~%]
 
 p {
-	word-wrap:break-word;
+    word-wrap:break-word;
 }
 
 /* header */
@@ -901,7 +902,7 @@ main h1.robot_name {
         margin-bottom:0.5rem;
     }
     dd {
-    	margin: 0 0 0 40px;
+        margin: 0 0 0 40px;
     }
 
     [%# Compat. with Foundation 5 ~%]
@@ -929,39 +930,39 @@ menu.shared li{
 /*Top Button*/
 .scroll-top-wrapper {
     position: fixed;
-	opacity: 0;
-	visibility: hidden;
-	overflow: hidden;
-	text-align: center;
-	z-index: 99999999;
+    opacity: 0;
+    visibility: hidden;
+    overflow: hidden;
+    text-align: center;
+    z-index: 99999999;
     background-color: [% color_6 %];
-	color: #eeeeee;
-	width: 50px;
-	height: 48px;
-	line-height: 48px;
-	right: 30px;
-	bottom: 30px;
-	padding-top: 2px;
-	border-top-left-radius: 10px;
-	border-top-right-radius: 10px;
-	border-bottom-right-radius: 10px;
-	border-bottom-left-radius: 10px;
-	-webkit-transition: all 0.5s ease-in-out;
-	-moz-transition: all 0.5s ease-in-out;
-	-ms-transition: all 0.5s ease-in-out;
-	-o-transition: all 0.5s ease-in-out;
-	transition: all 0.5s ease-in-out;
+    color: #eeeeee;
+    width: 50px;
+    height: 48px;
+    line-height: 48px;
+    right: 30px;
+    bottom: 30px;
+    padding-top: 2px;
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
+    border-bottom-right-radius: 10px;
+    border-bottom-left-radius: 10px;
+    -webkit-transition: all 0.5s ease-in-out;
+    -moz-transition: all 0.5s ease-in-out;
+    -ms-transition: all 0.5s ease-in-out;
+    -o-transition: all 0.5s ease-in-out;
+    transition: all 0.5s ease-in-out;
 }
 .scroll-top-wrapper:hover {
-	background-color: [% color_11 %];
+    background-color: [% color_11 %];
 }
 .scroll-top-wrapper.show {
     visibility:visible;
     cursor:pointer;
-	opacity: 1.0;
+    opacity: 1.0;
 }
 .scroll-top-wrapper i.fa {
-	line-height: inherit;
+    line-height: inherit;
 }
 /****End Top button***/
 
@@ -983,7 +984,7 @@ h4.letter {
 }
 
 .highlighted {
-	color: red;
+    color: red;
 }
 
 .item_list .item {
@@ -1106,40 +1107,40 @@ form#logs_form label,
 form.bold_label label {
 }
 #Canvas {
-	min-height: 95%;
-	width: 98%;
-	margin: 0 0.8em -5em 0.8em;
-	overflow: hidden;
+    min-height: 95%;
+    width: 98%;
+    margin: 0 0.8em -5em 0.8em;
+    overflow: hidden;
 }
 
 #Menus {
-	float:left;
-	width: 23.5em;
-	border: 0px solid;
-	margin-top:1em;
-	padding-top: 0px;
-	text-align: left;
+    float:left;
+    width: 23.5em;
+    border: 0px solid;
+    margin-top:1em;
+    padding-top: 0px;
+    text-align: left;
 }
 
 #Paint {
-	vertical-align:top;
-	text-align: center;
+    vertical-align:top;
+    text-align: center;
 }
 
 #Title {
-	text-align: left;
-	font-size:1.8em;
-	font-weight: bold;
-	padding:1em 0 0 0;
-	z-index:520;
+    text-align: left;
+    font-size:1.8em;
+    font-weight: bold;
+    padding:1em 0 0 0;
+    z-index:520;
 }
 [%~ END # IF 0 ~%]
 
 .menuInactive2 {
-	font-size: 1em;
-	line-height:1.4em;
-	text-decoration: none;
-	font-weight:normal;
+    font-size: 1em;
+    line-height:1.4em;
+    text-decoration: none;
+    font-weight:normal;
 }
 
 ul#MainMenuLinks li {
@@ -1148,32 +1149,32 @@ ul#MainMenuLinks li {
 
 [% IF 0 # No longer used. ~%]
 #toggleMenu {
-	float: right;
-	padding-right: 3px;
+    float: right;
+    padding-right: 3px;
 }
 
 td.adminmenu {
-	text-align: center;
+    text-align: center;
 }
 
 .text_left {
-	text-align: left;
+    text-align: left;
 }
 
 .text_right {
-	text-align: right!important;
+    text-align: right!important;
 }
 
 td.text_right {
-	text-align: right;
+    text-align: right;
 }
 
 .text_justify {
-	text-align: justify;
+    text-align: justify;
 }
 
 .without_padding {
-	padding:0!important;
+    padding:0!important;
 }
 
 .list_panel li {
@@ -1182,75 +1183,75 @@ td.text_right {
 [%~ END # IF 0 ~%]
 
 #list_type {
-	list-style-type: none;
+    list-style-type: none;
 }
 
 #list_type dd {
-	margin-left: 1em;
+    margin-left: 1em;
 }
 
 .smaller {
-	font-size: smaller;
+    font-size: smaller;
 }
 
 .larger {
-	font-size: larger;
+    font-size: larger;
 }
 
 [% IF 0 # No longer used. ~%]
 span.center {
-	text-align: center;
+    text-align: center;
 }
 [%~ END # IF 0 ~%]
 
 table td.review_cels {
-	text-align: center;
-	padding:0 0.2em;
+    text-align: center;
+    padding:0 0.2em;
 }
 
 table td.review_cels_mail {
-	text-align: left;
-	padding:0 0 0 0.2em;
+    text-align: left;
+    padding:0 0 0 0.2em;
 }
 
 [% IF 0 # No longer used. ~%]
 #home_rss_news {
-	float: right;
+    float: right;
 }
 
 #home_rss_news input {
-	border: 1px solid;
-	padding:0.05em 1em;
-	text-decoration: none;
-	font-size: 0.9em;
-	font-weight: 600;
-	letter-spacing:0.1em;
-	/* if IE zoom:1;*/
-	zoom: 1;
-	-moz-border-radius:10px;
-	-webkit-border-radius:10px;
-	-KHTML-border-radius:10px;
-	-icab-border-radius:10px;
-	border-radius:10px;
+    border: 1px solid;
+    padding:0.05em 1em;
+    text-decoration: none;
+    font-size: 0.9em;
+    font-weight: 600;
+    letter-spacing:0.1em;
+    /* if IE zoom:1;*/
+    zoom: 1;
+    -moz-border-radius:10px;
+    -webkit-border-radius:10px;
+    -KHTML-border-radius:10px;
+    -icab-border-radius:10px;
+    border-radius:10px;
 }
 
 #home_search_list {
-	clear: both;
+    clear: both;
 }
 
 #home_search_list form fieldset {
-	display: inline;
-	vertical-align: top;
+    display: inline;
+    vertical-align: top;
 }
 
 #home_container {
-	padding: 10px;
-	border: 1px dashed;
-	-moz-border-radius:4px;
-	-webkit-border-radius:4px;
-	-KHTML-border-radius:4px;
-	-icab-border-radius:4px;
-	border-radius:4px;
+    padding: 10px;
+    border: 1px dashed;
+    -moz-border-radius:4px;
+    -webkit-border-radius:4px;
+    -KHTML-border-radius:4px;
+    -icab-border-radius:4px;
+    border-radius:4px;
 }
 
 .home_page_list{
@@ -1272,60 +1273,60 @@ table td.review_cels_mail {
 
 [%# No longer used.
 .edit_list_request_enum{
-	margin: 0 0 1rem;
-	padding-left: 1em;
-	text-align: left;
-	font-size: 1em;
+    margin: 0 0 1rem;
+    padding-left: 1em;
+    text-align: left;
+    font-size: 1em;
 }
 
 ~%]
 [%# No longer used.
 .edit_list_request_enum span.divider:first-child {
-	display:none;
+    display:none;
 }
 ~%]
 
 [%# No longer used.
  /*.edit_list_request_enum label{
-	display: block;
-	float: left;
-	width: 150px;
+    display: block;
+    float: left;
+    width: 150px;
 }
 */
 ~%]
 
 .list_admin {
-	font-size: 1em;
+    font-size: 1em;
 }
 [%~ END # IF 0 ~%]
 
 .mailing_lists_menu {
-	padding: 10px;
-	margin: 5px 25px 5px 25px;
-	float: left;
-	font-size: 1.1em;
-	text-align: left;
+    padding: 10px;
+    margin: 5px 25px 5px 25px;
+    float: left;
+    font-size: 1.1em;
+    text-align: left;
 }
 
 ul.no_style {
-	list-style: none;
-	margin: 0;
+    list-style: none;
+    margin: 0;
 }
 
 .align_top {
-	vertical-align: top;
+    vertical-align: top;
 }
 
 #template_editor {
-	margin-top: 10px;
+    margin-top: 10px;
 }
 
 #template_editor ul {
-	padding-left: 5px;
+    padding-left: 5px;
 }
 
 #template_editor li {
-	margin: 2px;
+    margin: 2px;
 }
 
 
@@ -1335,139 +1336,139 @@ ul.no_style {
 
 [% IF 0 # No longer used. ~%]
 #help {
-	padding-left: 10px;
-	padding-top: 5px;
-	margin-bottom: 20px;
+    padding-left: 10px;
+    padding-top: 5px;
+    margin-bottom: 20px;
 }
 
 #help li {
-	padding: 1px;
+    padding: 1px;
 }
 
 #help_editfile, #blaklist {
-	margin: 1em;
+    margin: 1em;
 }
 
 #help_editfile ul, #blacklist ul {
-	padding-left: 1em;
-	margin-top: 0.5em;
-	margin-bottom: 0.5em;
+    padding-left: 1em;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
 }
 [%~ END # IF 0 ~%]
 
 ul#set_pending_radio {
-	display: inline;
-	list-style-type: none;
+    display: inline;
+    list-style-type: none;
 }
 
 ul#set_pending_radio li {
-	display: inline;
-	margin-right: 1em;
-	margin-left: 1em;
+    display: inline;
+    margin-right: 1em;
+    margin-left: 1em;
 }
 
 form#bold_label input {
-	margin-left: 5px;
-	margin-top: 5px;
+    margin-left: 5px;
+    margin-top: 5px;
 }
 
 form input[type="radio"],
 form input[type="checkbox"] {
-	vertical-align: inherit;
-	border:none;
+    vertical-align: inherit;
+    border:none;
 }
 
 [% IF 0 # No longer used. ~%]
 #global_mailing_lists {
-	text-align: center;
+    text-align: center;
 }
 
 #show_cert {
-	border: 1px solid;
+    border: 1px solid;
 }
 
 #show_cert ul {
-	list-style-type: none;
-	padding-top: 5px;
-	margin-bottom: 5px;
+    list-style-type: none;
+    padding-top: 5px;
+    margin-bottom: 5px;
 }
 
 #show_cert ul li {
-	line-height: 1em;
-	padding-left: 3px;
+    line-height: 1em;
+    padding-left: 3px;
 }
 [%~ END # IF 0 ~%]
 
 #cp_template {
-	border: 1px solid;
-	padding: 3px;
-	width: 410px;
+    border: 1px solid;
+    padding: 3px;
+    width: 410px;
 }
 
 #cp_template fieldset {
-	display: inline;
-	border: 1px solid;
-	vertical-align: top;
-	margin-left: 3px;
+    display: inline;
+    border: 1px solid;
+    vertical-align: top;
+    margin-left: 3px;
 }
 
 #cp_template legend,
 #cp_template label {
-	padding-left: 3px;
+    padding-left: 3px;
 }
 
 pre.code {
-	font-family: monospace;
-	border: 1px dotted;
-	padding: 0.5em;
+    font-family: monospace;
+    border: 1px dotted;
+    padding: 0.5em;
 }
 
 footer {
-	border-top: 1px solid [% color_9 %];
-	width:100%;
-	height:1.5em;
-	margin: 0;
-	font-size: 1.1em;
-	text-align: center;
-	padding-top:0.5rem;
-	padding-bottom:2.5rem;
+    border-top: 1px solid [% color_9 %];
+    width:100%;
+    height:1.5em;
+    margin: 0;
+    font-size: 1.1em;
+    text-align: center;
+    padding-top:0.5rem;
+    padding-bottom:2.5rem;
         clear:both;
 }
 
 footer a {
-	font-weight: normal;
-	font-size: 11px;
+    font-weight: normal;
+    font-size: 11px;
 }
 
 footer img {
-	margin:0 0.5em 0 0;
-	vertical-align:middle;
+    margin:0 0.5em 0 0;
+    vertical-align:middle;
 }
 
 [% IF 0 # No longer used. ~%]
 #Identity {
-	text-align: left;
-	padding-top: 1em;
+    text-align: left;
+    padding-top: 1em;
 }
 
 .Help {
-	display: none;
-	position: absolute;
-	border: 1px dotted;
-	z-index: 1000;
+    display: none;
+    position: absolute;
+    border: 1px dotted;
+    z-index: 1000;
 }
 
 #rows_nb {
-	font-size: 0.8em;
+    font-size: 0.8em;
 }
 [%~ END # IF 0 ~%]
 
 #page_size {
-	margin: 2rem 0;
-	padding-bottom: 20px;
+    margin: 2rem 0;
+    padding-bottom: 20px;
 }
 #page_size select{
-	width:100px;
+    width:100px;
 }
 
 [% IF 0 # No longer used. ~%]
@@ -1484,13 +1485,13 @@ footer img {
 
 [% IF 0 # No longer used. ~%]
 .nomenu .ContentBlock {
-	margin: 1em auto;
-	float:none;
-	width: 90%;
+    margin: 1em auto;
+    float:none;
+    width: 90%;
 }
 
 .ContentBlock h2 {
-	margin-top:0;
+    margin-top:0;
 }
 
 .ContentBlock > * {
@@ -1498,85 +1499,85 @@ footer img {
 }
 
 .ContentBlock * a {
-	text-align: left;
+    text-align: left;
 }
 [%~ END # IF 0 ~%]
 
 a img.Pictures {
-	height:30px;
+    height:30px;
 }
 
 #pictures_block {
-	text-align: center;
-	height: 120px ;
+    text-align: center;
+    height: 120px ;
 }
 
 #pictures_block div {
-	margin: 1em;
-	float: left;
+    margin: 1em;
+    float: left;
 }
 
 #large_picture {
-	height: 80px;
+    height: 80px;
 }
 
 #pictures_block #large img{
-	height: 80px;
+    height: 80px;
 }
 
 #pictures_block #small img{
-	height: 30px;
-	margin-top: 50px;
+    height: 30px;
+    margin-top: 50px;
 }
 
 .displayNone {
-	display: none;
-	height:0px;
-	width:0px;
+    display: none;
+    height:0px;
+    width:0px;
 }
 
 /*
 .title {
-	position: absolute;
-	top: 60px;
-	font-size: 1.6em;
-	text-indent: 30px;
+    position: absolute;
+    top: 60px;
+    font-size: 1.6em;
+    text-indent: 30px;
 }
 */
 
 [% IF 0 # No longer used. ~%]
 .customMenu {
-	text-indent: 0px;
+    text-indent: 0px;
 }
 
 a.dingbat {
-	text-align: center;
+    text-align: center;
 }
 
 .dingbat {
-	text-indent: 0px;
-	text-align: center;
-	font-weight: 100;
+    text-indent: 0px;
+    text-align: center;
+    font-weight: 100;
 }
 
 .smalltext {
-	font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .smalltext a {
-	font-size: 0.8em;
+    font-size: 0.8em;
 }
 
 .smallblacktext {
-	font-size: 1.2em;
+    font-size: 1.2em;
 }
 
 .mediumtext {
-	font-size: 1.2em;
+    font-size: 1.2em;
 }
 
 .largetext {
-	font-size: 1.6em;
+    font-size: 1.6em;
 }
 [%~ END # IF 0 ~%]
 
@@ -1621,106 +1622,106 @@ a.actionMenuLinks:hover {
 a.ArcMenuLinks,
 a.ArcMenuLinks:visited,
 a.ArcMenuLinks:link {
-	border: 1px solid;
-	font-weight:bold;
-	text-decoration: none;
-	padding: 0px 10px;
-	-moz-border-radius:5px;
-	-webkit-border-radius:5px;
-	-KHTML-border-radius:5px;
-	-icab-border-radius:5px;
-	border-radius:5px;
+    border: 1px solid;
+    font-weight:bold;
+    text-decoration: none;
+    padding: 0px 10px;
+    -moz-border-radius:5px;
+    -webkit-border-radius:5px;
+    -KHTML-border-radius:5px;
+    -icab-border-radius:5px;
+    border-radius:5px;
 }
 
 [%# No longer used, but may be included in archives created in the past. ~%]
 a.ArcMenuLinksCurrentPage {
-	border: 1px solid;
-	text-decoration: none;
-	padding: 0px 10px;
-	-moz-border-radius:5px;
-	-webkit-border-radius:5px;
-	-KHTML-border-radius:5px;
-	-icab-border-radius:5px;
-	border-radius:5px;
+    border: 1px solid;
+    text-decoration: none;
+    padding: 0px 10px;
+    -moz-border-radius:5px;
+    -webkit-border-radius:5px;
+    -KHTML-border-radius:5px;
+    -icab-border-radius:5px;
+    border-radius:5px;
 }
 
 a.ArcMenuLinksInactive,
 a.ArcMenuLinksInactive:hover {
-	border: 1px solid;
-	text-decoration: none;
-	padding: 0px 10px;
-	-moz-border-radius:5px;
-	-webkit-border-radius:5px;
-	-KHTML-border-radius:5px;
-	-icab-border-radius:5px;
-	border-radius:5px;
+    border: 1px solid;
+    text-decoration: none;
+    padding: 0px 10px;
+    -moz-border-radius:5px;
+    -webkit-border-radius:5px;
+    -KHTML-border-radius:5px;
+    -icab-border-radius:5px;
+    border-radius:5px;
 }
 
 a.ArcMenuLinksSortActive,
 a.ArcMenuLinksSortActive:hover,
 a.ArcMenuLinksSortInactive:hover  {
-	border: 1px solid;
-	text-decoration: none;
-	padding: 0px 10px;
-	-moz-border-radius:5px;
-	-webkit-border-radius:5px;
-	-KHTML-border-radius:5px;
-	-icab-border-radius:5px;
-	border-radius:5px;
+    border: 1px solid;
+    text-decoration: none;
+    padding: 0px 10px;
+    -moz-border-radius:5px;
+    -webkit-border-radius:5px;
+    -KHTML-border-radius:5px;
+    -icab-border-radius:5px;
+    border-radius:5px;
 }
 
 a.ArcMenuLinksSortInactive {
-	border: 1px solid;
-	text-decoration: none;
-	padding: 0px 10px;
-	-moz-border-radius:5px;
-	-webkit-border-radius:5px;
-	-KHTML-border-radius:5px;
-	-icab-border-radius:5px;
-	border-radius:5px;
+    border: 1px solid;
+    text-decoration: none;
+    padding: 0px 10px;
+    -moz-border-radius:5px;
+    -webkit-border-radius:5px;
+    -KHTML-border-radius:5px;
+    -icab-border-radius:5px;
+    border-radius:5px;
 }
 
 #ArcMenuLinksInactive {
-	border: 0px solid;
-	text-decoration: none;
-	padding-left: 3px;
+    border: 0px solid;
+    text-decoration: none;
+    padding-left: 3px;
 }
 /* end menu links for archive */
 
 h7 {
-	font-size: 0.8em;
-	font-style: italic;
+    font-size: 0.8em;
+    font-style: italic;
 }
 
 h7 strong {
-	font-size: 1em;
+    font-size: 1em;
 }
 
 [% IF 0 # No longer used. ~%]
 .listTitle {
-	font-size: 1.6em;
-	padding-bottom: 0.5em;
+    font-size: 1.6em;
+    padding-bottom: 0.5em;
 }
 
 .listTitle.description  {
-	font-size:1em;
-	font-weight:bold;
-	margin-top:0em;
-	margin-bottom:1.3em;
-	border:none;
+    font-size:1em;
+    font-weight:bold;
+    margin-top:0em;
+    margin-bottom:1.3em;
+    border:none;
 }
 [%~ END # IF 0 ~%]
 
 /*
 #ErrorBlock {
-	position:absolute;
-	left:0;
-	top:0;
-	z-index:600;
-	opacity:0.4;
-	width:100%;
-	height:100%;
-	background: none repeat scroll 0 0 [% color_1 %]
+    position:absolute;
+    left:0;
+    top:0;
+    z-index:600;
+    opacity:0.4;
+    width:100%;
+    height:100%;
+    background: none repeat scroll 0 0 [% color_1 %]
 }
  */
 
@@ -1745,12 +1746,12 @@ h7 strong {
     margin-bottom:0;
 }
 #ErrorMsg input[type="button"]{
-	background: #D91E18 none no-repeat scroll top left;
-	font-size: 0.9em;
+    background: #D91E18 none no-repeat scroll top left;
+    font-size: 0.9em;
 }
 
 #ErrorMsg input[type="button"]:hover {
-	background: [% color_13 %] none no-repeat scroll bottom left;
+    background: [% color_13 %] none no-repeat scroll bottom left;
         color:[% color_7 %];
 }
 
@@ -1824,11 +1825,11 @@ h7 strong {
 
 
 p.listenum {
-	margin-top: 0;
-	padding-top: 0;
-	margin-bottom: 0;
-	padding-bottom: 0;
-	font-size:0.9em;
+    margin-top: 0;
+    padding-top: 0;
+    margin-bottom: 0;
+    padding-bottom: 0;
+    font-size:0.9em;
 }
 
 ul.listenum {
@@ -1852,120 +1853,120 @@ span.divider{
 
 [% IF 0 # No longer used. ~%]
 div.admin_cmd {
-	float:left;
-	margin: 0em 0.3em 0.1em 0;
-	padding: 0 0.3em;
-	border: 1px solid;
-	-moz-border-radius:6px;
-	-webkit-border-radius:6px;
-	-KHTML-border-radius:6px;
-	-icab-border-radius:6px;
-	border-radius:6px;
+    float:left;
+    margin: 0em 0.3em 0.1em 0;
+    padding: 0 0.3em;
+    border: 1px solid;
+    -moz-border-radius:6px;
+    -webkit-border-radius:6px;
+    -KHTML-border-radius:6px;
+    -icab-border-radius:6px;
+    border-radius:6px;
 }
 
 div.admin_cmd a {
-	font-size:0.7em!important;
-	font-weight:bold;
+    font-size:0.7em!important;
+    font-weight:bold;
 }
 [%~ END # IF 0 ~%]
 
 /* Calendar in mhonarc-ressources.tt2 */
 ul.calendar {
-	margin-left:0!important;
-	padding-left:0!important;
+    margin-left:0!important;
+    padding-left:0!important;
 }
 
 ul.calendar a {
-	font-size: 1em;
+    font-size: 1em;
 }
 
 ul.calendar li {
-	list-style: none;
-	display: inline;
-	padding: 0px 1px 0px 2px;
-	line-height: 2em;
-	font-size: 1em;
-	text-decoration: none;
-	border: 1px solid;
-	-moz-border-radius:4px;
-	-webkit-border-radius:4px;
-	-KHTML-border-radius:4px;
-	-icab-border-radius:4px;
-	border-radius:4px;
+    list-style: none;
+    display: inline;
+    padding: 0px 1px 0px 2px;
+    line-height: 2em;
+    font-size: 1em;
+    text-decoration: none;
+    border: 1px solid;
+    -moz-border-radius:4px;
+    -webkit-border-radius:4px;
+    -KHTML-border-radius:4px;
+    -icab-border-radius:4px;
+    border-radius:4px;
 }
 
 ul li.calendarLinks {
-	border: 1px solid [% color_5 %];
+    border: 1px solid [% color_5 %];
 }
 
 ul li.calendarLinksCurrentPage,
 ul li.calendarLinksCurrentPage:hover {
-	border: 1px solid !important;
+    border: 1px solid !important;
 }
 
 ul li.calendarLinksCurrentPage,
 ul li.calendarLinksCurrentPage a {
-	border-bottom:1px solid !important;
+    border-bottom:1px solid !important;
 }
 
 ul li.calendarLinksInactive {
-	border: 1px solid [% color_3 %];
+    border: 1px solid [% color_3 %];
 }
 
 ul li.calendarYear {
-	border: 1px solid;
+    border: 1px solid;
 }
 /* end calendar in mhonarc-ressources.tt2 */
 
 abbr,
 acronym,
 .info {
-	border-bottom: 1px dotted;
-	cursor: help;
+    border-bottom: 1px dotted;
+    cursor: help;
 }
 
 p {
-	text-indent: 0px;
+    text-indent: 0px;
 }
 
 p.spacer {
-	clear: both;
+    clear: both;
 }
 
 code {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 /* notices in help. */
 .retraitita {
-	border: 1px dashed;
-	padding: 2px;
-	margin: 5px;
+    border: 1px dashed;
+    padding: 2px;
+    margin: 5px;
 }
 
 span.retraitita {
-	border: 1px dashed;
-	padding: 5px 10px;
-	margin: 5px;
-	display: block;
+    border: 1px dashed;
+    padding: 5px 10px;
+    margin: 5px;
+    display: block;
 }
 /* end notices in help. */
 
 a.input {
-	border: 1px solid;
-	padding: 0.2em 0.3em;
-	margin-left:0.2em;
-	text-decoration: none;
-	vertical-align: middle;
-	font-size: 0.7em;
-	font-weight:bold;
-	font-variant:small-caps;
-	/* if IE zoom:1;*/
-	zoom: 1;
+    border: 1px solid;
+    padding: 0.2em 0.3em;
+    margin-left:0.2em;
+    text-decoration: none;
+    vertical-align: middle;
+    font-size: 0.7em;
+    font-weight:bold;
+    font-variant:small-caps;
+    /* if IE zoom:1;*/
+    zoom: 1;
 }
 
 h2 a.input {
-	font-size: 0.7em;
+    font-size: 0.7em;
 }
 
 textarea {
@@ -1978,56 +1979,56 @@ textarea.desc {
 }
 
 textarea.textbox {
-	border: 1px solid;
-	padding: 3px;
+    border: 1px solid;
+    padding: 3px;
 }
 
 input.textbox {
-	border: 1px solid;
-	padding: 3px;
+    border: 1px solid;
+    padding: 3px;
 }
 
 input.button {
-	border: 1px solid;
-	padding: 0px 2px;
-	margin:2px;
+    border: 1px solid;
+    padding: 0px 2px;
+    margin:2px;
 }
 
 [% IF 0 # No longer used. ~%]
 #subnav {
-	float:left;
-	width:99.9%;
-	z-index:400!important;
+    float:left;
+    width:99.9%;
+    z-index:400!important;
 }
 
 #subnav ul {
-	font-size:0.9em;
-	margin:1em 0 0;
-	list-style:none;
+    font-size:0.9em;
+    margin:1em 0 0;
+    list-style:none;
 }
 
 #subnav ul li {
-	float:left;
-	display:inline;
-	margin:0 0.5em 0.2em 0.2em;
+    float:left;
+    display:inline;
+    margin:0 0.5em 0.2em 0.2em;
 }
 
 #subnav ul li.MainMenuLinks{
-	background-color: [% color_10 %];
-	padding: 0.2em 0.5em;
+    background-color: [% color_10 %];
+    padding: 0.2em 0.5em;
 }
 
 #subnav ul li.MainMenuLinks a {
-	color: [% color_7 %];
+    color: [% color_7 %];
 }
 
 #subnav ul li.MainMenuLinksCurrentPage {
-	background-color: [% color_13 %];
-	padding: 0.2em 0.5em;
+    background-color: [% color_13 %];
+    padding: 0.2em 0.5em;
 }
 
 #subnav ul li.MainMenuLinksCurrentPage a {
-	color: [% color_7 %];
+    color: [% color_7 %];
 }
 [%~ END # IF 0 ~%]
 
@@ -2037,12 +2038,12 @@ span.bottom_page, p.bottom_page{
 }
 
 .top {
-	float:right;
-	margin:0.5em 1em 1.5em 1em;
+    float:right;
+    margin:0.5em 1em 1.5em 1em;
 }
 
 .noborder {
-	border: none!important;
+    border: none!important;
 }
 
 [% IF 0 # No longer used: for microCal ~%]
@@ -2114,19 +2115,19 @@ span.bottom_page, p.bottom_page{
 [%~ END # IF 0 ~%]
 
 .viewmod {
-	display: none;
-	position: absolute;
-	z-index: 10;
-	background-color: [% color_0 %];
-	border: 1px solid [% color_1 %];
-	padding: 1em;
-	width: 80%;
+    display: none;
+    position: absolute;
+    z-index: 10;
+    background-color: [% color_0 %];
+    border: 1px solid [% color_1 %];
+    padding: 1em;
+    width: 80%;
 }
 
 /* Font family to cover languages as much as possible rather than quality */
 .neutral,
 .neutral option {
-	font-family: arial, sans-serif;
+    font-family: arial, sans-serif;
 }
 
 
@@ -2656,6 +2657,6 @@ span.fa-stack i.fa-plus-circle {
 }
 
 a, li {
-	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 

--- a/default/web_tt2/css_ie.tt2
+++ b/default/web_tt2/css_ie.tt2
@@ -7,8 +7,8 @@
 
 /* Workaround for "noscript ghost" bug */
 noscript {
-          display: block;
-          }
+    display: block;
+}
 
 </style>
 <![endif]-->
@@ -17,13 +17,13 @@ noscript {
 <style type="text/css">
 
 #subnav {
-          position:absolute;
-	  left:25em;
-          }
+    position:absolute;
+    left:25em;
+}
 
 #bandeau_top .login .MainMenuLinks {
-	                             margin-top:0.2em;
-           	                     }
+    margin-top:0.2em;
+}
 
 </style>
 <![endif]-->
@@ -33,31 +33,31 @@ noscript {
 <style type="text/css">
 
 ul#MainMenuLinks {
-                   margin-left:-3em;
-                   }
+    margin-left:-3em;
+}
 
 a.input {
-          padding: 0 0.3em;
-          }
+    padding: 0 0.3em;
+}
 
 /* "vertical-align: baseline" aligns form fields on bottom of widgets */
 form input,
 form textarea,
 form select {
-             vertical-align: middle;
-             }
+    vertical-align: middle;
+}
 .MainMenuLinks {
-                margin-bottom: 0.2em;
-                vertical-align: middle;
-                }
+    margin-bottom: 0.2em;
+    vertical-align: middle;
+}
 
 /* Workaround for "peek-a-boo" bug. */
 a.MainMenuLinks,
 a.MainMenuLinks:hover,
 a.MainMenuLinksCurrentPage,
 a.MainMenuLinksCurrentPage:hover {
-                                  position: relative;
-                                  }
+    position: relative;
+}
 
 </style>
 <![endif]-->
@@ -68,34 +68,34 @@ a.MainMenuLinksCurrentPage:hover {
 <style type="text/css">
 
 #logo {
-        position:absolute;
-        top:0.5em;
-        left:-5em;
-        z-index:510;
-        }
+    position:absolute;
+    top:0.5em;
+    left:-5em;
+    z-index:510;
+}
 
 #Stretcher {
-             width:99.5%;
-             }
+    width:99.5%;
+}
 
 #subnav {
-          width:100%;
-	  background-color:[% color_5 %];
-          border:1px solid [% color_8 %];
-          border-width: 0 1px 0 0;
-          }
+    width:100%;
+    background-color:[% color_5 %];
+    border:1px solid [% color_8 %];
+    border-width: 0 1px 0 0;
+}
 
 #nav {
-       width:99%;
-       }
+    width:99%;
+}
 
 #Footer {
-          margin: 0.5em 0.8em;
-          }
+    margin: 0.5em 0.8em;
+}
 
 #bandeau_top .login .MainMenuLinks {
-	                             margin-top:0;
-           	                     }
+    margin-top:0;
+}
 
 
 </style>

--- a/default/web_tt2/d_control.tt2
+++ b/default/web_tt2/d_control.tt2
@@ -1,6 +1,6 @@
 <!-- d_control.tt2 -->
 <h2>[%|loc%]Shared documents[%END%] <a  href="[% 'nomenu/help/shared' | url_rel %]" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=400,height=200')" target="wws_help"><i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i></a></h2>
-    
+
 <menu class="shared">
   [% FOREACH a = shared_doc.ancestors ~%]
     [% IF a.type == 'root' ~%]

--- a/default/web_tt2/d_install_shared.tt2
+++ b/default/web_tt2/d_install_shared.tt2
@@ -7,14 +7,14 @@
 <p>[%|loc%]already exist(s), do you want to confirm the install and erase the old file(s) or cancel the install?[%END%]</p>
 
 <form action="[% path_cgi %]" method="post">
-<fieldset>
-  <input id="mode_confirm" class="MainMenuLinks" type="submit" name="mode_confirm" value="[%|loc%]Confirm[%END%]" /></td>
-  <input id="mode_cancel" class="MainMenuLinks" type="submit" name="mode_cancel" value="[%|loc%]Cancel[%END%]" /></td>
- <input type="hidden" name="list" value="[% list %]" />
-[% FOREACH elt = id %]
- <input type="hidden" name="id" value="[% elt %]" />
-[% END %]
- <input type="hidden" name="action_d_install_shared" value="1" /> 
-</fieldset>
-</form>  
+  <fieldset>
+    <input id="mode_confirm" class="MainMenuLinks" type="submit" name="mode_confirm" value="[%|loc%]Confirm[%END%]" /></td>
+    <input id="mode_cancel" class="MainMenuLinks" type="submit" name="mode_cancel" value="[%|loc%]Cancel[%END%]" /></td>
+   <input type="hidden" name="list" value="[% list %]" />
+  [% FOREACH elt = id %]
+   <input type="hidden" name="id" value="[% elt %]" />
+  [% END %]
+   <input type="hidden" name="action_d_install_shared" value="1" /> 
+  </fieldset>
+</form>
 <!-- end d_install_shared.tt2 -->

--- a/default/web_tt2/d_properties.tt2
+++ b/default/web_tt2/d_properties.tt2
@@ -1,6 +1,6 @@
 <!-- d_properties.tt2 -->
 <h2>[%|loc%]Shared documents[%END%] <a  href="[% 'nomenu/help/shared' | url_rel %]" title="[%|loc%]Open in a new window[%END%]" onclick="window.open('','wws_help','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=400,height=200')" target="wws_help"><i class="fa fa-question-circle" title="[%|loc%]Help[%END%]"></i></a></h2>
-    
+
 <menu class="shared">
   [% FOREACH a = shared_doc.ancestors ~%]
     [% IF a.type == 'root' ~%]

--- a/default/web_tt2/d_read.tt2
+++ b/default/web_tt2/d_read.tt2
@@ -110,182 +110,183 @@
     [% FOREACH s = shared_doc.children ~%]
       [% NEXT UNLESS s.type == 'directory' ~%]
       <tr class="color0">
-	<td class="review_cels_mail">
+        <td class="review_cels_mail">
           <a href="[% 'd_read' | url_rel([list,s.paths_d]) %]"> 
             [% PROCESS SharedGetIcon shared_item = s %]
-            [% s.name %]</a></td>
-	<td class="review_cels">
+            [% s.name %]</a>
+        </td>
+        <td class="review_cels">
         [% IF s.owner ~%] 
-	  [% s.owner | mailto(s.owner) | obfuscate(listconf.spam_protection) %]
+          [% s.owner | mailto(s.owner) | obfuscate(listconf.spam_protection) %]
         [%~ ELSE ~%]
-	   [%|loc%]Unknown[%END%] 
-	[%~ END ~%]
-	</td>	    
-	<td>&nbsp;</td>
-	<td class="review_cels"> [% s.date %] </td>
+           [%|loc%]Unknown[%END%] 
+        [%~ END ~%]
+        </td>
+        <td>&nbsp;</td>
+        <td class="review_cels"> [% s.date %] </td>
 
-	[% IF expert_page ~%]
-	  <td class="review_cels text-right">
-	  [% IF s.may_edit ~%]
-	    <a href="[% 'd_delete' | url_rel([list,s.paths_d],{previous_action=>action}) %]"
+      [% IF expert_page ~%]
+        <td class="review_cels text-right">
+          [% IF s.may_edit ~%]
+            <a href="[% 'd_delete' | url_rel([list,s.paths_d],{previous_action=>action}) %]"
               class="tip-left" data-tooltip aria-haspopup="true"
               title="[%|loc%]delete[%END%]"><i class="fa fa-trash fa-lg"></i>
             </a>
-	  [%~ ELSE ~%]
+          [%~ ELSE ~%]
 
           [%~ END %]
-	
-	  [% IF s.may_control ~%]
-	    &nbsp;<a href="[% 'd_control' | url_rel([list,s.paths_d]) %]"
+
+          [% IF s.may_control ~%]
+            &nbsp;<a href="[% 'd_control' | url_rel([list,s.paths_d]) %]"
               class="tip-left" data-tooltip aria-haspopup="true"
               title="[%|loc%]access[%END%]"><i class="fa fa-lock fa-lg"></i>
             </a>
-	  [%~ ELSE ~%]
+          [%~ ELSE ~%]
 
-	  [%~ END %]
-      
+          [%~ END %]
+
           [% IF s.may_edit ~%]
             &nbsp;<a href="[% 'd_properties' | url_rel([list,s.paths_d]) %]"
               class="tip-left" data-tooltip aria-haspopup="true"
               title="[%|loc%]properties[%END%]"><i class="fa fa-cog fa-lg"></i>
             </a>
-	  [%~ ELSE ~%]
+          [%~ ELSE ~%]
 
-	  [%~ END %]
+          [%~ END %]
 
           [% IF is_editor ~%]
 
           [%~ END %]
           </td>
-	[%~ END %]
+      [%~ END %]
       </tr>
-    [%~ END %] 
+    [%~ END %]
   [%~ END %]
 
   [% IF shared_doc.children ~%]
     [% FOREACH f = shared_doc.children ~%]
       [% NEXT IF f.type == 'directory' ~%]
       [% IF f.moderate ~%]
-	[% IF expert_page ~%]
+        [% IF expert_page ~%]
          <tr class="bg_color_bg">
-	[%~ END %]
+        [%~ END %]
       [%~ ELSE ~%]
-        <tr class="color0">
+      <tr class="color0">
       [%~ END %]
-        
+
       [% IF f.html ~%]
-	<td class="review_cels_mail">
-        <a href="[% 'd_read' | url_rel([list,f.paths_d]) %]"
-         title="[%|loc%]Open in a new window[%END%]" target="html_window">
-          [% PROCESS SharedGetIcon shared_item = f %]
-          [% f.name %] </a>
-	</td>
-      [%~ ELSIF f.url ~%]
         <td class="review_cels_mail">
-	<a href="[% f.url %]" title="[%|loc%]Open in a new window[%END%]"
-         target="html_window">
-          [% PROCESS SharedGetIcon shared_item = f %]
-          [% f.label %] </a>
-	</td>
-      [%~ ELSE ~%]
-	[% IF f.moderate ~%]
-	  [% IF expert_page ~%]
-	    <td class="review_cels_mail">
-	    <a href="[% 'd_read' | url_rel([list,f.paths_d]) %]">
-              [% PROCESS SharedGetIcon shared_item = f %]
-              [% f.name %] </a>
-	    </td>
-          [%~ END %] 
-	[%~ ELSE ~%]
-	  <td class="review_cels_mail">
-	  <a href="[% 'd_read' | url_rel([list,f.paths_d]) %]">
+          <a href="[% 'd_read' | url_rel([list,f.paths_d]) %]"
+           title="[%|loc%]Open in a new window[%END%]" target="html_window">
             [% PROCESS SharedGetIcon shared_item = f %]
             [% f.name %] </a>
-	  </td>  
-	[%~ END ~%]
-      [% END %] 
+        </td>
+      [%~ ELSIF f.url ~%]
+        <td class="review_cels_mail">
+          <a href="[% f.url %]" title="[%|loc%]Open in a new window[%END%]"
+           target="html_window">
+          [% PROCESS SharedGetIcon shared_item = f %]
+          [% f.label %] </a>
+        </td>
+      [%~ ELSE ~%]
+        [% IF f.moderate ~%]
+          [% IF expert_page ~%]
+            <td class="review_cels_mail">
+              <a href="[% 'd_read' | url_rel([list,f.paths_d]) %]">
+                [% PROCESS SharedGetIcon shared_item = f %]
+                [% f.name %] </a>
+            </td>
+          [%~ END %] 
+        [%~ ELSE ~%]
+          <td class="review_cels_mail">
+            <a href="[% 'd_read' | url_rel([list,f.paths_d]) %]">
+              [% PROCESS SharedGetIcon shared_item = f %]
+              [% f.name %] </a>
+          </td>
+        [%~ END ~%]
+      [% END %]
 
       [% IF f.moderate ~%]
-	[% IF expert_page ~%]
-	  <td class="review_cels">[%|loc%]to moderate[%END%]</td>
+        [% IF expert_page ~%]
+          <td class="review_cels">[%|loc%]to moderate[%END%]</td>
         [%~ END %]
       [%~ ELSE ~%]
         <td class="review_cels">
-	[% IF f.owner.length ~%]
-	  [% f.owner | mailto(f.owner) | obfuscate(listconf.spam_protection) %]
- 	[%~ ELSE ~%]
-          [%|loc%]Unknown[%END%]  
-        [%~ END ~%]
-	</td>
+          [% IF f.owner.length ~%]
+            [% f.owner | mailto(f.owner) | obfuscate(listconf.spam_protection) %]
+          [%~ ELSE ~%]
+            [%|loc%]Unknown[%END%]
+          [%~ END ~%]
+        </td>
       [%~ END %]
-	 
+
       [% IF f.moderate ~%]
         [% IF expert_page ~%]
           <td class="review_cels">&nbsp;
-	  [% IF !f.url ~%]
-	    [% f.size %] 
-	  [%~ END %]
-	  </td>
-	  <td class="review_cels"> [% f.date %] </td>
-	[%~ END %]
+          [% IF !f.url ~%]
+            [% f.size %] 
+          [%~ END %]
+          </td>
+          <td class="review_cels"> [% f.date %] </td>
+        [%~ END %]
       [%~ ELSE ~%]
         <td class="review_cels">&nbsp;
-	[%~ IF !f.url ~%]
-          [% f.size %] 
-	[%~ END ~%]
-	</td>
-	<td class="review_cels"> [% f.date %] </td>
+          [%~ IF !f.url ~%]
+            [% f.size %]
+            [%~ END ~%]
+        </td>
+        <td class="review_cels"> [% f.date %] </td>
       [%~ END %]
 
       [% IF expert_page ~%]
-	<td class="review_cels text-right">
-        [% IF is_editor ~%]
-          [% IF f.moderate ~%]
-	    [% IF expert_page ~%]
-              <a href="[% 'docindex' | url_rel([list]) %]"
-                class="tip-left color_10" data-tooltip aria-haspopup="true"
-                title="[%|loc%]moderate[%END%]">
-              <i class="fa fa-shield fa-lg"></i></a>&nbsp;
-	    [%~ END %]
-          [%~ ELSE ~%]
-	
+        <td class="review_cels text-right">
+          [% IF is_editor ~%]
+            [% IF f.moderate ~%]
+              [% IF expert_page ~%]
+                <a href="[% 'docindex' | url_rel([list]) %]"
+                  class="tip-left color_10" data-tooltip aria-haspopup="true"
+                  title="[%|loc%]moderate[%END%]">
+                <i class="fa fa-shield fa-lg"></i></a>&nbsp;
+              [%~ END %]
+            [%~ ELSE ~%]
+
+            [%~ END %]
           [%~ END %]
-        [%~ END %]
 
-	[% IF f.may_edit ~%]
-	  <a href="[% 'd_editfile' | url_rel([list,f.paths_d]) %]"
-            class="tip-left" data-tooltip aria-haspopup="true"
-            title="[%|loc%]edit[%END%]"><i class="fa fa-pencil fa-lg"></i></a>
-          &nbsp;<a href="[% 'd_delete' | url_rel([list,f.paths_d],{previous_action=>action}) %]"
-            class="tip-left" data-tooltip aria-haspopup="true"
-            title="[%|loc%]delete[%END%]"><i class="fa fa-trash fa-lg"></i></a>
-        [%~ ELSE ~%]
+          [% IF f.may_edit ~%]
+            <a href="[% 'd_editfile' | url_rel([list,f.paths_d]) %]"
+              class="tip-left" data-tooltip aria-haspopup="true"
+              title="[%|loc%]edit[%END%]"><i class="fa fa-pencil fa-lg"></i></a>
+            &nbsp;<a href="[% 'd_delete' | url_rel([list,f.paths_d],{previous_action=>action}) %]"
+              class="tip-left" data-tooltip aria-haspopup="true"
+              title="[%|loc%]delete[%END%]"><i class="fa fa-trash fa-lg"></i></a>
+          [%~ ELSE ~%]
 
-        [%~ END %]
-		 
-        [% IF f.may_control ~%]
-          &nbsp;<a href="[% 'd_control' | url_rel([list,f.paths_d]) %]"
-            class="tip-left" data-tooltip aria-haspopup="true"
-            title="[%|loc%]access[%END%]"><i class="fa fa-lock fa-lg"></i></a>
-        [%~ ELSE ~%]
+          [%~ END %]
 
-        [%~ END %]
-        
-        [% IF f.may_edit ~%]
-          &nbsp;<a href="[% 'd_properties' | url_rel([list,f.paths_d]) %]"
-            class="tip-left" data-tooltip aria-haspopup="true"
-            title="[%|loc%]properties[%END%]"><i class="fa fa-cog fa-lg"></i>
-          </a>
-	[%~ ELSE ~%]
+          [% IF f.may_control ~%]
+            &nbsp;<a href="[% 'd_control' | url_rel([list,f.paths_d]) %]"
+              class="tip-left" data-tooltip aria-haspopup="true"
+              title="[%|loc%]access[%END%]"><i class="fa fa-lock fa-lg"></i></a>
+          [%~ ELSE ~%]
 
-	[%~ END %]
+          [%~ END %]
+
+          [% IF f.may_edit ~%]
+            &nbsp;<a href="[% 'd_properties' | url_rel([list,f.paths_d]) %]"
+             class="tip-left" data-tooltip aria-haspopup="true"
+             title="[%|loc%]properties[%END%]"><i class="fa fa-cog fa-lg"></i>
+           </a>
+          [%~ ELSE ~%]
+
+          [%~ END %]
         </td>
       [%~ END %]
       </tr>
-    [%~ END %] 
+    [%~ END %]
   [%~ END %]
 [%~ END %]
-</table>	        
+</table>
  
 <br />
 [% IF expert_page ~%] 

--- a/default/web_tt2/docindex.tt2
+++ b/default/web_tt2/docindex.tt2
@@ -3,52 +3,52 @@
 [% IF shared_doc.children %]
 <form class="noborder toggleContainer" data-toggle-selector="input[name='id']"
   action="[% path_cgi %]" method="POST" name="moderate_shared">
-<fieldset>
-  <input type="hidden" name="list" value="[% list %]" />
-  <input class="MainMenuLinks" type="submit" name="action_d_install_shared" value="[%|loc%]Install[%END%]" />
-  <input class="MainMenuLinks" type="submit" name="action_d_reject_shared.quiet" value="[%|loc%]Reject[%END%]" />
-  <input class="MainMenuLinks" type="submit" name="action_d_reject_shared" value="[%|loc%]Notified reject[%END%]" />
-  <br />
-    <table  class="responsive listOfItems">
-    <caption>[%|loc%]Listing of documents shared to moderate[%END%]</caption>
-      <tr>
-        <th><a href="#"
-          data-tooltip aria-haspopup="true"
-          title="[%|loc%]Toggle Selection[%END%]"
-          class="toggleButton"><i class="fa fa-check-square-o"></i></a></th>
-        <th>[%|loc%]Date[%END%]</th>
-        <th>[%|loc%]Author[%END%]</th>
-        <th>[%|loc%]Path[%END%]</th>
-        <th>[%|loc%]Size[%END%]	</th>
-      </tr>	 
-      [% FOREACH f = shared_doc.children %]
+  <fieldset>
+    <input type="hidden" name="list" value="[% list %]" />
+    <input class="MainMenuLinks" type="submit" name="action_d_install_shared" value="[%|loc%]Install[%END%]" />
+    <input class="MainMenuLinks" type="submit" name="action_d_reject_shared.quiet" value="[%|loc%]Reject[%END%]" />
+    <input class="MainMenuLinks" type="submit" name="action_d_reject_shared" value="[%|loc%]Notified reject[%END%]" />
+    <br />
+      <table  class="responsive listOfItems">
+      <caption>[%|loc%]Listing of documents shared to moderate[%END%]</caption>
         <tr>
-         <td>
-            <input type="checkbox" name="id" value="[% f.paths.join("/") %]" />
-	 </td>
-	  <td>
-	    [% IF f.date %]
-	      [% f.date %]
-	    [% ELSE %]
-	      &nbsp;
-	    [% END %]
-	  </td>
-	  <td>[% f.owner %]</td>
-	  <td>
-	    <a href="[% 'd_read' | url_rel([list,f.paths_d]) %]">[% f.paths.join("/") %]</a>
-	  </td>
-	  <td>[% f.size %] kb</td>
-	</tr>
-      [% END %] 
-    </table>
+          <th><a href="#"
+            data-tooltip aria-haspopup="true"
+            title="[%|loc%]Toggle Selection[%END%]"
+            class="toggleButton"><i class="fa fa-check-square-o"></i></a></th>
+          <th>[%|loc%]Date[%END%]</th>
+          <th>[%|loc%]Author[%END%]</th>
+          <th>[%|loc%]Path[%END%]</th>
+          <th>[%|loc%]Size[%END%]</th>
+        </tr>
+        [% FOREACH f = shared_doc.children %]
+          <tr>
+           <td>
+              <input type="checkbox" name="id" value="[% f.paths.join("/") %]" />
+           </td>
+           <td>
+           [% IF f.date %]
+            [% f.date %]
+           [% ELSE %]
+            &nbsp;
+           [% END %]
+           </td>
+           <td>[% f.owner %]</td>
+           <td>
+             <a href="[% 'd_read' | url_rel([list,f.paths_d]) %]">[% f.paths.join("/") %]</a>
+           </td>
+           <td>[% f.size %] kb</td>
+         </tr>
+        [% END %]
+      </table>
 
-  <input class="MainMenuLinks toggleButton" type="button"
-    value="[%|loc%]Toggle Selection[%END%]" />
-<br /><br />
-  <input class="MainMenuLinks" type="submit" name="action_d_install_shared" value="[%|loc%]Install[%END%]" />
-  <input class="MainMenuLinks" type="submit" name="action_d_reject_shared.quiet" value="[%|loc%]Reject[%END%]" />
-  <input class="MainMenuLinks" type="submit" name="action_d_reject_shared" value="[%|loc%]Notified reject[%END%]" />
-</fieldset>
+    <input class="MainMenuLinks toggleButton" type="button"
+      value="[%|loc%]Toggle Selection[%END%]" />
+    <br /><br />
+    <input class="MainMenuLinks" type="submit" name="action_d_install_shared" value="[%|loc%]Install[%END%]" />
+    <input class="MainMenuLinks" type="submit" name="action_d_reject_shared.quiet" value="[%|loc%]Reject[%END%]" />
+    <input class="MainMenuLinks" type="submit" name="action_d_reject_shared" value="[%|loc%]Notified reject[%END%]" />
+  </fieldset>
 </form>
 [% ELSE %]
 <p class="small-8 small-centered columns alert-box info text-center">[%|loc%]No documents to moderate[%END%]</p>

--- a/default/web_tt2/dump_scenario.tt2
+++ b/default/web_tt2/dump_scenario.tt2
@@ -30,7 +30,7 @@
 <select id="new_scenario_scope" name="new_scenario_scope">
     <option value="robot">[%|loc(robot)%]robot %1[%END%]</option>
     <option value="list" selected>[%|loc(list)%]list %1[%END%]</option>
-</select>	
+</select>
 [% END %]
 -->
 <label for="new_scenario_name">[%|loc%]scenario name:[%END%]</label> <input id="new_scenario_name" type="text" name="new_scenario_name" size="30" value="[% scenario_name %]" />

--- a/default/web_tt2/edit_config.tt2
+++ b/default/web_tt2/edit_config.tt2
@@ -27,7 +27,7 @@
      <td [% IF confparam.query ~%]
        data-tooltip aria-haspopup="true" title="[% confparam.query %]"
      [%~ END %]>
-	<strong>[% confparam.name  %]</strong>
+       <strong>[% confparam.name  %]</strong>
      </td>
      <td>
 

--- a/default/web_tt2/edit_template.tt2
+++ b/default/web_tt2/edit_template.tt2
@@ -43,10 +43,10 @@
 <input type="hidden" name="template_path" value="[% template_path %]" />
 <input type="hidden" name="tpl_lang" value="[% tpl_lang %]" />
 [% IF list %]
-	<input type="hidden" name="list" value="[% list %]" /> 
+  <input type="hidden" name="list" value="[% list %]" /> 
 [% END %] 
 
-<input type="hidden" name="scope" value="[% scope %]" /> 	
+<input type="hidden" name="scope" value="[% scope %]" />
 <input type="submit" class="MainMenuLinks" name="action_edit_template" value="[%|loc%]save[%END%]" />
 
 [% IF saved %]

--- a/default/web_tt2/editfile.tt2
+++ b/default/web_tt2/editfile.tt2
@@ -16,7 +16,7 @@
   <br />
   <input class="MainMenuLinks" type="submit" name="action_savefile" value="[%|loc%]Save[%END%]" />
 </fieldset>
-</form>	
+</form>
 
 [% ELSE %]
 <form class="noborder" action="[% path_cgi %]" method="post">

--- a/default/web_tt2/error.tt2
+++ b/default/web_tt2/error.tt2
@@ -58,11 +58,11 @@
   [%|loc(auth.action)%]AUTHORIZATION REJECT (%1)[%END-%]   
   [% IF auth.change_email_failed %][%|loc(auth.listname)%]Could not change your subscription address for the list '%1' because your new address is not allowed to subscribe/unsubscribe:[%END%][% END %]
   [% SET reason = auth.msg -%] 
-  [% IF reason == 'edit_right' %][% SET role = auth.role -%][% SET right = auth.right -%][% END -%] 	 
+  [% IF reason == 'edit_right' %][% SET role = auth.role -%][% SET right = auth.right -%][% END -%]
   [% PROCESS report.tt2
      report_type='auth'
      report_entry=auth.msg
-  %]	
+  %]
   [%~ IF auth.login %]<br />[%|loc%]You need to login[%END%][% END %]
   <br />
 [% END %]

--- a/default/web_tt2/help.tt2
+++ b/default/web_tt2/help.tt2
@@ -10,12 +10,12 @@
 
 <h2><i class="fa fa-book"></i> [%|helploc%]Subscriber, moderator and owner documentation[%END%]</h2>
 
-	<p>[%|helploc%]In this documentation, you will find:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]a <a href="introduction">general introduction</a> to mailing lists;[%END%]</li>
-		<li>[%|helploc%]a <a href="user">user guide</a> about the use of Sympa;[%END%]</li>
-		<li>[%|helploc%]an <a href="admin">administrator guide</a> about the use of Sympa.[%END%]</li>
-	</ul>
+<p>[%|helploc%]In this documentation, you will find:[%END%]</p>
+<ul>
+    <li>[%|helploc%]a <a href="introduction">general introduction</a> to mailing lists;[%END%]</li>
+    <li>[%|helploc%]a <a href="user">user guide</a> about the use of Sympa;[%END%]</li>
+    <li>[%|helploc%]an <a href="admin">administrator guide</a> about the use of Sympa.[%END%]</li>
+</ul>
 
 <p>[%|helploc%]If you want to perform a particular task, take a look at the list of all <a href="introduction#features">available features</a> in the mailing list management software Sympa.[%END%]<br />
 [%|helploc%]If you experience any problem, please refer to the <a href="faquser">users <acronym title="Frequently asked questions">FAQ</acronym></a> or to the <a href="faqadmin">administrators <acronym title="Frequently asked questions">FAQ</acronym></a>.[%END%]</p>

--- a/default/web_tt2/help_admin.tt2
+++ b/default/web_tt2/help_admin.tt2
@@ -1,259 +1,259 @@
 <!-- help_admin.tt2 -->
 
-	<h2 class="block"><a name="docadmin"></a>[%|helploc%]Mailing lists - Owner and moderator guide[%END%]</h2>
+    <h2 class="block"><a name="docadmin"></a>[%|helploc%]Mailing lists - Owner and moderator guide[%END%]</h2>
 
-	<h3>[%|helploc%]Introduction: who is in charge of managing mailing lists?[%END%]</h3>
-	<p>[%|helploc%]Reminder: a mailing list service involves four types of roles:[%END%]</p>
-	<ul>
-		<li><strong>[%|helploc%]listmaster;[%END%]</strong></li>
-		<li><strong>[%|helploc%]owner;[%END%]</strong></li>
-		<li><strong>[%|helploc%]moderator;[%END%]</strong></li>
-		<li><strong>[%|helploc%]subscriber.[%END%]</strong></li>
-	</ul>
-	<p>[%|helploc%]Refer to the <a href="introduction#roles">description of each role</a> to know more about this.[%END%]</p>
-	
-	<h3><a name="create_list"></a>[%|helploc%]Requesting the creation of a mailing list[%END%]</h3>
-	<p>[%|helploc%]The <strong>list creation request</strong> can be <strong>subject to conditions</strong>. Even though you meet those conditions, the <strong>list creation</strong> will nevertheless be <strong>subject to approval by the listmasters</strong>.[%END%]</p>
-	<p>[%|helploc%]To request the creation of a mailing list, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]Go to the <strong><a href="../home">list environment homepage</a></strong> and <a href="user#sympa_auth"><strong>log on</strong></a>.[%END%]</li>
-		<li>[%|helploc%]In the top menu, <strong>click on the 'Create list' link</strong>.[%END%]<br/>
-	        <span class="retraitita">[%|helploc%]If this link does not display, it means that you do not have the privileges required to create a list.[%END%]</span></li>
-		<li>[%|helploc('',domain)%]Give your list a <strong>name</strong> (only enter the name without the '@' and the domain name; example: <em class="example">languages_spanish</em> and not <em class="example">languages_spanish@%2</em>).[%END%]<br />
-		<span class="retraitita">[%|helploc%]Do not use any spaces, accents or specials characters in list names: those characters might cause problems.[%END%]</span>
-		<span class="retraitita">[%|helploc('',domain)%]Choose an explicit yet short name: think of the subscribers who will have to type this name every time they will send a message to the list! If you manage a set of lists, you can prefix your lists' names with a common prefix; thus they will be sorted together and will be easily recognizable (example: <em class="example">xx-users@%2, xx-hotline@%2</em>, etc.).[%END%]</span></li>
-		<li>[%|helploc%]Choose a <strong>list type</strong> among the predefined types (the predefined types are only examples of typical configurations that can be changed by the list owners after creation; it is even possible to configure the list beyond the options offered in the list administration module, by asking the listmasters).[%END%]</li>
-		<li>[%|helploc%]Enter a <strong>subject</strong> for your list. This subject will display as a header for all the list pages, and will also be visible on list index pages (list of lists, list of your subscriptions, etc.) and in the browser title bar.[%END%]<br />
+    <h3>[%|helploc%]Introduction: who is in charge of managing mailing lists?[%END%]</h3>
+    <p>[%|helploc%]Reminder: a mailing list service involves four types of roles:[%END%]</p>
+    <ul>
+        <li><strong>[%|helploc%]listmaster;[%END%]</strong></li>
+        <li><strong>[%|helploc%]owner;[%END%]</strong></li>
+        <li><strong>[%|helploc%]moderator;[%END%]</strong></li>
+        <li><strong>[%|helploc%]subscriber.[%END%]</strong></li>
+    </ul>
+    <p>[%|helploc%]Refer to the <a href="introduction#roles">description of each role</a> to know more about this.[%END%]</p>
 
-		<li>[%|helploc%]Choose a <strong>topic</strong> in the 'Topics' drop-menu.[%END%]<br />
-		<p class="retraitita">[%|helploc%]If no topic suits your needs, you can request the creation of a new topic by asking the listmasters.[%END%]</p></li>
-		<li>[%|helploc%]Enter a <strong>description</strong> for your list. This description will display on the list information page and in the 'Subscribers Charter' sent by email to each new subscriber, under the 'List subject' heading. This description may involve explanations about the following issues:[%END%]
-		<ul>
-			<li>[%|helploc%]object of the list and targets;[%END%]</li>
-			<li>[%|helploc%]topics discussed;[%END%]</li>
-			<li>[%|helploc%]operation of the list (liabilities, status of the list, etc.);[%END%]</li>
-			<li>[%|helploc%]rules applying;[%END%]</li>
-			<li>[%|helploc%]description of the typical subscribers (their occupations, the projects they manage, their nationalities, etc.).[%END%]</li>
-		</ul>
-		<p class="retraitita">[%|helploc%]You can format your list description with <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym> tags. Be careful: if your description is long, cut it with manual line breaks (ENTER key of your keyboard); otherwise, it might not be entirely visible in your browser window.[%END%]</p>
+    <h3><a name="create_list"></a>[%|helploc%]Requesting the creation of a mailing list[%END%]</h3>
+    <p>[%|helploc%]The <strong>list creation request</strong> can be <strong>subject to conditions</strong>. Even though you meet those conditions, the <strong>list creation</strong> will nevertheless be <strong>subject to approval by the listmasters</strong>.[%END%]</p>
+    <p>[%|helploc%]To request the creation of a mailing list, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]Go to the <strong><a href="../home">list environment homepage</a></strong> and <a href="user#sympa_auth"><strong>log on</strong></a>.[%END%]</li>
+        <li>[%|helploc%]In the top menu, <strong>click on the 'Create list' link</strong>.[%END%]<br/>
+            <span class="retraitita">[%|helploc%]If this link does not display, it means that you do not have the privileges required to create a list.[%END%]</span></li>
+        <li>[%|helploc('',domain)%]Give your list a <strong>name</strong> (only enter the name without the '@' and the domain name; example: <em class="example">languages_spanish</em> and not <em class="example">languages_spanish@%2</em>).[%END%]<br />
+        <span class="retraitita">[%|helploc%]Do not use any spaces, accents or specials characters in list names: those characters might cause problems.[%END%]</span>
+        <span class="retraitita">[%|helploc('',domain)%]Choose an explicit yet short name: think of the subscribers who will have to type this name every time they will send a message to the list! If you manage a set of lists, you can prefix your lists' names with a common prefix; thus they will be sorted together and will be easily recognizable (example: <em class="example">xx-users@%2, xx-hotline@%2</em>, etc.).[%END%]</span></li>
+        <li>[%|helploc%]Choose a <strong>list type</strong> among the predefined types (the predefined types are only examples of typical configurations that can be changed by the list owners after creation; it is even possible to configure the list beyond the options offered in the list administration module, by asking the listmasters).[%END%]</li>
+        <li>[%|helploc%]Enter a <strong>subject</strong> for your list. This subject will display as a header for all the list pages, and will also be visible on list index pages (list of lists, list of your subscriptions, etc.) and in the browser title bar.[%END%]<br />
 
-		<li>[%|helploc%]Click on the '<strong>Submit your creation request</strong>' button.[%END%]</li>
-	</ol>
+        <li>[%|helploc%]Choose a <strong>topic</strong> in the 'Topics' drop-menu.[%END%]<br />
+        <p class="retraitita">[%|helploc%]If no topic suits your needs, you can request the creation of a new topic by asking the listmasters.[%END%]</p></li>
+        <li>[%|helploc%]Enter a <strong>description</strong> for your list. This description will display on the list information page and in the 'Subscribers Charter' sent by email to each new subscriber, under the 'List subject' heading. This description may involve explanations about the following issues:[%END%]
+        <ul>
+            <li>[%|helploc%]object of the list and targets;[%END%]</li>
+            <li>[%|helploc%]topics discussed;[%END%]</li>
+            <li>[%|helploc%]operation of the list (liabilities, status of the list, etc.);[%END%]</li>
+            <li>[%|helploc%]rules applying;[%END%]</li>
+            <li>[%|helploc%]description of the typical subscribers (their occupations, the projects they manage, their nationalities, etc.).[%END%]</li>
+        </ul>
+        <p class="retraitita">[%|helploc%]You can format your list description with <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym> tags. Be careful: if your description is long, cut it with manual line breaks (ENTER key of your keyboard); otherwise, it might not be entirely visible in your browser window.[%END%]</p>
 
-	<p>[%|helploc%]A message displays to inform you that your list creation request has been sent to the listmasters and that from now on, you can modify the list by clicking on the 'Admin' button. However, the message warns you that the list will be actually installed and made visible on the server only after approval by a listmaster.[%END%]</p>
-	<p>[%|helploc%]After this, you will have to <strong>wait for the list creation to be approved of by one of the listmasters</strong>. Then you will receive a notice message entitled '<strong>Creation of the nameofthelist list</strong>', informing you that your list was actually created.[%END%]</p>
-	<p>[%|helploc%]<strong>Last, subscribe to your list</strong>: creating a list or becoming its owner or moderator does not mean that you are automatically subscribed to it![%END%]</p>
+        <li>[%|helploc%]Click on the '<strong>Submit your creation request</strong>' button.[%END%]</li>
+    </ol>
 
-	<h3>[%|helploc%]Managing a list[%END%]</h3>
+    <p>[%|helploc%]A message displays to inform you that your list creation request has been sent to the listmasters and that from now on, you can modify the list by clicking on the 'Admin' button. However, the message warns you that the list will be actually installed and made visible on the server only after approval by a listmaster.[%END%]</p>
+    <p>[%|helploc%]After this, you will have to <strong>wait for the list creation to be approved of by one of the listmasters</strong>. Then you will receive a notice message entitled '<strong>Creation of the nameofthelist list</strong>', informing you that your list was actually created.[%END%]</p>
+    <p>[%|helploc%]<strong>Last, subscribe to your list</strong>: creating a list or becoming its owner or moderator does not mean that you are automatically subscribed to it![%END%]</p>
 
-	<p>[%|helploc%]To manage a list you own, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]Go to the <strong>list environment homepage</strong> and <strong><a href="user#sympa_auth">log on</a></strong>.[%END%]<br />
-		<p class="retraitita">[%|helploc%]If you are subscribed to the list with several addresses, use the address with which you requested the list creation.[%END%]</p></li>
-		<li>[%|helploc%]<strong>Go to the information page of the list</strong> you want to manage.[%END%]</li>
-		<li>[%|helploc%]In the left menu, <strong>click on the 'Admin' link</strong>.[%END%]</li>
-	</ol>
+    <h3>[%|helploc%]Managing a list[%END%]</h3>
 
-	<p>[%|helploc%]To browse the sections of the administration module, click on the links below the 'Admin' link, in the left menu.[%END%]</p>
-	<p>[%|helploc%]Those different sections allow you to:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<a href="listconfig">configure the list</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#customize">customize files related to the list</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#manage_members">manage subscribers</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#manage_archives">manage the message archive of the list</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#manage_bounces">manage bounces</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#manage_shared">create, delete or restore the shared document web space</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#renamelist">rename the list</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#supprlist">delete the list</a>.[%END%]</li>
-	</ul>
+    <p>[%|helploc%]To manage a list you own, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]Go to the <strong>list environment homepage</strong> and <strong><a href="user#sympa_auth">log on</a></strong>.[%END%]<br />
+        <p class="retraitita">[%|helploc%]If you are subscribed to the list with several addresses, use the address with which you requested the list creation.[%END%]</p></li>
+        <li>[%|helploc%]<strong>Go to the information page of the list</strong> you want to manage.[%END%]</li>
+        <li>[%|helploc%]In the left menu, <strong>click on the 'Admin' link</strong>.[%END%]</li>
+    </ol>
 
-	<p>[%|helploc%]The options available in the 'Moderate' submenu allow you to:[%END%]
-	<ul>
-		<li>[%|helploc%]<a href="#moderate">moderate messages</a> sent to the list;[%END%]</li>
-		<li>[%|helploc%]<a href="shared">moderate documents</a> available in the shared document web space;[%END%]</li>
-		<li>[%|helploc%]<a href="#manage_members">moderate pending subscriptions</a>.[%END%]</li>
-	</ul>
+    <p>[%|helploc%]To browse the sections of the administration module, click on the links below the 'Admin' link, in the left menu.[%END%]</p>
+    <p>[%|helploc%]Those different sections allow you to:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<a href="listconfig">configure the list</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#customize">customize files related to the list</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#manage_members">manage subscribers</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#manage_archives">manage the message archive of the list</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#manage_bounces">manage bounces</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#manage_shared">create, delete or restore the shared document web space</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#renamelist">rename the list</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#supprlist">delete the list</a>.[%END%]</li>
+    </ul>
 
-	<h4><a name="edit_list"></a>[%|helploc%]Configuring the list[%END%]</h4>
-	<p>[%|helploc%]To learn how to configure the list, please refer to the <a href="listconfig"><strong>documentation about list configuration</strong></a>.[%END%]</p>
+    <p>[%|helploc%]The options available in the 'Moderate' submenu allow you to:[%END%]
+    <ul>
+        <li>[%|helploc%]<a href="#moderate">moderate messages</a> sent to the list;[%END%]</li>
+        <li>[%|helploc%]<a href="shared">moderate documents</a> available in the shared document web space;[%END%]</li>
+        <li>[%|helploc%]<a href="#manage_members">moderate pending subscriptions</a>.[%END%]</li>
+    </ul>
 
-	<h4><a name="customize"></a>[%|helploc%]Customizing the list[%END%]</h4>
-	<p>[%|helploc%]From this page, you can <strong>edit a number of files relating to your list</strong>, among which:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]typical messages sent to subscribers in particular occasions:[%END%]
-		<ul>
-			<li>[%|helploc%]<strong>welcome message</strong>: this message is the notice sent to people who just subscribed. You should write a charter for your list and add it in this welcome message. You can create a structured <acronym lang="en" xml:lang="en" title="Multipurpose Internet Mail Extensions">MIME</acronym> message (reserved to the <acronym lang="en" xml:lang="en" title="Multipurpose Internet Mail Extensions">MIME</acronym> format experts);[%END%]</li>
-			<li>[%|helploc%]<strong>unsubscribe message</strong>: this message is sent to people unsubscribing from the list;[%END%]</li>
-			<li>[%|helploc%]<strong>deletion message</strong>: this message is sent to people you unsubscribe from the list (DEL command), especially because their address caused bounces;[%END%]</li>
-			<li>[%|helploc%]<strong>remind message</strong>: this message is sent to subscribers as a personalized reminder when using the REMIND command. This command is essential to the good management of your list since many bounces are due to people whose current address is not their subscription address anymore, or even who forgot that they were subscribed to the list;[%END%]</li>
-			<li>[%|helploc%]<strong>subscribing invitation message</strong>: this message is sent to people you invite to subscribe to the list using the INVITE command;[%END%]</li>
-			<li>[%|helploc%]<strong>notice of message rejected by the moderator</strong>: this message is sent to the sender of a message rejected by the moderator;[%END%]</li>
-			<li>[%|helploc%]<strong>notice of message rejected because of a virus</strong>: this message is sent to the sender of a message in which a virus was found.[%END%]</li>
-		</ul></li>
+    <h4><a name="edit_list"></a>[%|helploc%]Configuring the list[%END%]</h4>
+    <p>[%|helploc%]To learn how to configure the list, please refer to the <a href="listconfig"><strong>documentation about list configuration</strong></a>.[%END%]</p>
 
-		<li>[%|helploc%]miscellaneous files:[%END%]
-		<ul>
-			<li>[%|helploc%]<strong>list description</strong>: the list description is sent by email in return to the INFO command. By default, it is also included in the welcome message (subscription notice). It is not the same as the list presentation page displayed on the mailing list web interface;[%END%]</li>
-			<li>[%|helploc%]<strong>list homepage</strong>: this description is available on the information page of the list. It can be in <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym> format. Even though you do not use this format, use <code>&lt;br /&gt;</code> tags to indicate line breaks;[%END%]</li>
-			<li>[%|helploc%]<strong>message header</strong>: when available, it is added as a <acronym lang="en" xml:lang="en" title="Multipurpose Internet Mail Extensions">MIME</acronym> attachment at the beginning of each message distributed to the list;[%END%]</li>
-			<li>[%|helploc%]<strong>message footer</strong>: when available, it is added as a <acronym lang="en" xml:lang="en" title="Multipurpose Internet Mail Extensions">MIME</acronym> attachment at the end of each message distributed to the list.[%END%]</li>
-		</ul>
-		</li>
-	</ul>
-	<p>[%|helploc%]By default, Sympa uses default files; in this case, the specific files corresponding to your list are empty. <strong>To edit a file, choose it from the drop-down list and click on the 'Edit' button</strong>. You will have the possibility to change the <strong>'From' field</strong> (sender), the <strong>'Subject' field</strong> (subject line) and the <strong>message body</strong>.[%END%]</p>
-		<p class="retraitita">[%|helploc%]Be careful: the values between square brackets are variables. Do not change them, unless you really know what you are doing...[%END%]</p>
-	
+    <h4><a name="customize"></a>[%|helploc%]Customizing the list[%END%]</h4>
+    <p>[%|helploc%]From this page, you can <strong>edit a number of files relating to your list</strong>, among which:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]typical messages sent to subscribers in particular occasions:[%END%]
+        <ul>
+            <li>[%|helploc%]<strong>welcome message</strong>: this message is the notice sent to people who just subscribed. You should write a charter for your list and add it in this welcome message. You can create a structured <acronym lang="en" xml:lang="en" title="Multipurpose Internet Mail Extensions">MIME</acronym> message (reserved to the <acronym lang="en" xml:lang="en" title="Multipurpose Internet Mail Extensions">MIME</acronym> format experts);[%END%]</li>
+            <li>[%|helploc%]<strong>unsubscribe message</strong>: this message is sent to people unsubscribing from the list;[%END%]</li>
+            <li>[%|helploc%]<strong>deletion message</strong>: this message is sent to people you unsubscribe from the list (DEL command), especially because their address caused bounces;[%END%]</li>
+            <li>[%|helploc%]<strong>remind message</strong>: this message is sent to subscribers as a personalized reminder when using the REMIND command. This command is essential to the good management of your list since many bounces are due to people whose current address is not their subscription address anymore, or even who forgot that they were subscribed to the list;[%END%]</li>
+            <li>[%|helploc%]<strong>subscribing invitation message</strong>: this message is sent to people you invite to subscribe to the list using the INVITE command;[%END%]</li>
+            <li>[%|helploc%]<strong>notice of message rejected by the moderator</strong>: this message is sent to the sender of a message rejected by the moderator;[%END%]</li>
+            <li>[%|helploc%]<strong>notice of message rejected because of a virus</strong>: this message is sent to the sender of a message in which a virus was found.[%END%]</li>
+        </ul></li>
 
-	<h4><a name="manage_shared"></a>[%|helploc%]Managing the shared document web space[%END%]</h4>
-	<p>[%|helploc%]By default, lists have no shared document web space. Thus, you need to create it. To do that, go to the <strong>list administration module</strong> and click on the '<strong>Create shared</strong>' link.[%END%]</p>
-
-	<p>[%|helploc%]To allow subscribers to publish documents in the shared document web space, you need to <strong>change default rights</strong>: in the list administration module, click on '<strong>Edit list config</strong>' and then on '<strong>Privileges</strong>'. At the bottom of the page, there is a drop-down list entitled '<a href="listconfig#docsrights"><strong>Who can edit</strong></a>'; choose the '<strong>Restricted to subscribers (private)</strong>' option.[%END%]</p>
-	<p class="retraitita">[%|helploc%]Be careful: if you created folders before changing those rights, the folders will still be unwritable. If you want to make them writable, you will have to <a href="shared#acces">change access rights</a> for each folder.[%END%]</p>
-	<p>[%|helploc%]You might also want to <a href="listconfig#docsrights">set up <strong>quotas</strong></a> for the shared document web space on the 'Privileges' page of the 'Edit list config' section.[%END%]</p>
-	
-	<p>[%|helploc%]To <strong>know everything about the management of the shared document web space</strong> (how to organize it, change access rights, name documents, etc.), refer to the '<a href="shared">Using the shared document web space</a>' section of the User guide.[%END%]</p>
-	<p>[%|helploc%]To <strong>deny access to the shared document web space</strong>, click on '<strong>Delete shared</strong>' in the 'Admin' submenu. Then you will still have the possibility to <strong>reopen it</strong> by clicking on '<strong>Restore shared</strong>'. Deleting and restoring the shared document web space has <strong>no impact on the documents it contains</strong>.[%END%]</p>
-
-	<h4><a name="manage_members"></a>[%|helploc%]Managing subscribers[%END%]</h4>
-
-	<p>[%|helploc%]This section lets you browse the <strong>list of all the list subscribers</strong>. For each subscriber, the following information is available:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>email address</strong>;[%END%]</li>
-		<li>[%|helploc%]<strong>domain</strong> of the email address (<em class="example">@cru.fr</em>, <em class="example">@sympa.org</em>, <em class="example">@fai.com</em>, etc.);[%END%]</li>
-		<li>[%|helploc%]<strong>picture</strong> (if that feature was activated for the list);[%END%]</li>
-		<li>[%|helploc%]<strong>name</strong> (according to the subscription method, it is not always displayed);[%END%]</li>
-		<li>[%|helploc%]<a href="#deliverymode"><strong>message delivery mode</strong></a>;[%END%]</li>
-		<li>[%|helploc%]<strong>data source</strong> indicating the origin in case the subscriber is included in the list and not directly subscribed;[%END%]</li>
-		<li>[%|helploc%]<strong>date of subscription</strong> to the list;[%END%]</li>
-		<li>[%|helploc%]<strong>latest update</strong> of the subscriber options.[%END%]</li>
-	</ul>
-
-	<p class="retraitita">[%|helploc%]By default, each page displays 25 subscribers. You can browse through the pages by using the browsing arrows or display more subscribers on each page. You may also wish to sort subscribers according to different criteria by clicking on the corresponding column header.[%END%]</p>
-	<p>[%|helploc%]To <strong>search a subscriber</strong>, enter all or part of his/her email address or name in the input field and click on the '<strong>Search</strong>' button.[%END%]</p>
-	<p>[%|helploc%]You can <strong>subscribe other people to the list</strong> from this page:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]To add <strong>a single person</strong>, enter his/her email address in the input field and click on the '<strong>Add</strong>' button.[%END%]</li>
-		<li>[%|helploc%]To add <strong>several persons</strong>, click on the '<strong>Multiple add</strong>' button. In the input field that displays, enter the email addresses and names of the people you want to subscribe to the list and click on '<strong>Add subscribers</strong>'.[%END%]</li>
-	</ul>
-	
-
-	<p class="retraitita">[%|helploc%]If you want to subscribe people without letting them know through a notice, tick the 'Quiet' box. However, it is far better to warn people that you subscribe them![%END%]</p>
-	<p>[%|helploc(conf.email,domain)%]Even though you have the possibility to subscribe people to your mailing lists, it is always <strong>much better that people take the necessary steps to subscribe themselves</strong> to the list. You can also <strong>invite people to subscribe to the list</strong> through the INVITE command: send an email to %1@%2 and type the following command in the message body: <strong>invite nameofthelist emailaddress</strong> (example: <em class="example">invite list_example john.doe(@)fai.com</em>).[%END%]</p>
-	<p>[%|helploc%]To <strong>accept or reject the subscription requests to the list</strong>, click on '<strong>Pending subscriptions</strong>'. The list of all people who requested subscription to the list displays. To accept or reject a request, tick the box in front of a person's name and click on the button of your choice.[%END%]</p>
-	<p>[%|helploc%]To <strong>send a subscription reminder to all subscribers</strong>, click on the '<strong>Remind all</strong>' button. The subscription reminder message contains:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]the <strong>name of the list</strong> to which the subscriber is subscribed;[%END%]</li>
-		<li>[%|helploc%]the <strong>email address</strong> with which the subscriber is subscribed;[%END%]</li>
-		<li>[%|helploc%]the subscriber's <strong>list password</strong>;[%END%]</li>
-		<li>[%|helploc%]a <strong>link to the information page</strong> of the list;[%END%]</li>
-		<li>[%|helploc%]a <strong>clickable address in order to allow subscribers to unsubscribe</strong> from the list.[%END%]</li>
-	</ul>
-	<p class="retraitita">[%|helploc%]You can also configure an automatic subscription reminder through the '<a href="listconfig#other">Miscellaneous</a>' page of the 'Edit list config' section.[%END%]</p>
-	
-
-	<p>[%|helploc%]To <strong>unsubscribe subscribers</strong> from this page, select them by ticking the boxes in front of their names and click on the '<strong>Delete selected email addresses</strong>' button.[%END%]</p>
-	<p class="retraitita">[%|helploc%]If you do not want to notify the subscribers, tick the 'Quiet' box. However, this is not advisable, except in the case of bouncing subscribers.[%END%]</p>
-	
-	<p class="retraitita">[%|helploc%]Tip: to select all subscribers at once, first make sure that they are all displayed on the page, and then click on the 'Toggle selection' button: all subscribers will be selected in a single click![%END%]</p>
-
-	<p>[%|helploc%]To <strong>change a subscriber's subscriber options</strong>, click on his/her email address.[%END%]</p>
-	<p>[%|helploc%]From this page, you can <strong>change the name, email address and message delivery mode of the subscriber</strong>. You can also <strong>unsubscribe him/her</strong>.[%END%]</p>
-	
-	<p>[%|helploc%]If the subscriber is <a href="#manage_bounces">bouncing</a>, another form displays under the 'Subscriber information' form:[%END%]</p>
-	<p>[%|helploc%]The information displayed involves:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]the type of error (in English);[%END%]</li>
-		<li>[%|helploc%]the number or errors;[%END%]</li>
-		<li>[%|helploc%]the period during which errors occurred.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]You can <strong>check the latest error</strong> or <strong>reset errors</strong>. If you reset errors, the subscriber's <a href="listconfig#bouncers">score</a> will be reset to zero.[%END%]</p>
-	
-	<p>[%|helploc%]To manage bouncing addresses more easily, go to the '<a href="#manage_bounces">Bounces</a>' page of the list administration module.[%END%]</p>
-	
-
-	<h4><a name="manage_bounces"></a>[%|helploc%]Managing bounces[%END%]</h4>
-	<p>[%|helploc%]When there is a <strong>problem with subscribers' email addresses</strong> (obsolete email addresses, addresses temporarily unavailable when messages were sent, inbox quota exceeded, etc.), the percentage of bouncing addresses displays in the left menu under the text '<strong>Error rate</strong>'. To check the bouncing addresses, go to the '<strong>Bounces</strong>' page of the list administration module.[%END%]</p>
-	<p>[%|helploc%]The Sympa software automatically manages bouncing subscribers: according to the number of errors and to the traffic on the list, bouncing subscribers are either notified, unsubscribed, or their score is reset to zero when their address stops bouncing.[%END%]</p>
-	<p>[%|helploc%]To <strong>make addresses stop being reported as bouncing</strong>, select them by ticking their boxes and click on the '<strong>Reset errors for selected users</strong>' button. If the error remains, the addresses will be reported as bouncing again as soon as a message is posted on the list.[%END%]</p>
-	<p>[%|helploc%]You can also <strong>unsubscribe subscribers whose addresses are still bouncing</strong>: too many bouncing addresses cause a considerable load on the mailing list server. To unsubscribe subscribers, select them by ticking the boxes in front of their names and click on the '<strong>Delete selected email addresses</strong>' button.[%END%]</p>	
-	<p class="retraitita">[%|helploc%]Tip: to select all subscribers at once, first make sure that they are all displayed on the page, and then click on the 'Toggle selection' button: all subscribers will be selected in a single click![%END%]</p>
-
-	<h4><a name="moderate"></a>[%|helploc%]Moderating messages sent to the list[%END%]</h4>
-	<p>[%|helploc%]When a list is moderated, <strong>all messages have to be approved of by one of the moderators before being distributed to the list</strong>. After sending a message to a list, subscribers are automatically notified by email that their message will be moderated. As for moderators, they also receive a notice message from Sympa, which includes the message to moderate.[%END%]</p>
-
-	<p>[%|helploc%]You can <strong>perform moderating tasks</strong> either <strong>by email</strong>, by answering the messages received from Sympa, or <strong>through the mailing list web interface</strong>. To do that, click on the '<strong>Message</strong>' link in the 'Moderate' submenu: you are brought to a page that displays all messages to be moderated (the most recent messages are on top of page). <strong>To read a message, click on its subject</strong>.[%END%]</p>
-
-	<p>[%|helploc%]You have <strong>two options</strong>:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>authorize the message distribution</strong> on the list;[%END%]</li>
-		<li>[%|helploc%]<strong>reject the message and notify sender</strong>: when you reject a message, it is better to notify its sender...[%END%]<br />
-	</ul>
-	<p>[%|helploc%]All moderators can decide to distribute a message or not. However, <strong>the first moderator to process the message will carry the day</strong>. You will be notified by Sympa if you try to process a message that has already been moderated. When there are several moderators, it is <strong>easier to moderate messages from the mailing list web interface</strong>: thus, you will be able to view all messages remaining to be moderated.[%END%]</p>
-	<p class="retraitita">[%|helploc%]<strong>Whatever the date and time of moderation, the date and time of sending of the message do not change</strong>. Thus, if the distribution of the message is allowed with a lot of delay, it is possible to receive a message dated January 1st on December 31st![%END%]</p>
-	<p>[%|helploc%]In case the message was rejected with a notice, the subscriber who had sent it is notified by email. You can <a href="#customize">customize the message he/she gets</a>.[%END%]</p>
-
-	<p>[%|helploc%]Checking the '<strong>Reject without notification</strong>' checkbox allows you to prevent the message author from receiving a notification.[%END%]</p>
-
-	<p>[%|helploc%]Checking the '<strong>Add to blacklist</strong>' checkbox both skip the rejection notification and adds the message author to the list own blacklist. You can manage the blacklist via the '<strong>edit blacklist</strong>' button at the bottom of the page.[%END%]</p>
-
-	<p>[%|helploc%]If you wish to customize the rejection message that is sent to a message author, you can do so via the '<strong>Manage rejection messages</strong>' button. The message management page will let define a set of rejection messages and define the default one.[%END%]</p>
-
-	<p>[%|helploc%]<strong>Reminder</strong>: you can <a href="listconfig#description">add or remove moderators</a> through the list administration module. To do that, from the list information page, click on '<strong>Admin</strong>', on '<strong>Edit list config</strong>', and then on '<strong>List definition</strong>'.[%END%]</p>
-	<p>[%|helploc%]It is also possible to <strong>process messages after their distribution on the list</strong>; this can be useful when a list is not moderated. If you want to <strong>delete a message</strong>, <a href="arc#arcsearch">search for it in the online message archive</a> and click on the '<strong>Tag this mail for deletion</strong>' button in the upper right corner of the message. A confirmation message displays; click on 'OK'. The message will be deleted after a few seconds. <strong>Be careful: this operation is irreversible!!! If you delete a message, you will not be able to retrieve it.</strong>[%END%]</p>
-	
-
-	<h4><a name="manage_archives"></a>[%|helploc%]Managing the message archive[%END%]</h4>
-	<p>[%|helploc%]The mailing list management robot Sympa can generate <strong>downloadable compressed archives (.ZIP format) of the messages sent to the list</strong>. To download those archives, <strong>select the months</strong> that interest you in the list and click on the '<strong>Download .zip archive</strong>' button.[%END%]</p>
-	<p class="retraitita">[%|helploc%]Tip: in the 'Archive selection' list, to select all months during which messages have been sent, click on the first month, hold down the SHIFT key and click on the last month of the list.[%END%]</p>
-	<p>[%|helploc%]You will receive a file of the type '<strong>nameofthelist_archive.zip</strong>' containing <strong>folders named 'nameofthelist_year-month'</strong> (example: <em class="example">list_example_2005-06</em>) for each month. Inside each folder, <strong>the file names are numbers</strong> representing their position in the chronology of the messages sent (example: the file named '1' contains the first message sent in the month). The message files have <strong>no extension</strong>; use the text editor of your choice (Notepad, WordPad, Vim, etc.) to open them. <strong>Each file represents an entire message (full header)</strong>.[%END%]</p>
-	<p>[%|helploc%]From the 'Manage archives' page, you can also <strong>delete messages</strong> (deletion month by month and not message by message). To do that, <strong>select the months</strong> that interest you in the list and click on the '<strong>Delete Selected Month(s)</strong>' button.[%END%]</p>
-	<p class="retraitita">[%|helploc%]<strong>Be careful: this operation is irreversible!!! When you click on 'Delete selected months', keep in mind that you are not only deleting an archive file, but also the entire message archive of the selected month!!!</strong>[%END%]</p>
-	
-
-	<h4><a name="renamelist"></a>[%|helploc%]Renaming the list[%END%]</h4>
-	<p>[%|helploc%]In the <strong>list administration module</strong>, click on '<strong>Rename list</strong>'. Enter the name of your choice and click on the 'Rename this list' button. A confirmation message displays; click on 'OK'.[%END%]</p>
-	<p class="retraitita">[%|helploc%]If you change your mind, you will only have to redo the inverse operation in order to retrieve the former list name.[%END%]</p>
-	<p>[%|helploc%]<strong>Be careful: when you rename a list, you have to let the listmasters know; otherwise, the change will not be effective</strong>.[%END%]</p>
-	<p>[%|helploc%]A few tips to name your lists:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>Do not use any spaces, accents or specials characters</strong> in list names: those characters might cause problems.[%END%]</li>
-		<li>[%|helploc%]Choose an <strong>explicit yet short name</strong>: think of the subscribers who will have to type this name every time they will send a message to the list![%END%]</li>
-		<li>[%|helploc(domain)%]If you manage a set of lists, you can <strong>prefix your lists' names with a common prefix</strong>; thus they will be sorted together and will be easily recognizable (example: <em class="example">xx-users@%1, xx-hotline@%1.fr</em>, etc.).[%END%]</li>
-	</ul>
+        <li>[%|helploc%]miscellaneous files:[%END%]
+        <ul>
+            <li>[%|helploc%]<strong>list description</strong>: the list description is sent by email in return to the INFO command. By default, it is also included in the welcome message (subscription notice). It is not the same as the list presentation page displayed on the mailing list web interface;[%END%]</li>
+            <li>[%|helploc%]<strong>list homepage</strong>: this description is available on the information page of the list. It can be in <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym> format. Even though you do not use this format, use <code>&lt;br /&gt;</code> tags to indicate line breaks;[%END%]</li>
+            <li>[%|helploc%]<strong>message header</strong>: when available, it is added as a <acronym lang="en" xml:lang="en" title="Multipurpose Internet Mail Extensions">MIME</acronym> attachment at the beginning of each message distributed to the list;[%END%]</li>
+            <li>[%|helploc%]<strong>message footer</strong>: when available, it is added as a <acronym lang="en" xml:lang="en" title="Multipurpose Internet Mail Extensions">MIME</acronym> attachment at the end of each message distributed to the list.[%END%]</li>
+        </ul>
+        </li>
+    </ul>
+    <p>[%|helploc%]By default, Sympa uses default files; in this case, the specific files corresponding to your list are empty. <strong>To edit a file, choose it from the drop-down list and click on the 'Edit' button</strong>. You will have the possibility to change the <strong>'From' field</strong> (sender), the <strong>'Subject' field</strong> (subject line) and the <strong>message body</strong>.[%END%]</p>
+        <p class="retraitita">[%|helploc%]Be careful: the values between square brackets are variables. Do not change them, unless you really know what you are doing...[%END%]</p>
 
 
-	<h4><a name="supprlist"></a>[%|helploc%]Deleting the list[%END%]</h4>
-	<p>[%|helploc%]In the <strong>list administration module</strong>, click on '<strong>Remove list</strong>'. A confirmation message displays; click on 'OK'.[%END%]</p>
-	<p class="retraitita">[%|helploc%]<strong>Be careful: if you delete the list, you will not be able to reopen it yourself!!! If you want to reopen the list, you will have to ask the listmasters.</strong>[%END%]</p>
+    <h4><a name="manage_shared"></a>[%|helploc%]Managing the shared document web space[%END%]</h4>
+    <p>[%|helploc%]By default, lists have no shared document web space. Thus, you need to create it. To do that, go to the <strong>list administration module</strong> and click on the '<strong>Create shared</strong>' link.[%END%]</p>
 
-	<p>[%|helploc%]In real terms, what are the <strong>consequences</strong> of a list deletion?[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>All subscribers are immediately unsubscribed</strong> automatically (including owners and moderators).[%END%]</li>
-		<li>[%|helploc%]<strong>The message archive is preserved</strong> but no one can access it anymore.[%END%]</li>
-		<li>[%|helploc%]<strong>The documents published in the shared document web space are preserved</strong> but no one can access them anymore.[%END%]</li>
-		<li>[%|helploc%]<strong>Only the listmasters have the power to reopen the list</strong>; if they do, the former list subscribers will automatically be subscribed again.[%END%]</li>
-	</ul>
-	<p class="retraitita">[%|helploc%]Be careful: due to a slight latency, the list pages remain accessible for a while if you know their addresses. Then they will become fully unavailable.[%END%]</p>
-	
-	<p>[%|helploc%]<strong>If you want the list and all the associated files to be deleted permanently</strong>, you will have to ask the listmasters.[%END%]</p>
+    <p>[%|helploc%]To allow subscribers to publish documents in the shared document web space, you need to <strong>change default rights</strong>: in the list administration module, click on '<strong>Edit list config</strong>' and then on '<strong>Privileges</strong>'. At the bottom of the page, there is a drop-down list entitled '<a href="listconfig#docsrights"><strong>Who can edit</strong></a>'; choose the '<strong>Restricted to subscribers (private)</strong>' option.[%END%]</p>
+    <p class="retraitita">[%|helploc%]Be careful: if you created folders before changing those rights, the folders will still be unwritable. If you want to make them writable, you will have to <a href="shared#acces">change access rights</a> for each folder.[%END%]</p>
+    <p>[%|helploc%]You might also want to <a href="listconfig#docsrights">set up <strong>quotas</strong></a> for the shared document web space on the 'Privileges' page of the 'Edit list config' section.[%END%]</p>
 
-	<h3><a name="rulesadmin"></a>[%|helploc%]Good practices[%END%]</h3>
-	<p>[%|helploc%]In order to have dynamic lists, <strong>you must be deeply involved</strong> in their exchanges: if a list is neither controlled nor enlivened by its owners, it may result in a loss of quality in its messages and it might even end up vanishing...[%END%]</p>
-	<p>[%|helploc%]<strong>The use of email in general and for mailing lists is bound by a set of precise rules necessary to share pleasant exchanges: the "Netiquette"</strong>. As a list owner or moderator, it is your role to have subscribers respect it. You will find the general principles of the Netiquette, as well as many links on the <a target="_blank" href="http://en.wikipedia.org/wiki/Netiquette">page of the Wikipedia dedicated to the Netiquette</a>.[%END%]</p>
-		<p><a name="charter"></a>[%|helploc%]You should <strong>write a charter for your list</strong> to define all the rules that apply to its use:[%END%]</p>
-		<ul>
-			<li>[%|helploc%]allowed, tolerated and forbidden topics;[%END%]</li>
-			<li>[%|helploc%]writing rules (for example to specify the languages in which the subscribers are to post, to ban "<acronym lang="en" xml:lang="en" title="Short Message Service">SMS</acronym> language", etc.);[%END%]</li>
-			<li>[%|helploc%]rules applying when sending messages (frequency, attachments, etc.);[%END%]</li>
-			<li>[%|helploc%]liabilities of subscribers regarding the netiquette;[%END%]</li>
-			<li>[%|helploc%]rights and responsibilities of the subscribers;[%END%]</li>
-			<li>[%|helploc%]information about retention of the messages sent to the list;[%END%]</li>
-			<li>[%|helploc%]legal information and privacy policy;[%END%]</li>
-			<li>[%|helploc%]sanctions applying to those who would not respect the list charter;[%END%]</li>
-			<li>[%|helploc%]etc.[%END%]</li>
-		</ul>
-		
-		<p class="retraitita">[%|helploc%]In order to have all subscribers read the list charter, you should include it in the welcome message they get after subscribing. To do that, you need to <a href="#customize">customize that message</a> through the 'Customize' page of the list administration module.[%END%]</p>
-		<p>[%|helploc%]When available, the 'Owner and moderator charter' provides list owners and moderators with all the necessary information to carry out their roles. This Charter involves all the rights and responsibilities of owners and moderators.[%END%]</p>
-		<hr />
+    <p>[%|helploc%]To <strong>know everything about the management of the shared document web space</strong> (how to organize it, change access rights, name documents, etc.), refer to the '<a href="shared">Using the shared document web space</a>' section of the User guide.[%END%]</p>
+    <p>[%|helploc%]To <strong>deny access to the shared document web space</strong>, click on '<strong>Delete shared</strong>' in the 'Admin' submenu. Then you will still have the possibility to <strong>reopen it</strong> by clicking on '<strong>Restore shared</strong>'. Deleting and restoring the shared document web space has <strong>no impact on the documents it contains</strong>.[%END%]</p>
+
+    <h4><a name="manage_members"></a>[%|helploc%]Managing subscribers[%END%]</h4>
+
+    <p>[%|helploc%]This section lets you browse the <strong>list of all the list subscribers</strong>. For each subscriber, the following information is available:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>email address</strong>;[%END%]</li>
+        <li>[%|helploc%]<strong>domain</strong> of the email address (<em class="example">@cru.fr</em>, <em class="example">@sympa.org</em>, <em class="example">@fai.com</em>, etc.);[%END%]</li>
+        <li>[%|helploc%]<strong>picture</strong> (if that feature was activated for the list);[%END%]</li>
+        <li>[%|helploc%]<strong>name</strong> (according to the subscription method, it is not always displayed);[%END%]</li>
+        <li>[%|helploc%]<a href="#deliverymode"><strong>message delivery mode</strong></a>;[%END%]</li>
+        <li>[%|helploc%]<strong>data source</strong> indicating the origin in case the subscriber is included in the list and not directly subscribed;[%END%]</li>
+        <li>[%|helploc%]<strong>date of subscription</strong> to the list;[%END%]</li>
+        <li>[%|helploc%]<strong>latest update</strong> of the subscriber options.[%END%]</li>
+    </ul>
+
+    <p class="retraitita">[%|helploc%]By default, each page displays 25 subscribers. You can browse through the pages by using the browsing arrows or display more subscribers on each page. You may also wish to sort subscribers according to different criteria by clicking on the corresponding column header.[%END%]</p>
+    <p>[%|helploc%]To <strong>search a subscriber</strong>, enter all or part of his/her email address or name in the input field and click on the '<strong>Search</strong>' button.[%END%]</p>
+    <p>[%|helploc%]You can <strong>subscribe other people to the list</strong> from this page:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]To add <strong>a single person</strong>, enter his/her email address in the input field and click on the '<strong>Add</strong>' button.[%END%]</li>
+        <li>[%|helploc%]To add <strong>several persons</strong>, click on the '<strong>Multiple add</strong>' button. In the input field that displays, enter the email addresses and names of the people you want to subscribe to the list and click on '<strong>Add subscribers</strong>'.[%END%]</li>
+    </ul>
+
+
+    <p class="retraitita">[%|helploc%]If you want to subscribe people without letting them know through a notice, tick the 'Quiet' box. However, it is far better to warn people that you subscribe them![%END%]</p>
+    <p>[%|helploc(conf.email,domain)%]Even though you have the possibility to subscribe people to your mailing lists, it is always <strong>much better that people take the necessary steps to subscribe themselves</strong> to the list. You can also <strong>invite people to subscribe to the list</strong> through the INVITE command: send an email to %1@%2 and type the following command in the message body: <strong>invite nameofthelist emailaddress</strong> (example: <em class="example">invite list_example john.doe(@)fai.com</em>).[%END%]</p>
+    <p>[%|helploc%]To <strong>accept or reject the subscription requests to the list</strong>, click on '<strong>Pending subscriptions</strong>'. The list of all people who requested subscription to the list displays. To accept or reject a request, tick the box in front of a person's name and click on the button of your choice.[%END%]</p>
+    <p>[%|helploc%]To <strong>send a subscription reminder to all subscribers</strong>, click on the '<strong>Remind all</strong>' button. The subscription reminder message contains:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]the <strong>name of the list</strong> to which the subscriber is subscribed;[%END%]</li>
+        <li>[%|helploc%]the <strong>email address</strong> with which the subscriber is subscribed;[%END%]</li>
+        <li>[%|helploc%]the subscriber's <strong>list password</strong>;[%END%]</li>
+        <li>[%|helploc%]a <strong>link to the information page</strong> of the list;[%END%]</li>
+        <li>[%|helploc%]a <strong>clickable address in order to allow subscribers to unsubscribe</strong> from the list.[%END%]</li>
+    </ul>
+    <p class="retraitita">[%|helploc%]You can also configure an automatic subscription reminder through the '<a href="listconfig#other">Miscellaneous</a>' page of the 'Edit list config' section.[%END%]</p>
+
+
+    <p>[%|helploc%]To <strong>unsubscribe subscribers</strong> from this page, select them by ticking the boxes in front of their names and click on the '<strong>Delete selected email addresses</strong>' button.[%END%]</p>
+    <p class="retraitita">[%|helploc%]If you do not want to notify the subscribers, tick the 'Quiet' box. However, this is not advisable, except in the case of bouncing subscribers.[%END%]</p>
+
+    <p class="retraitita">[%|helploc%]Tip: to select all subscribers at once, first make sure that they are all displayed on the page, and then click on the 'Toggle selection' button: all subscribers will be selected in a single click![%END%]</p>
+
+    <p>[%|helploc%]To <strong>change a subscriber's subscriber options</strong>, click on his/her email address.[%END%]</p>
+    <p>[%|helploc%]From this page, you can <strong>change the name, email address and message delivery mode of the subscriber</strong>. You can also <strong>unsubscribe him/her</strong>.[%END%]</p>
+
+    <p>[%|helploc%]If the subscriber is <a href="#manage_bounces">bouncing</a>, another form displays under the 'Subscriber information' form:[%END%]</p>
+    <p>[%|helploc%]The information displayed involves:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]the type of error (in English);[%END%]</li>
+        <li>[%|helploc%]the number or errors;[%END%]</li>
+        <li>[%|helploc%]the period during which errors occurred.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]You can <strong>check the latest error</strong> or <strong>reset errors</strong>. If you reset errors, the subscriber's <a href="listconfig#bouncers">score</a> will be reset to zero.[%END%]</p>
+
+    <p>[%|helploc%]To manage bouncing addresses more easily, go to the '<a href="#manage_bounces">Bounces</a>' page of the list administration module.[%END%]</p>
+
+
+    <h4><a name="manage_bounces"></a>[%|helploc%]Managing bounces[%END%]</h4>
+    <p>[%|helploc%]When there is a <strong>problem with subscribers' email addresses</strong> (obsolete email addresses, addresses temporarily unavailable when messages were sent, inbox quota exceeded, etc.), the percentage of bouncing addresses displays in the left menu under the text '<strong>Error rate</strong>'. To check the bouncing addresses, go to the '<strong>Bounces</strong>' page of the list administration module.[%END%]</p>
+    <p>[%|helploc%]The Sympa software automatically manages bouncing subscribers: according to the number of errors and to the traffic on the list, bouncing subscribers are either notified, unsubscribed, or their score is reset to zero when their address stops bouncing.[%END%]</p>
+    <p>[%|helploc%]To <strong>make addresses stop being reported as bouncing</strong>, select them by ticking their boxes and click on the '<strong>Reset errors for selected users</strong>' button. If the error remains, the addresses will be reported as bouncing again as soon as a message is posted on the list.[%END%]</p>
+    <p>[%|helploc%]You can also <strong>unsubscribe subscribers whose addresses are still bouncing</strong>: too many bouncing addresses cause a considerable load on the mailing list server. To unsubscribe subscribers, select them by ticking the boxes in front of their names and click on the '<strong>Delete selected email addresses</strong>' button.[%END%]</p>
+    <p class="retraitita">[%|helploc%]Tip: to select all subscribers at once, first make sure that they are all displayed on the page, and then click on the 'Toggle selection' button: all subscribers will be selected in a single click![%END%]</p>
+
+    <h4><a name="moderate"></a>[%|helploc%]Moderating messages sent to the list[%END%]</h4>
+    <p>[%|helploc%]When a list is moderated, <strong>all messages have to be approved of by one of the moderators before being distributed to the list</strong>. After sending a message to a list, subscribers are automatically notified by email that their message will be moderated. As for moderators, they also receive a notice message from Sympa, which includes the message to moderate.[%END%]</p>
+
+    <p>[%|helploc%]You can <strong>perform moderating tasks</strong> either <strong>by email</strong>, by answering the messages received from Sympa, or <strong>through the mailing list web interface</strong>. To do that, click on the '<strong>Message</strong>' link in the 'Moderate' submenu: you are brought to a page that displays all messages to be moderated (the most recent messages are on top of page). <strong>To read a message, click on its subject</strong>.[%END%]</p>
+
+    <p>[%|helploc%]You have <strong>two options</strong>:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>authorize the message distribution</strong> on the list;[%END%]</li>
+        <li>[%|helploc%]<strong>reject the message and notify sender</strong>: when you reject a message, it is better to notify its sender...[%END%]<br />
+    </ul>
+    <p>[%|helploc%]All moderators can decide to distribute a message or not. However, <strong>the first moderator to process the message will carry the day</strong>. You will be notified by Sympa if you try to process a message that has already been moderated. When there are several moderators, it is <strong>easier to moderate messages from the mailing list web interface</strong>: thus, you will be able to view all messages remaining to be moderated.[%END%]</p>
+    <p class="retraitita">[%|helploc%]<strong>Whatever the date and time of moderation, the date and time of sending of the message do not change</strong>. Thus, if the distribution of the message is allowed with a lot of delay, it is possible to receive a message dated January 1st on December 31st![%END%]</p>
+    <p>[%|helploc%]In case the message was rejected with a notice, the subscriber who had sent it is notified by email. You can <a href="#customize">customize the message he/she gets</a>.[%END%]</p>
+
+    <p>[%|helploc%]Checking the '<strong>Reject without notification</strong>' checkbox allows you to prevent the message author from receiving a notification.[%END%]</p>
+
+    <p>[%|helploc%]Checking the '<strong>Add to blacklist</strong>' checkbox both skip the rejection notification and adds the message author to the list own blacklist. You can manage the blacklist via the '<strong>edit blacklist</strong>' button at the bottom of the page.[%END%]</p>
+
+    <p>[%|helploc%]If you wish to customize the rejection message that is sent to a message author, you can do so via the '<strong>Manage rejection messages</strong>' button. The message management page will let define a set of rejection messages and define the default one.[%END%]</p>
+
+    <p>[%|helploc%]<strong>Reminder</strong>: you can <a href="listconfig#description">add or remove moderators</a> through the list administration module. To do that, from the list information page, click on '<strong>Admin</strong>', on '<strong>Edit list config</strong>', and then on '<strong>List definition</strong>'.[%END%]</p>
+    <p>[%|helploc%]It is also possible to <strong>process messages after their distribution on the list</strong>; this can be useful when a list is not moderated. If you want to <strong>delete a message</strong>, <a href="arc#arcsearch">search for it in the online message archive</a> and click on the '<strong>Tag this mail for deletion</strong>' button in the upper right corner of the message. A confirmation message displays; click on 'OK'. The message will be deleted after a few seconds. <strong>Be careful: this operation is irreversible!!! If you delete a message, you will not be able to retrieve it.</strong>[%END%]</p>
+
+
+    <h4><a name="manage_archives"></a>[%|helploc%]Managing the message archive[%END%]</h4>
+    <p>[%|helploc%]The mailing list management robot Sympa can generate <strong>downloadable compressed archives (.ZIP format) of the messages sent to the list</strong>. To download those archives, <strong>select the months</strong> that interest you in the list and click on the '<strong>Download .zip archive</strong>' button.[%END%]</p>
+    <p class="retraitita">[%|helploc%]Tip: in the 'Archive selection' list, to select all months during which messages have been sent, click on the first month, hold down the SHIFT key and click on the last month of the list.[%END%]</p>
+    <p>[%|helploc%]You will receive a file of the type '<strong>nameofthelist_archive.zip</strong>' containing <strong>folders named 'nameofthelist_year-month'</strong> (example: <em class="example">list_example_2005-06</em>) for each month. Inside each folder, <strong>the file names are numbers</strong> representing their position in the chronology of the messages sent (example: the file named '1' contains the first message sent in the month). The message files have <strong>no extension</strong>; use the text editor of your choice (Notepad, WordPad, Vim, etc.) to open them. <strong>Each file represents an entire message (full header)</strong>.[%END%]</p>
+    <p>[%|helploc%]From the 'Manage archives' page, you can also <strong>delete messages</strong> (deletion month by month and not message by message). To do that, <strong>select the months</strong> that interest you in the list and click on the '<strong>Delete Selected Month(s)</strong>' button.[%END%]</p>
+    <p class="retraitita">[%|helploc%]<strong>Be careful: this operation is irreversible!!! When you click on 'Delete selected months', keep in mind that you are not only deleting an archive file, but also the entire message archive of the selected month!!!</strong>[%END%]</p>
+
+
+    <h4><a name="renamelist"></a>[%|helploc%]Renaming the list[%END%]</h4>
+    <p>[%|helploc%]In the <strong>list administration module</strong>, click on '<strong>Rename list</strong>'. Enter the name of your choice and click on the 'Rename this list' button. A confirmation message displays; click on 'OK'.[%END%]</p>
+    <p class="retraitita">[%|helploc%]If you change your mind, you will only have to redo the inverse operation in order to retrieve the former list name.[%END%]</p>
+    <p>[%|helploc%]<strong>Be careful: when you rename a list, you have to let the listmasters know; otherwise, the change will not be effective</strong>.[%END%]</p>
+    <p>[%|helploc%]A few tips to name your lists:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>Do not use any spaces, accents or specials characters</strong> in list names: those characters might cause problems.[%END%]</li>
+        <li>[%|helploc%]Choose an <strong>explicit yet short name</strong>: think of the subscribers who will have to type this name every time they will send a message to the list![%END%]</li>
+        <li>[%|helploc(domain)%]If you manage a set of lists, you can <strong>prefix your lists' names with a common prefix</strong>; thus they will be sorted together and will be easily recognizable (example: <em class="example">xx-users@%1, xx-hotline@%1.fr</em>, etc.).[%END%]</li>
+    </ul>
+
+
+    <h4><a name="supprlist"></a>[%|helploc%]Deleting the list[%END%]</h4>
+    <p>[%|helploc%]In the <strong>list administration module</strong>, click on '<strong>Remove list</strong>'. A confirmation message displays; click on 'OK'.[%END%]</p>
+    <p class="retraitita">[%|helploc%]<strong>Be careful: if you delete the list, you will not be able to reopen it yourself!!! If you want to reopen the list, you will have to ask the listmasters.</strong>[%END%]</p>
+
+    <p>[%|helploc%]In real terms, what are the <strong>consequences</strong> of a list deletion?[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>All subscribers are immediately unsubscribed</strong> automatically (including owners and moderators).[%END%]</li>
+        <li>[%|helploc%]<strong>The message archive is preserved</strong> but no one can access it anymore.[%END%]</li>
+        <li>[%|helploc%]<strong>The documents published in the shared document web space are preserved</strong> but no one can access them anymore.[%END%]</li>
+        <li>[%|helploc%]<strong>Only the listmasters have the power to reopen the list</strong>; if they do, the former list subscribers will automatically be subscribed again.[%END%]</li>
+    </ul>
+    <p class="retraitita">[%|helploc%]Be careful: due to a slight latency, the list pages remain accessible for a while if you know their addresses. Then they will become fully unavailable.[%END%]</p>
+
+    <p>[%|helploc%]<strong>If you want the list and all the associated files to be deleted permanently</strong>, you will have to ask the listmasters.[%END%]</p>
+
+    <h3><a name="rulesadmin"></a>[%|helploc%]Good practices[%END%]</h3>
+    <p>[%|helploc%]In order to have dynamic lists, <strong>you must be deeply involved</strong> in their exchanges: if a list is neither controlled nor enlivened by its owners, it may result in a loss of quality in its messages and it might even end up vanishing...[%END%]</p>
+    <p>[%|helploc%]<strong>The use of email in general and for mailing lists is bound by a set of precise rules necessary to share pleasant exchanges: the "Netiquette"</strong>. As a list owner or moderator, it is your role to have subscribers respect it. You will find the general principles of the Netiquette, as well as many links on the <a target="_blank" href="http://en.wikipedia.org/wiki/Netiquette">page of the Wikipedia dedicated to the Netiquette</a>.[%END%]</p>
+    <p><a name="charter"></a>[%|helploc%]You should <strong>write a charter for your list</strong> to define all the rules that apply to its use:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]allowed, tolerated and forbidden topics;[%END%]</li>
+        <li>[%|helploc%]writing rules (for example to specify the languages in which the subscribers are to post, to ban "<acronym lang="en" xml:lang="en" title="Short Message Service">SMS</acronym> language", etc.);[%END%]</li>
+        <li>[%|helploc%]rules applying when sending messages (frequency, attachments, etc.);[%END%]</li>
+        <li>[%|helploc%]liabilities of subscribers regarding the netiquette;[%END%]</li>
+        <li>[%|helploc%]rights and responsibilities of the subscribers;[%END%]</li>
+        <li>[%|helploc%]information about retention of the messages sent to the list;[%END%]</li>
+        <li>[%|helploc%]legal information and privacy policy;[%END%]</li>
+        <li>[%|helploc%]sanctions applying to those who would not respect the list charter;[%END%]</li>
+        <li>[%|helploc%]etc.[%END%]</li>
+    </ul>
+
+    <p class="retraitita">[%|helploc%]In order to have all subscribers read the list charter, you should include it in the welcome message they get after subscribing. To do that, you need to <a href="#customize">customize that message</a> through the 'Customize' page of the list administration module.[%END%]</p>
+    <p>[%|helploc%]When available, the 'Owner and moderator charter' provides list owners and moderators with all the necessary information to carry out their roles. This Charter involves all the rights and responsibilities of owners and moderators.[%END%]</p>
+    <hr />
 <!-- end help_admin.tt2 -->

--- a/default/web_tt2/help_arc.tt2
+++ b/default/web_tt2/help_arc.tt2
@@ -1,120 +1,120 @@
 <!-- help_arc.tt2 -->
 
 <h3 class="block"><a name="archives"></a>[%|helploc%]Reading the list archive online[%END%]</h3>
-	<p>[%|helploc%]<strong>To read the messages sent to a list</strong>, you have two options:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]read the messages you receive <strong>in your email inbox</strong>;[%END%]</li>
-		<li>[%|helploc%]read the list archive <strong>online</strong> (through the mailing list web interface).[%END%]</li>
-	</ul>
+<p>[%|helploc%]<strong>To read the messages sent to a list</strong>, you have two options:[%END%]</p>
+<ul>
+    <li>[%|helploc%]read the messages you receive <strong>in your email inbox</strong>;[%END%]</li>
+    <li>[%|helploc%]read the list archive <strong>online</strong> (through the mailing list web interface).[%END%]</li>
+</ul>
 
-	<p>[%|helploc%]<strong>To read the list archive online</strong>, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Go to the information page of the list</strong> of which you want to read the archive.[%END%]</li>
-		<li>[%|helploc%]<strong>In the left menu, click on the 'Archive' link</strong>.[%END%]</li>
-		<li>[%|helploc%]The message index of the current month displays.[%END%]</li>
-	</ol>
+<p>[%|helploc%]<strong>To read the list archive online</strong>, do as follows:[%END%]</p>
+<ol>
+    <li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
+    <li>[%|helploc%]<strong>Go to the information page of the list</strong> of which you want to read the archive.[%END%]</li>
+    <li>[%|helploc%]<strong>In the left menu, click on the 'Archive' link</strong>.[%END%]</li>
+    <li>[%|helploc%]The message index of the current month displays.[%END%]</li>
+</ol>
 
-	<h4>[%|helploc%]Presentation of messages[%END%]</h4>
-	<p>[%|helploc%]<strong>The page always displays the latest messages</strong>; thus if the list was idle during the current month, the messages of the latest active month are displayed.[%END%]</p>
-	<p>[%|helploc%]When there are <strong>too many messages to be displayed on a single page, only the latest messages display by default</strong>. <strong>To change page, click on the arrow links around the current page's number</strong>:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]The '<strong>&lt;</strong>' arrow displays older messages.[%END%]</li>
-		<li>[%|helploc%]The '<strong>&gt;</strong>' arrow displays newer messages.[%END%]</li>
-		<li>[%|helploc%]The '<strong>&lt;&lt;</strong>' link displays the oldest messages.[%END%]</li>
-		<li>[%|helploc%]The '<strong>&gt;&gt;</strong>' link displays the latest messages.[%END%]</li>
-	</ul>
-	
-	<h4>[%|helploc%]Chronological and thread order[%END%]</h4>
-	<p>[%|helploc%]<strong>By default, messages are displayed as threads</strong>: they are <strong>gathered according to their subject</strong>. This way, all answers to a given message are displayed just below the thread's first message and are indented for better readability.[%END%]</p>
-	<p class="retraitita">[%|helploc%]Be careful: it is possible for two messages to have the same subject without being related; however, they will be displayed as if they belonged to the same thread.[%END%]</p>
+<h4>[%|helploc%]Presentation of messages[%END%]</h4>
+<p>[%|helploc%]<strong>The page always displays the latest messages</strong>; thus if the list was idle during the current month, the messages of the latest active month are displayed.[%END%]</p>
+<p>[%|helploc%]When there are <strong>too many messages to be displayed on a single page, only the latest messages display by default</strong>. <strong>To change page, click on the arrow links around the current page's number</strong>:[%END%]</p>
+<ul>
+    <li>[%|helploc%]The '<strong>&lt;</strong>' arrow displays older messages.[%END%]</li>
+    <li>[%|helploc%]The '<strong>&gt;</strong>' arrow displays newer messages.[%END%]</li>
+    <li>[%|helploc%]The '<strong>&lt;&lt;</strong>' link displays the oldest messages.[%END%]</li>
+    <li>[%|helploc%]The '<strong>&gt;&gt;</strong>' link displays the latest messages.[%END%]</li>
+</ul>
 
-	<p>[%|helploc%]<strong>To display messages chronologically, click on the 'Chronological' link</strong>.[%END%]</p>
-	<p class="retraitita">[%|helploc%]Be careful: this display setting applies as long as you read the messages of a particular month, but if you change month, the default display setting 'Thread' will apply again.[%END%]</p>
+<h4>[%|helploc%]Chronological and thread order[%END%]</h4>
+<p>[%|helploc%]<strong>By default, messages are displayed as threads</strong>: they are <strong>gathered according to their subject</strong>. This way, all answers to a given message are displayed just below the thread's first message and are indented for better readability.[%END%]</p>
+<p class="retraitita">[%|helploc%]Be careful: it is possible for two messages to have the same subject without being related; however, they will be displayed as if they belonged to the same thread.[%END%]</p>
 
-	<h4>[%|helploc%]Browsing through the messages[%END%]</h4>
-	<p>[%|helploc%]<strong>To read a message, click on its subject</strong>. Then you can browse through the messages sent to the list by clicking on the arrows surrounding the words 'Chronological' and 'Thread':[%END%]</p>
-	<ul>
-		<li>[%|helploc%]By clicking on the arrows surrounding the word 'Chronological', you read messages according to their chronological order.[%END%]</li>
-		<li>[%|helploc%]By clicking on the arrows surrounding the word 'Thread', you read messages as a thread (i.e. gathered according to their subject).[%END%]</li>
-		<li>[%|helploc%]The left arrows let you browse through older messages.[%END%]</li>
-		<li>[%|helploc%]The right arrows let you browse through newer messages.[%END%]</li>
-	</ul>
+<p>[%|helploc%]<strong>To display messages chronologically, click on the 'Chronological' link</strong>.[%END%]</p>
+<p class="retraitita">[%|helploc%]Be careful: this display setting applies as long as you read the messages of a particular month, but if you change month, the default display setting 'Thread' will apply again.[%END%]</p>
 
-	<p>[%|helploc%]<strong>Other messages belonging to the same thread as the message displayed are listed at its bottom</strong>. Click on their subject to read them.[%END%]</p>
+<h4>[%|helploc%]Browsing through the messages[%END%]</h4>
+<p>[%|helploc%]<strong>To read a message, click on its subject</strong>. Then you can browse through the messages sent to the list by clicking on the arrows surrounding the words 'Chronological' and 'Thread':[%END%]</p>
+<ul>
+    <li>[%|helploc%]By clicking on the arrows surrounding the word 'Chronological', you read messages according to their chronological order.[%END%]</li>
+    <li>[%|helploc%]By clicking on the arrows surrounding the word 'Thread', you read messages as a thread (i.e. gathered according to their subject).[%END%]</li>
+    <li>[%|helploc%]The left arrows let you browse through older messages.[%END%]</li>
+    <li>[%|helploc%]The right arrows let you browse through newer messages.[%END%]</li>
+</ul>
 
-	<p>[%|helploc%]<strong>To come back to the messages index, click on 'Chronological' or 'Thread'</strong> according to whether you want to display the index as a chronological history or as a thread. When there are too many messages to be displayed on a single page, <strong>you are brought to the index page displaying the message you just read</strong>, and not to the page displaying the latest messages.[%END%]</p>
+<p>[%|helploc%]<strong>Other messages belonging to the same thread as the message displayed are listed at its bottom</strong>. Click on their subject to read them.[%END%]</p>
 
-	<p>[%|helploc%]<strong>To look at another month's archive, click on the number of the month in the calendar</strong> at the top left of your screen. Every month during which  messages have been sent has a clickable number.[%END%]</p>
-	<p class="retraitita">[%|helploc%]When you are on a message page, the calendar does not display.[%END%]</p>
+<p>[%|helploc%]<strong>To come back to the messages index, click on 'Chronological' or 'Thread'</strong> according to whether you want to display the index as a chronological history or as a thread. When there are too many messages to be displayed on a single page, <strong>you are brought to the index page displaying the message you just read</strong>, and not to the page displaying the latest messages.[%END%]</p>
 
-	<h4>[%|helploc%]Content of the messages: links and attachments[%END%]</h4>
-	<p>[%|helploc%]Normally, <strong>every link contained in a message is clickable</strong>: just click on it and it will bring you to the linked resource.[%END%]</p>
-	<p class="retraitita">[%|helploc%]Be careful: when you click on a link contained in a message, you leave the mailing list environment. If you do not want to do that, open the link in a new window or tab. Leaving the mailing list environment does not mean that you log out: your logout depends on the value you set for the 'Connection expiration period' option on the 'Your preferences' page.[%END%]</p>
-	<p>[%|helploc%]<strong>When a file is attached to a message, it is displayed at the bottom of the message</strong>. To download it, you only have to <strong>click on its name</strong>.[%END%]</p>
-	
-	<h4><a name="answeronline"></a>[%|helploc%]Replying to a message from the mailing list web interface[%END%]</h4>
-	<p>[%|helploc%]You can reply to a message directly from the mailing list web interface. To do this, <strong>click on the 'Reply' button on the top right of the message</strong>.[%END%]</p>
-	<p class="retraitita">[%|helploc%]Be careful: after clicking on the 'Reply' button, you will not be able to change the recipient anymore; thus be careful when choosing between the message's sender and the list (i.e. all subscribers)![%END%]</p>
+<p>[%|helploc%]<strong>To look at another month's archive, click on the number of the month in the calendar</strong> at the top left of your screen. Every month during which  messages have been sent has a clickable number.[%END%]</p>
+<p class="retraitita">[%|helploc%]When you are on a message page, the calendar does not display.[%END%]</p>
 
-	<p>[%|helploc%]This method is <strong>not very flexible</strong>: from the mailing list web interface, you can not add or change some recipients, add an attachment or format the messages you send. <strong>Thus you might prefer to use an email client or a webmail</strong>.[%END%]</p>
-	
-<!--	renvoyer à [mon adresse]  
+<h4>[%|helploc%]Content of the messages: links and attachments[%END%]</h4>
+<p>[%|helploc%]Normally, <strong>every link contained in a message is clickable</strong>: just click on it and it will bring you to the linked resource.[%END%]</p>
+<p class="retraitita">[%|helploc%]Be careful: when you click on a link contained in a message, you leave the mailing list environment. If you do not want to do that, open the link in a new window or tab. Leaving the mailing list environment does not mean that you log out: your logout depends on the value you set for the 'Connection expiration period' option on the 'Your preferences' page.[%END%]</p>
+<p>[%|helploc%]<strong>When a file is attached to a message, it is displayed at the bottom of the message</strong>. To download it, you only have to <strong>click on its name</strong>.[%END%]</p>
+
+<h4><a name="answeronline"></a>[%|helploc%]Replying to a message from the mailing list web interface[%END%]</h4>
+<p>[%|helploc%]You can reply to a message directly from the mailing list web interface. To do this, <strong>click on the 'Reply' button on the top right of the message</strong>.[%END%]</p>
+<p class="retraitita">[%|helploc%]Be careful: after clicking on the 'Reply' button, you will not be able to change the recipient anymore; thus be careful when choosing between the message's sender and the list (i.e. all subscribers)![%END%]</p>
+
+<p>[%|helploc%]This method is <strong>not very flexible</strong>: from the mailing list web interface, you can not add or change some recipients, add an attachment or format the messages you send. <strong>Thus you might prefer to use an email client or a webmail</strong>.[%END%]</p>
+
+<!--    renvoyer à [mon adresse]  
 signoff * -->
-	
-	<h4><a name="arcsearch"></a>[%|helploc%]Searching in a list archive[%END%]</h4>
-	<p>[%|helploc%]If you want to find a particular message or if you look for information on a topic, <strong>you can perform a search in the list archive</strong>. To do that, you have <strong>two options</strong>:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]perform a <strong>simple search</strong>;[%END%]</li>
-		<li>[%|helploc%]perform a <strong>search with the advanced search mode</strong>.[%END%]</li>
-	</ul>
 
-	
-	<h5>[%|helploc%]Performing a simple search[%END%]</h5>
-	<p><span class="remarque">[%|helploc%]Before starting to use the simple search mode, you should know that <a href="#advancedsearch">advanced search</a> is much more flexible than simple search and will suit your needs better if you do not know precisely what you are looking for.[%END%]</span></p>
-	<p>[%|helploc%]To perform a simple search, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Go to the information page of the list</strong> of your interest.[%END%]<br />
-			<span class="retraitita">[%|helploc%]It is impossible to perform a search in the archive of several lists at once. If you want to do it nevertheless, you will need to repeat the search for each list.[%END%]</span></li>
-		<li>[%|helploc%]In the left menu, <strong>click on the 'Archive' link</strong>. A message index page displays.[%END%]<br />
-			<span class="retraitita">[%|helploc%]You can perform searches from index pages and from message pages.[%END%]</span></li>
-		<li>[%|helploc%]<strong>Go to the message index of the month</strong> in which you want to search. To do that, use the calendar displayed at the top left of your screen.[%END%]<br />
-			<span class="retraitita">[%|helploc%]The search will process the messages of the month you chose and of the previous month during which messages have been sent. If you do not know when the message was sent, use the advanced search mode.[%END%]</span></li>
-		<li>[%|helploc%]<strong>Enter your keywords</strong> in the search box in the upper right corner of your screen.[%END%]<br />
-			<span class="retraitita">[%|helploc%]Be careful: the search engine will process your input as a sentence. If you want to search with several non contiguous words, use the advanced search mode.[%END%]</span></li>
-		<li>[%|helploc%]<strong>Click on the 'Search' button</strong>.[%END%]</li>
-	</ol>
-	<p>[%|helploc%]The messages matching your search display. To know more, please refer to the <a href="#resultsearch">'Search results'</a> section.[%END%]</p>
+<h4><a name="arcsearch"></a>[%|helploc%]Searching in a list archive[%END%]</h4>
+<p>[%|helploc%]If you want to find a particular message or if you look for information on a topic, <strong>you can perform a search in the list archive</strong>. To do that, you have <strong>two options</strong>:[%END%]</p>
+<ul>
+    <li>[%|helploc%]perform a <strong>simple search</strong>;[%END%]</li>
+    <li>[%|helploc%]perform a <strong>search with the advanced search mode</strong>.[%END%]</li>
+</ul>
 
-	<h5><a name="advancedsearch"></a>[%|helploc%]Performing a search with the advanced search mode[%END%]</h5>
-	<p>[%|helploc%]As the advanced search mode is much more powerful and flexible than the simple search mode, it is much easier to use. To perform an advanced search, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Go to the information page of the list</strong> of your interest.[%END%]<br />
-			<span class="retraitita">[%|helploc%]It is impossible to perform a search in the archive of several lists at once. If you want to do it nevertheless, you will need to repeat the search for each list.[%END%]</span></li>
-		<li>[%|helploc%]In the left menu, <strong>click on the 'Archive' link</strong>. A message index page displays.[%END%]<br />
-			<span class="retraitita">[%|helploc%]You can perform searches from index pages and from message pages.[%END%]</span></li>
-		<li>[%|helploc%]<strong>Click on the 'Advanced search' button</strong> below the search box.[%END%]</li>
-		<li>[%|helploc%]<strong>Enter your keywords</strong> in the search box.[%END%]</li>
-		<li>[%|helploc%]Choose your <strong>search options</strong>.[%END%]<br />
-		<span class="retraitita">[%|helploc%]Tip: in the 'Extend search field' list, to select all months for which an archive is available, click on the first month, hold down the SHIFT key and click on the last month of the list. Although it is not indicated in the list, the current month will of course be processed as well.[%END%]</span></li>
-		<li>[%|helploc%]<strong>Click on the 'Search' button</strong>.[%END%]</li>
-	</ol>
-	<p>[%|helploc%]The messages matching your search display. To know more, please refer to the <a href="#resultsearch">'Search results'</a> section.[%END%]</p>
 
-	<h5><a name="resultsearch"></a>[%|helploc%]Search results[%END%]</h5>
-	<p>[%|helploc%]<strong>By default, the messages displayed on the results page are sorted from the latest to the oldest and each page displays up to ten results</strong>. With the advanced search mode, you can change these settings to match your preferences.[%END%]</p>
-	<p>[%|helploc%]<strong>When there are many results, they are sometimes displayed on several pages</strong>. Do not get caught by this: if you can not find the message you are looking for, make sure that there are no other results page before giving up...[%END%]</p>
-	<p>[%|helploc%]When you specify a large search range, <strong>sometimes only a part of the messages is processed in a first step of search. In this case, a button labeled 'Continue search' displays below results</strong>. Click on it to search in the rest of messages. If messages are very numerous, sometimes you will need to perform this action several times.[%END%]</p>
-	<p>[%|helploc%]For each message, the <strong>information displayed on the results page</strong> is the following:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]message subject;[%END%]</li>
-		<li>[%|helploc%]sending date;[%END%]</li>
-		<li>[%|helploc%]sender;[%END%]</li>
-		<li>[%|helploc%]a few lines of context containing the searched keywords.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]<strong>To read one of the messages matching your search, you only need to click on its subject</strong>.[%END%]</p>
-	<p class="retraitita">[%|helploc%]Be careful: with Internet Explorer, if you go and read a message from the results page, you will not be able to use the 'Back' button of your browser to come back to that page. We advise you to use a modern browser such as Firefox. If you can not use a browser other than Internet Explorer, we advise you to open messages in a new window (right click on links and choose 'Open in New Window') in order to preserve your search results.[%END%]</p>
+<h5>[%|helploc%]Performing a simple search[%END%]</h5>
+<p><span class="remarque">[%|helploc%]Before starting to use the simple search mode, you should know that <a href="#advancedsearch">advanced search</a> is much more flexible than simple search and will suit your needs better if you do not know precisely what you are looking for.[%END%]</span></p>
+<p>[%|helploc%]To perform a simple search, do as follows:[%END%]</p>
+<ol>
+    <li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
+    <li>[%|helploc%]<strong>Go to the information page of the list</strong> of your interest.[%END%]<br />
+        <span class="retraitita">[%|helploc%]It is impossible to perform a search in the archive of several lists at once. If you want to do it nevertheless, you will need to repeat the search for each list.[%END%]</span></li>
+    <li>[%|helploc%]In the left menu, <strong>click on the 'Archive' link</strong>. A message index page displays.[%END%]<br />
+        <span class="retraitita">[%|helploc%]You can perform searches from index pages and from message pages.[%END%]</span></li>
+    <li>[%|helploc%]<strong>Go to the message index of the month</strong> in which you want to search. To do that, use the calendar displayed at the top left of your screen.[%END%]<br />
+        <span class="retraitita">[%|helploc%]The search will process the messages of the month you chose and of the previous month during which messages have been sent. If you do not know when the message was sent, use the advanced search mode.[%END%]</span></li>
+    <li>[%|helploc%]<strong>Enter your keywords</strong> in the search box in the upper right corner of your screen.[%END%]<br />
+        <span class="retraitita">[%|helploc%]Be careful: the search engine will process your input as a sentence. If you want to search with several non contiguous words, use the advanced search mode.[%END%]</span></li>
+    <li>[%|helploc%]<strong>Click on the 'Search' button</strong>.[%END%]</li>
+</ol>
+<p>[%|helploc%]The messages matching your search display. To know more, please refer to the <a href="#resultsearch">'Search results'</a> section.[%END%]</p>
+
+<h5><a name="advancedsearch"></a>[%|helploc%]Performing a search with the advanced search mode[%END%]</h5>
+<p>[%|helploc%]As the advanced search mode is much more powerful and flexible than the simple search mode, it is much easier to use. To perform an advanced search, do as follows:[%END%]</p>
+<ol>
+    <li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
+    <li>[%|helploc%]<strong>Go to the information page of the list</strong> of your interest.[%END%]<br />
+        <span class="retraitita">[%|helploc%]It is impossible to perform a search in the archive of several lists at once. If you want to do it nevertheless, you will need to repeat the search for each list.[%END%]</span></li>
+    <li>[%|helploc%]In the left menu, <strong>click on the 'Archive' link</strong>. A message index page displays.[%END%]<br />
+        <span class="retraitita">[%|helploc%]You can perform searches from index pages and from message pages.[%END%]</span></li>
+    <li>[%|helploc%]<strong>Click on the 'Advanced search' button</strong> below the search box.[%END%]</li>
+    <li>[%|helploc%]<strong>Enter your keywords</strong> in the search box.[%END%]</li>
+    <li>[%|helploc%]Choose your <strong>search options</strong>.[%END%]<br />
+    <span class="retraitita">[%|helploc%]Tip: in the 'Extend search field' list, to select all months for which an archive is available, click on the first month, hold down the SHIFT key and click on the last month of the list. Although it is not indicated in the list, the current month will of course be processed as well.[%END%]</span></li>
+    <li>[%|helploc%]<strong>Click on the 'Search' button</strong>.[%END%]</li>
+</ol>
+<p>[%|helploc%]The messages matching your search display. To know more, please refer to the <a href="#resultsearch">'Search results'</a> section.[%END%]</p>
+
+<h5><a name="resultsearch"></a>[%|helploc%]Search results[%END%]</h5>
+<p>[%|helploc%]<strong>By default, the messages displayed on the results page are sorted from the latest to the oldest and each page displays up to ten results</strong>. With the advanced search mode, you can change these settings to match your preferences.[%END%]</p>
+<p>[%|helploc%]<strong>When there are many results, they are sometimes displayed on several pages</strong>. Do not get caught by this: if you can not find the message you are looking for, make sure that there are no other results page before giving up...[%END%]</p>
+<p>[%|helploc%]When you specify a large search range, <strong>sometimes only a part of the messages is processed in a first step of search. In this case, a button labeled 'Continue search' displays below results</strong>. Click on it to search in the rest of messages. If messages are very numerous, sometimes you will need to perform this action several times.[%END%]</p>
+<p>[%|helploc%]For each message, the <strong>information displayed on the results page</strong> is the following:[%END%]</p>
+<ul>
+    <li>[%|helploc%]message subject;[%END%]</li>
+    <li>[%|helploc%]sending date;[%END%]</li>
+    <li>[%|helploc%]sender;[%END%]</li>
+    <li>[%|helploc%]a few lines of context containing the searched keywords.[%END%]</li>
+</ul>
+<p>[%|helploc%]<strong>To read one of the messages matching your search, you only need to click on its subject</strong>.[%END%]</p>
+<p class="retraitita">[%|helploc%]Be careful: with Internet Explorer, if you go and read a message from the results page, you will not be able to use the 'Back' button of your browser to come back to that page. We advise you to use a modern browser such as Firefox. If you can not use a browser other than Internet Explorer, we advise you to open messages in a new window (right click on links and choose 'Open in New Window') in order to preserve your search results.[%END%]</p>
 
 <!-- end help_arc.tt2 -->

--- a/default/web_tt2/help_faqadmin.tt2
+++ b/default/web_tt2/help_faqadmin.tt2
@@ -1,15 +1,15 @@
 <!-- help_faqadmin.tt2 -->
 
-		<h3 class="block">[%|helploc%]Administrators Frequently Asked Questions[%END%]</h3>
+<h3 class="block">[%|helploc%]Administrators Frequently Asked Questions[%END%]</h3>
 
-		<h4>[%|helploc%]A subscriber does not receive the list messages[%END%]</h4>
-		<p>[%|helploc%]To find the cause of the problem, do as follows:[%END%]</p>
-		<ol>
-			<li>[%|helploc%]<strong>Check that the user is really subscribed to the list</strong> on the 'Manage subscribers' page.[%END%]</li>
-			<li>[%|helploc%]<strong>Check the subscriber's message delivery mode</strong>; the page about the subscriber is available by clicking on his/her email address from the members list. When the delivery mode is the 'Digest' mode, it is normal that the subscriber does not receive messages as soon as they are sent.[%END%]</li>
-			<li>[%|helploc%]<strong>Check that the subscriber's email address is not bouncing</strong> on the 'Bounces' page. A subscriber email address is considered to be bouncing when messages sent to it generate error logs (called "bounces"). These errors can be temporary (inbox full, mail server unavailable) or permanent (no email account for the user). In any case, the mailing list server automatically manages the deletion of addresses generating too many errors.[%END%]</li>
-			<li>[%|helploc%]<strong>Try and send a message yourself to the subscriber</strong> in order to check if he/she receives it.[%END%]</li>
-			<li>[%|helploc%]As a last resort, <strong>contact the listmaster</strong>, who will check the mail server logs in order to find the cause of the problem.[%END%]</li>
-		</ol>
+<h4>[%|helploc%]A subscriber does not receive the list messages[%END%]</h4>
+<p>[%|helploc%]To find the cause of the problem, do as follows:[%END%]</p>
+<ol>
+    <li>[%|helploc%]<strong>Check that the user is really subscribed to the list</strong> on the 'Manage subscribers' page.[%END%]</li>
+    <li>[%|helploc%]<strong>Check the subscriber's message delivery mode</strong>; the page about the subscriber is available by clicking on his/her email address from the members list. When the delivery mode is the 'Digest' mode, it is normal that the subscriber does not receive messages as soon as they are sent.[%END%]</li>
+    <li>[%|helploc%]<strong>Check that the subscriber's email address is not bouncing</strong> on the 'Bounces' page. A subscriber email address is considered to be bouncing when messages sent to it generate error logs (called "bounces"). These errors can be temporary (inbox full, mail server unavailable) or permanent (no email account for the user). In any case, the mailing list server automatically manages the deletion of addresses generating too many errors.[%END%]</li>
+    <li>[%|helploc%]<strong>Try and send a message yourself to the subscriber</strong> in order to check if he/she receives it.[%END%]</li>
+    <li>[%|helploc%]As a last resort, <strong>contact the listmaster</strong>, who will check the mail server logs in order to find the cause of the problem.[%END%]</li>
+</ol>
 
 <!-- end help_faqadmin.tt2 -->

--- a/default/web_tt2/help_faquser.tt2
+++ b/default/web_tt2/help_faquser.tt2
@@ -1,73 +1,73 @@
 <!-- help_faquser.tt2 -->
 
-		<h3 class="block">[%|helploc%]Users Frequently Asked Questions[%END%]</h3>
+        <h3 class="block">[%|helploc%]Users Frequently Asked Questions[%END%]</h3>
 
-		<h4>[%|helploc%]You can not subscribe to a list[%END%]</h4>
-		<p>[%|helploc%]This problem may be due to the following reasons:[%END%]</p>
-		<ul>
-			<li><strong>[%|helploc%]The list owners forgot to process your subscription request</strong>: to err is human, and your request might have been lost among many other messages! Resubmit your request before <a href="#contactadmin">contacting list owners directly</a>.[%END%]</li>
-			<li><strong>[%|helploc%]Subscription to the list is reserved to a certain category of people</strong>. To know more, <a href="#contactadmin">contact list owners</a>.[%END%]</li>
-		</ul>
+        <h4>[%|helploc%]You can not subscribe to a list[%END%]</h4>
+        <p>[%|helploc%]This problem may be due to the following reasons:[%END%]</p>
+        <ul>
+            <li><strong>[%|helploc%]The list owners forgot to process your subscription request</strong>: to err is human, and your request might have been lost among many other messages! Resubmit your request before <a href="#contactadmin">contacting list owners directly</a>.[%END%]</li>
+            <li><strong>[%|helploc%]Subscription to the list is reserved to a certain category of people</strong>. To know more, <a href="#contactadmin">contact list owners</a>.[%END%]</li>
+        </ul>
 
-		<h4>[%|helploc%]You can not log on to the mailing list web interface[%END%]</h4>
-		<p>[%|helploc%]This problem may be due to the following reasons:[%END%]</p>
-		<ul>
-			<li>[%|helploc%]<strong>You have no password</strong>. To be given a password, follow the <a href="../firstpasswd">First login?</a> link from the homepage. You will receive your new password by email.[%END%]</li>
-			<li>[%|helploc%]<strong>You entered an incorrect password</strong>. If you have forgotten your password, you can reset it. To do so, follow the <a href="../renewpasswd">Lost password?</a> link from the homepage.[%END%]</li>
+        <h4>[%|helploc%]You can not log on to the mailing list web interface[%END%]</h4>
+        <p>[%|helploc%]This problem may be due to the following reasons:[%END%]</p>
+        <ul>
+            <li>[%|helploc%]<strong>You have no password</strong>. To be given a password, follow the <a href="../firstpasswd">First login?</a> link from the homepage. You will receive your new password by email.[%END%]</li>
+            <li>[%|helploc%]<strong>You entered an incorrect password</strong>. If you have forgotten your password, you can reset it. To do so, follow the <a href="../renewpasswd">Lost password?</a> link from the homepage.[%END%]</li>
 
-			<li>[%|helploc%]<strong>You are not using the correct username</strong> (the email address with which you are subscribed to the list).[%END%]</li>
-		</ul>
-		<p class="retraitita">[%|helploc%]In order to avoid any mistake when typing your password, you can type it into another application (such as your email client) and copy and paste it into your web browser.[%END%]</p>
+            <li>[%|helploc%]<strong>You are not using the correct username</strong> (the email address with which you are subscribed to the list).[%END%]</li>
+        </ul>
+        <p class="retraitita">[%|helploc%]In order to avoid any mistake when typing your password, you can type it into another application (such as your email client) and copy and paste it into your web browser.[%END%]</p>
 
-		<h4>[%|helploc%]You do not receive (all) messages sent to a list[%END%]</h4>
-		<p>[%|helploc%]This problem can have multiple reasons:[%END%]</p>
-		<ul>
-			<li><a name="notsubscribedyet"></a><strong>[%|helploc%]You have never been subscribed to the list[%END%]</strong>: 
-			<ul>
-				<li>[%|helploc%]Maybe you made a mistake in your email address when you tried to subscribe.[%END%]</li>
-				<li>[%|helploc%]Maybe you are subscribed with an email address other than the one you are checking.[%END%]</li>
-				<li>[%|helploc%]Maybe your subscription request was rejected by the list owners.[%END%]</li>
-			</ul>
-			[%|helploc%]In any case, try and <a href="user#subscribe">subscribe</a> again.[%END%]</li>
-			<li><a name="notsubscribedanymore"></a><strong>[%|helploc%]You are not subscribed to the list anymore[%END%]</strong>:
-			<ul>
-				<li>[%|helploc%]If your address has been bouncing for a while, you might have been automatically unsubscribed by the system (or even by the list owners). Try and <a href="user#subscribe">subscribe again</a> after ensuring that your email address will not be in trouble again.[%END%]</li>
-				<li>[%|helploc%]If you have not respected the different rules applying to the mailing list, the list owners might have "banned" you...[%END%]</li>
-				<li>[%|helploc%]You might also have been arbitrarily unsubscribed by an ill-intentioned person, in case the list is not configured to send a confirmation request for any subscription and unsubscription request... In that case, try and <a href="user#subscribe">subscribe</a> again.[%END%]</li>
-			</ul>
-			<li>[%|helploc%]<strong>Your <a href="user#deliverymode">delivery mode</a> does not allow you to receive messages</strong>: for example, it is the case with the 'Nomail' delivery mode.[%END%]</li>
-			<li>[%|helploc%]<strong>Your inbox is full</strong>. Be careful: when your inbox is not completely full, you receive only small messages, which makes it difficult to understand what actually is the problem... Furthermore, if your email address causes trouble on a regular basis, you might be unsubscribed by the list owners or by the system. Thus, you should clean your inbox frequently.[%END%]</li>
-			<li>[%|helploc%]<strong>Your inbox is subject to some restrictions</strong>: it does not allow you to receive messages with attachments, bans some types of attachments or limits the maximum size of incoming messages; in that case, we advise you to choose the <a href="user#deliverymode">Urlize delivery mode</a>.[%END%]</li>
-		</ul>
-		
-		<!--Vérifier systèmes anti-virus, anti-spam-->
+        <h4>[%|helploc%]You do not receive (all) messages sent to a list[%END%]</h4>
+        <p>[%|helploc%]This problem can have multiple reasons:[%END%]</p>
+        <ul>
+            <li><a name="notsubscribedyet"></a><strong>[%|helploc%]You have never been subscribed to the list[%END%]</strong>: 
+            <ul>
+                <li>[%|helploc%]Maybe you made a mistake in your email address when you tried to subscribe.[%END%]</li>
+                <li>[%|helploc%]Maybe you are subscribed with an email address other than the one you are checking.[%END%]</li>
+                <li>[%|helploc%]Maybe your subscription request was rejected by the list owners.[%END%]</li>
+            </ul>
+            [%|helploc%]In any case, try and <a href="user#subscribe">subscribe</a> again.[%END%]</li>
+            <li><a name="notsubscribedanymore"></a><strong>[%|helploc%]You are not subscribed to the list anymore[%END%]</strong>:
+            <ul>
+                <li>[%|helploc%]If your address has been bouncing for a while, you might have been automatically unsubscribed by the system (or even by the list owners). Try and <a href="user#subscribe">subscribe again</a> after ensuring that your email address will not be in trouble again.[%END%]</li>
+                <li>[%|helploc%]If you have not respected the different rules applying to the mailing list, the list owners might have "banned" you...[%END%]</li>
+                <li>[%|helploc%]You might also have been arbitrarily unsubscribed by an ill-intentioned person, in case the list is not configured to send a confirmation request for any subscription and unsubscription request... In that case, try and <a href="user#subscribe">subscribe</a> again.[%END%]</li>
+            </ul>
+            <li>[%|helploc%]<strong>Your <a href="user#deliverymode">delivery mode</a> does not allow you to receive messages</strong>: for example, it is the case with the 'Nomail' delivery mode.[%END%]</li>
+            <li>[%|helploc%]<strong>Your inbox is full</strong>. Be careful: when your inbox is not completely full, you receive only small messages, which makes it difficult to understand what actually is the problem... Furthermore, if your email address causes trouble on a regular basis, you might be unsubscribed by the list owners or by the system. Thus, you should clean your inbox frequently.[%END%]</li>
+            <li>[%|helploc%]<strong>Your inbox is subject to some restrictions</strong>: it does not allow you to receive messages with attachments, bans some types of attachments or limits the maximum size of incoming messages; in that case, we advise you to choose the <a href="user#deliverymode">Urlize delivery mode</a>.[%END%]</li>
+        </ul>
+        
+        <!--Vérifier systèmes anti-virus, anti-spam-->
 
-		<h4>[%|helploc%]You can not send messages to a list[%END%]</h4>
-		<p>[%|helploc%]This problem can have multiple reasons:[%END%]</p>
-		<ul>
-			<li>[%|helploc%]<strong>You have <a href="#notsubscribedyet">never been subscribed</a></strong> to the list.[%END%]</li>
-			<li>[%|helploc%]<strong>You are <a href="#notsubscribedanymore">not subscribed to the list anymore</a></strong>.[%END%]</li>
-			<li>[%|helploc%]<strong>You are using another address</strong> than the one with which you are subscribed to the list.[%END%]</li>
-			<li>[%|helploc%]<strong>If the list is a moderated list, the distribution of the message depends on the moderators' availability</strong>: they can not monitor the list night and day! Thus the distribution of your message might be a bit delayed.[%END%]</li>
-			<li>[%|helploc(domain)%]<strong>If the list is a moderated list, your message might have been rejected by a moderator</strong>. In case you received no notice, you can possibly send a message to nameofthelist-request@%1 to ask for an explanation.[%END%]</li>
-			<li>[%|helploc%]<strong>The message you are trying to send does not fulfill the conditions to be distributed</strong> on the list: it may be too large, contain a forbidden type of attachment or even contain any type of attachment (in case attachments are forbidden on the list).[%END%]</li>
-			<li>[%|helploc%]<strong>The problem may also come from your email account</strong>:[%END%]
-			<ul>
-				<li>[%|helploc%]The mail server is temporarily unavailable.[%END%]</li>
-				<li>[%|helploc%]Your inbox is full and it prevents you from sending new messages.[%END%]</li>
-				<li>[%|helploc%]Your inbox is subject to some restrictions: it does not allow you to send messages with attachments, bans some types of attachments or limits the maximum size of outgoing messages.[%END%]</li>				
-			</ul></li>
-			<li>[%|helploc%]Last, <strong>you might have made a mistake in the list address</strong> when sending your message![%END%]</li>
-		</ul>
+        <h4>[%|helploc%]You can not send messages to a list[%END%]</h4>
+        <p>[%|helploc%]This problem can have multiple reasons:[%END%]</p>
+        <ul>
+            <li>[%|helploc%]<strong>You have <a href="#notsubscribedyet">never been subscribed</a></strong> to the list.[%END%]</li>
+            <li>[%|helploc%]<strong>You are <a href="#notsubscribedanymore">not subscribed to the list anymore</a></strong>.[%END%]</li>
+            <li>[%|helploc%]<strong>You are using another address</strong> than the one with which you are subscribed to the list.[%END%]</li>
+            <li>[%|helploc%]<strong>If the list is a moderated list, the distribution of the message depends on the moderators' availability</strong>: they can not monitor the list night and day! Thus the distribution of your message might be a bit delayed.[%END%]</li>
+            <li>[%|helploc(domain)%]<strong>If the list is a moderated list, your message might have been rejected by a moderator</strong>. In case you received no notice, you can possibly send a message to nameofthelist-request@%1 to ask for an explanation.[%END%]</li>
+            <li>[%|helploc%]<strong>The message you are trying to send does not fulfill the conditions to be distributed</strong> on the list: it may be too large, contain a forbidden type of attachment or even contain any type of attachment (in case attachments are forbidden on the list).[%END%]</li>
+            <li>[%|helploc%]<strong>The problem may also come from your email account</strong>:[%END%]
+            <ul>
+                <li>[%|helploc%]The mail server is temporarily unavailable.[%END%]</li>
+                <li>[%|helploc%]Your inbox is full and it prevents you from sending new messages.[%END%]</li>
+                <li>[%|helploc%]Your inbox is subject to some restrictions: it does not allow you to send messages with attachments, bans some types of attachments or limits the maximum size of outgoing messages.[%END%]</li>                
+            </ul></li>
+            <li>[%|helploc%]Last, <strong>you might have made a mistake in the list address</strong> when sending your message![%END%]</li>
+        </ul>
 
-		<h4>[%|helploc%]You can not unsubscribe from a list[%END%]</h4>
-		<p>[%|helploc%]This problem can have multiple reasons:[%END%]</p>
-		<ul>
-			<li>[%|helploc%]<strong>You are using another address</strong> than the one with which you are subscribed to the list.[%END%]</li>
-			<li>[%|helploc%]<strong>You are subscribed through a dynamic data source</strong> (examples: databases, <acronym lang="en" xml:lang="en" title="Lightweight Directory Access Protocol">LDAP</acronym> directories, etc.) which does not allow you to unsubscribe. <a href="#contactadmin">Contact the list owners</a> to know more about this.[%END%]</li>
-			<li>[%|helploc%]<strong>The list owners forgot to process your unsubscription request</strong>: to err is human, and your request might have been lost among many other messages! Resubmit your request before <a href="#contactadmin">contacting list owners directly</a>.[%END%]</li>
-		</ul>
+        <h4>[%|helploc%]You can not unsubscribe from a list[%END%]</h4>
+        <p>[%|helploc%]This problem can have multiple reasons:[%END%]</p>
+        <ul>
+            <li>[%|helploc%]<strong>You are using another address</strong> than the one with which you are subscribed to the list.[%END%]</li>
+            <li>[%|helploc%]<strong>You are subscribed through a dynamic data source</strong> (examples: databases, <acronym lang="en" xml:lang="en" title="Lightweight Directory Access Protocol">LDAP</acronym> directories, etc.) which does not allow you to unsubscribe. <a href="#contactadmin">Contact the list owners</a> to know more about this.[%END%]</li>
+            <li>[%|helploc%]<strong>The list owners forgot to process your unsubscription request</strong>: to err is human, and your request might have been lost among many other messages! Resubmit your request before <a href="#contactadmin">contacting list owners directly</a>.[%END%]</li>
+        </ul>
 
-		<h4><a name="contactadmin"></a>[%|helploc%]You want to contact list owners[%END%]</h4>
-		<p>[%|helploc(domain)%]The list owners and moderators' names are mentioned in the left menu. However, you should never write directly to a list owner or moderator: first, the person to whom you are writing might be absent, and furthermore, it is better to inform all owners and moderators of your request. When you have a question or remark, <strong>the address you should write to is: nameofthelist-request@%1</strong> (replace 'nameofthelist' by the name of the list).[%END%]</p>
+        <h4><a name="contactadmin"></a>[%|helploc%]You want to contact list owners[%END%]</h4>
+        <p>[%|helploc(domain)%]The list owners and moderators' names are mentioned in the left menu. However, you should never write directly to a list owner or moderator: first, the person to whom you are writing might be absent, and furthermore, it is better to inform all owners and moderators of your request. When you have a question or remark, <strong>the address you should write to is: nameofthelist-request@%1</strong> (replace 'nameofthelist' by the name of the list).[%END%]</p>
 <!-- end help_faquser.tt2 -->

--- a/default/web_tt2/help_introduction.tt2
+++ b/default/web_tt2/help_introduction.tt2
@@ -2,122 +2,122 @@
 
 <h2 class="block">[%|helploc%]Mailing lists - General introduction[%END%]</h2>
 
-	<h3>[%|helploc%]What is a mailing list?[%END%]</h3>
-	<p>[%|helploc%]A mailing list is a <strong>distribution list allowing a group of subscribers to automatically receive by email all messages sent to the list</strong>: every message sent to the list by a subscriber is received by all the other subscribers. When subscribed to a mailing list, it is possible to send messages, to reply to them or to read them without contributing (i.e. to "lurk").[%END%]</p>
-	<p>[%|helploc%]<strong>Special cases:</strong>[%END%]</p>
-	<ul>
-		<li>[%|helploc%]It is sometimes possible to send messages to a mailing lit without having subscribed to it. However, you need to be subscribed to a list to receive its messages.[%END%]</li>
-		<li>[%|helploc%]It is sometimes impossible to send messages to the list even though you are actually subscribed to it: it is the case for announcement lists, which are used to transmit information from a unique sender to a large number of recipients.[%END%]</li>
-	</ul>
-	
-	<h3>[%|helploc%]Interest of mailing lists[%END%]</h3>
-	<p>[%|helploc%]People subscribe to a mailing list (sometimes abbreviated in <acronym title="Mailing List">ML</acronym>) to <strong>be informed about a particular topic</strong> and to <strong>take part in exchanges about it</strong>. Examples are:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]mailing list for all the employees of a company;[%END%]</li>
-		<li>[%|helploc%]mailing list reserved to the participants in a project;[%END%]</li>
-		<li>[%|helploc%]mailing list dedicated to a class of students;[%END%]</li>
-		<li>[%|helploc%]mailing list about the latest news in computer security;[%END%]</li>
-		<li>[%|helploc%]mailing list of mutual aid between handymen;[%END%]</li>
-		<li>[%|helploc%]mailing list restricted to a family and dedicated to the organization of large family gatherings;[%END%]</li>
-		<li>[%|helploc%]and so on![%END%]</li>
-	</ul>
+    <h3>[%|helploc%]What is a mailing list?[%END%]</h3>
+    <p>[%|helploc%]A mailing list is a <strong>distribution list allowing a group of subscribers to automatically receive by email all messages sent to the list</strong>: every message sent to the list by a subscriber is received by all the other subscribers. When subscribed to a mailing list, it is possible to send messages, to reply to them or to read them without contributing (i.e. to "lurk").[%END%]</p>
+    <p>[%|helploc%]<strong>Special cases:</strong>[%END%]</p>
+    <ul>
+        <li>[%|helploc%]It is sometimes possible to send messages to a mailing lit without having subscribed to it. However, you need to be subscribed to a list to receive its messages.[%END%]</li>
+        <li>[%|helploc%]It is sometimes impossible to send messages to the list even though you are actually subscribed to it: it is the case for announcement lists, which are used to transmit information from a unique sender to a large number of recipients.[%END%]</li>
+    </ul>
+    
+    <h3>[%|helploc%]Interest of mailing lists[%END%]</h3>
+    <p>[%|helploc%]People subscribe to a mailing list (sometimes abbreviated in <acronym title="Mailing List">ML</acronym>) to <strong>be informed about a particular topic</strong> and to <strong>take part in exchanges about it</strong>. Examples are:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]mailing list for all the employees of a company;[%END%]</li>
+        <li>[%|helploc%]mailing list reserved to the participants in a project;[%END%]</li>
+        <li>[%|helploc%]mailing list dedicated to a class of students;[%END%]</li>
+        <li>[%|helploc%]mailing list about the latest news in computer security;[%END%]</li>
+        <li>[%|helploc%]mailing list of mutual aid between handymen;[%END%]</li>
+        <li>[%|helploc%]mailing list restricted to a family and dedicated to the organization of large family gatherings;[%END%]</li>
+        <li>[%|helploc%]and so on![%END%]</li>
+    </ul>
 
-	<h3>[%|helploc%]Types of mailing lists[%END%]</h3>
-	<p>[%|helploc%]There are <strong>thousands of mailing lists</strong> of all kinds on the Internet: public or private, free or not, with subscription subject to conditions or not, etc. Those lists may have from a dozen up to several thousand members.[%END%]</p>
-	<p>[%|helploc%]According to the way they work, we can distinguish between <strong>two types of lists</strong>:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>Announcements lists</strong> allow subscribers to receive messages without being allowed to post some themselves. In fact, those messages are newsletters: electronic magazines, daily services (daily horoscope, daily weather report, daily security alert, etc.), update notices about a website, etc. With this type of mailing list, the information flows from a unique sender to a large number of recipients.[%END%]</li>
-		<li>[%|helploc%]<strong>Discussion lists</strong> allow all subscribers to take part in exchanges. Those lists can be moderated or not:[%END%]
-		<ul>
-			<li>[%|helploc%]In a <strong>moderated discussion list</strong>, messages are transmitted to all subscribers after approval by one of the list moderators. Moderation is a token of quality for the list. For example, it ensures that subscribers will not receive off-topic messages, unsolicited commercial messages (spams), messages containing large attachments, etc.[%END%]</li>
-			<li>[%|helploc%]In a <strong>non moderated discussion list</strong>, messages are transmitted to all subscribers as soon as the mailing list management robot receives them.[%END%]</li>
-		</ul></li>
-	</ul>
+    <h3>[%|helploc%]Types of mailing lists[%END%]</h3>
+    <p>[%|helploc%]There are <strong>thousands of mailing lists</strong> of all kinds on the Internet: public or private, free or not, with subscription subject to conditions or not, etc. Those lists may have from a dozen up to several thousand members.[%END%]</p>
+    <p>[%|helploc%]According to the way they work, we can distinguish between <strong>two types of lists</strong>:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>Announcements lists</strong> allow subscribers to receive messages without being allowed to post some themselves. In fact, those messages are newsletters: electronic magazines, daily services (daily horoscope, daily weather report, daily security alert, etc.), update notices about a website, etc. With this type of mailing list, the information flows from a unique sender to a large number of recipients.[%END%]</li>
+        <li>[%|helploc%]<strong>Discussion lists</strong> allow all subscribers to take part in exchanges. Those lists can be moderated or not:[%END%]
+        <ul>
+            <li>[%|helploc%]In a <strong>moderated discussion list</strong>, messages are transmitted to all subscribers after approval by one of the list moderators. Moderation is a token of quality for the list. For example, it ensures that subscribers will not receive off-topic messages, unsolicited commercial messages (spams), messages containing large attachments, etc.[%END%]</li>
+            <li>[%|helploc%]In a <strong>non moderated discussion list</strong>, messages are transmitted to all subscribers as soon as the mailing list management robot receives them.[%END%]</li>
+        </ul></li>
+    </ul>
 
-	<h3><a name="features"></a>[%|helploc%]Features[%END%]</h3>
-	<p>[%|helploc%]Once subscribed to a mailing list service, you can:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>search for mailing lists</strong> matching your main interests or your particular situation;[%END%]</li>
-		<li>[%|helploc%]<strong>manage your subscriptions</strong>:[%END%]
-		<ul>
-			<li>[%|helploc%]<a href="user#subscribe">subscribe</a> to lists,[%END%]</li>
-			<li>[%|helploc%]<a href="user#unsubscribe">unsubscribe</a> from lists to which you are subscribed,[%END%]</li>
-			<li>[%|helploc%]change your <a href="user#options">subscriber options</a> list by list,[%END%]</li>
-			<li>[%|helploc%]change your <a href="user#pref">general preferences</a>, which apply to the whole mailing list environment (name, password, language of the mailing list web interface, etc.);[%END%]</li>
-		</ul></li>
-		<li><strong>[%|helploc%]use mailing lists[%END%]</strong>:
-		<ul>
-			<li>[%|helploc%]read the <a href="arc">online message archive of lists to which you are not subscribed</a> if that archive is public and if your personal rights allow you to access those lists,[%END%]</li>
-			<li>[%|helploc%]read the <a href="arc">archive of lists to which you are subscribed</a>,[%END%]</li>
-			<li>[%|helploc%]perform <a href="arc#arcsearch">searches in the list archive</a>,[%END%]</li>
-			<li>[%|helploc%]<a href="sendmsg">send messages</a> to lists to which you are subscribed,[%END%]</li>
-			<li>[%|helploc%]<a href="shared#shared_read">download documents</a> from the shared document web space,[%END%]</li>
-			<li>[%|helploc%]<a href="shared#shared_upload">upload documents</a> in the shared document web space;[%END%]</li>
-		</ul></li>
-		<li><strong>[%|helploc%]manage mailing lists[%END%]</strong>:
-		<ul>
-			<li>[%|helploc%]<a href="admin#create_list">create new lists</a> (restricted access) - subject to authorization,[%END%]</li>
-			<li>[%|helploc%]<a href="admin#edit_list">configure lists</a> you own,[%END%]</li>
-			<li>[%|helploc%]<a href="admin#manage_members">manage subscriptions</a>,[%END%]</li>
-			<li>[%|helploc%]<a href="admin#manage_shared">manage the shared document web space</a>,[%END%]</li>
-			<li>[%|helploc%]<a href="admin#moderate">moderate lists</a> for which you are a moderator.[%END%]</li>
-		</ul></li>
-	</ul>
+    <h3><a name="features"></a>[%|helploc%]Features[%END%]</h3>
+    <p>[%|helploc%]Once subscribed to a mailing list service, you can:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>search for mailing lists</strong> matching your main interests or your particular situation;[%END%]</li>
+        <li>[%|helploc%]<strong>manage your subscriptions</strong>:[%END%]
+        <ul>
+            <li>[%|helploc%]<a href="user#subscribe">subscribe</a> to lists,[%END%]</li>
+            <li>[%|helploc%]<a href="user#unsubscribe">unsubscribe</a> from lists to which you are subscribed,[%END%]</li>
+            <li>[%|helploc%]change your <a href="user#options">subscriber options</a> list by list,[%END%]</li>
+            <li>[%|helploc%]change your <a href="user#pref">general preferences</a>, which apply to the whole mailing list environment (name, password, language of the mailing list web interface, etc.);[%END%]</li>
+        </ul></li>
+        <li><strong>[%|helploc%]use mailing lists[%END%]</strong>:
+        <ul>
+            <li>[%|helploc%]read the <a href="arc">online message archive of lists to which you are not subscribed</a> if that archive is public and if your personal rights allow you to access those lists,[%END%]</li>
+            <li>[%|helploc%]read the <a href="arc">archive of lists to which you are subscribed</a>,[%END%]</li>
+            <li>[%|helploc%]perform <a href="arc#arcsearch">searches in the list archive</a>,[%END%]</li>
+            <li>[%|helploc%]<a href="sendmsg">send messages</a> to lists to which you are subscribed,[%END%]</li>
+            <li>[%|helploc%]<a href="shared#shared_read">download documents</a> from the shared document web space,[%END%]</li>
+            <li>[%|helploc%]<a href="shared#shared_upload">upload documents</a> in the shared document web space;[%END%]</li>
+        </ul></li>
+        <li><strong>[%|helploc%]manage mailing lists[%END%]</strong>:
+        <ul>
+            <li>[%|helploc%]<a href="admin#create_list">create new lists</a> (restricted access) - subject to authorization,[%END%]</li>
+            <li>[%|helploc%]<a href="admin#edit_list">configure lists</a> you own,[%END%]</li>
+            <li>[%|helploc%]<a href="admin#manage_members">manage subscriptions</a>,[%END%]</li>
+            <li>[%|helploc%]<a href="admin#manage_shared">manage the shared document web space</a>,[%END%]</li>
+            <li>[%|helploc%]<a href="admin#moderate">moderate lists</a> for which you are a moderator.[%END%]</li>
+        </ul></li>
+    </ul>
 
-	<h3><a name="roles"></a>[%|helploc%]How the mailing list service works: roles and responsibilities[%END%]</h3>
+    <h3><a name="roles"></a>[%|helploc%]How the mailing list service works: roles and responsibilities[%END%]</h3>
 
-	<p>[%|helploc%]A mailing list service involves four types of roles:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>listmaster;</strong>[%END%]</li>
-		<li>[%|helploc%]<strong>owner;</strong>[%END%]</li>
-		<li>[%|helploc%]<strong>moderator;</strong>[%END%]</li>
-		<li>[%|helploc%]<strong>subscriber.</strong>[%END%]</li>
-	</ul>
-	<p>[%|helploc%]It is possible to have several roles at once (for example, you can be an owner and a moderator of a list and be subscribed to several others).[%END%]</p>
-	
-	<h4>[%|helploc%]Listmasters[%END%]</h4>
-	<p>[%|helploc%]Listmasters are in charge of the <strong>management of the mailing list service</strong>. Their duties:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>manage the mailing list server</strong> (deployment, maintenance, etc.);[%END%]</li>
-		<li>[%|helploc%]<strong>define the general orientations of the mailing list service</strong>:[%END%]
-		<ul>
-			<li>[%|helploc%]who will be allowed to ask for the creation of a new list,[%END%]</li>
-			<li>[%|helploc%]which options will be available to manage lists (scenario definition),[%END%]</li>
-			<li>[%|helploc%]what the default files will contain (creation of templates),[%END%]</li>
-			<li>[%|helploc%]what will the mailing list web interface look like;[%END%]</li>
-		</ul></li>
-		<li>[%|helploc%]<strong>set the way the mailing list service should be used</strong> and <strong>document those rules through providing charters</strong> to subscribers, moderators and owners;[%END%]</li>
-		<li>[%|helploc%]<strong>approve of requests of mailing list creations</strong>;[%END%]</li>
-		<li>[%|helploc%]<strong>temporarily replace list owners</strong> when necessary; on the other hand, listmasters are not supposed to take the place of moderators.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]<strong>List owners and moderators can turn to listmasters</strong> when they face a problem not dealt with by the documentation or for any comment. However, in order not to flood listmasters with messages, it is recommended that subscribers rather turn to list owners.[%END%]</p>
-	
-	<h4>[%|helploc%]Owners[%END%]</h4>
-	<p>[%|helploc%]<strong>The list owner is generally its creator</strong> or, failing him/her, the person who requested the list creation or who became responsible for it. <strong>His/her role</strong>:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>define the <a href="admin#edit_list">way the list will be used</a></strong>;[%END%]</li>
-		<li>[%|helploc%]<strong> write a <a href="admin#charter">list charter</a></strong> aimed at subscribers;[%END%]</li>
-		<li>[%|helploc%]<strong>appoint one or several <a href="listconfig#description">moderators</a></strong>;[%END%]</li>
-		<li>[%|helploc%]<strong>manage <a href="admin#manage_members">subscriptions and unsubscriptions</a></strong>;[%END%]</li>
-		<li>[%|helploc%]<strong>decide whether it is relevant to put a <a href="admin#manage_shared">shared document web space</a></strong> at the subscribers' disposal;[%END%]</li>
-		<li>[%|helploc%]<strong>answer questions from subscribers and potential subscribers about the list;</strong>[%END%]</li>
-		<li>[%|helploc%]etc.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]A list can have several owners. However, the <strong>'Privileged' profile</strong> is reserved to the list's creator; other owners have a 'Normal' profile, which has fewer prerogatives.[%END%]</p>
+    <p>[%|helploc%]A mailing list service involves four types of roles:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>listmaster;</strong>[%END%]</li>
+        <li>[%|helploc%]<strong>owner;</strong>[%END%]</li>
+        <li>[%|helploc%]<strong>moderator;</strong>[%END%]</li>
+        <li>[%|helploc%]<strong>subscriber.</strong>[%END%]</li>
+    </ul>
+    <p>[%|helploc%]It is possible to have several roles at once (for example, you can be an owner and a moderator of a list and be subscribed to several others).[%END%]</p>
+    
+    <h4>[%|helploc%]Listmasters[%END%]</h4>
+    <p>[%|helploc%]Listmasters are in charge of the <strong>management of the mailing list service</strong>. Their duties:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>manage the mailing list server</strong> (deployment, maintenance, etc.);[%END%]</li>
+        <li>[%|helploc%]<strong>define the general orientations of the mailing list service</strong>:[%END%]
+        <ul>
+            <li>[%|helploc%]who will be allowed to ask for the creation of a new list,[%END%]</li>
+            <li>[%|helploc%]which options will be available to manage lists (scenario definition),[%END%]</li>
+            <li>[%|helploc%]what the default files will contain (creation of templates),[%END%]</li>
+            <li>[%|helploc%]what will the mailing list web interface look like;[%END%]</li>
+        </ul></li>
+        <li>[%|helploc%]<strong>set the way the mailing list service should be used</strong> and <strong>document those rules through providing charters</strong> to subscribers, moderators and owners;[%END%]</li>
+        <li>[%|helploc%]<strong>approve of requests of mailing list creations</strong>;[%END%]</li>
+        <li>[%|helploc%]<strong>temporarily replace list owners</strong> when necessary; on the other hand, listmasters are not supposed to take the place of moderators.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]<strong>List owners and moderators can turn to listmasters</strong> when they face a problem not dealt with by the documentation or for any comment. However, in order not to flood listmasters with messages, it is recommended that subscribers rather turn to list owners.[%END%]</p>
+    
+    <h4>[%|helploc%]Owners[%END%]</h4>
+    <p>[%|helploc%]<strong>The list owner is generally its creator</strong> or, failing him/her, the person who requested the list creation or who became responsible for it. <strong>His/her role</strong>:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>define the <a href="admin#edit_list">way the list will be used</a></strong>;[%END%]</li>
+        <li>[%|helploc%]<strong> write a <a href="admin#charter">list charter</a></strong> aimed at subscribers;[%END%]</li>
+        <li>[%|helploc%]<strong>appoint one or several <a href="listconfig#description">moderators</a></strong>;[%END%]</li>
+        <li>[%|helploc%]<strong>manage <a href="admin#manage_members">subscriptions and unsubscriptions</a></strong>;[%END%]</li>
+        <li>[%|helploc%]<strong>decide whether it is relevant to put a <a href="admin#manage_shared">shared document web space</a></strong> at the subscribers' disposal;[%END%]</li>
+        <li>[%|helploc%]<strong>answer questions from subscribers and potential subscribers about the list;</strong>[%END%]</li>
+        <li>[%|helploc%]etc.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]A list can have several owners. However, the <strong>'Privileged' profile</strong> is reserved to the list's creator; other owners have a 'Normal' profile, which has fewer prerogatives.[%END%]</p>
 
-	<h4>[%|helploc%]Moderators[%END%]</h4>
+    <h4>[%|helploc%]Moderators[%END%]</h4>
 
-	<p>[%|helploc%]<strong>Moderators are appointed by the list owner</strong>. They are <strong>in charge of <a href="admin#moderate">controlling the relevancy of the messages</a></strong> sent to the list: after reading them, <strong>they choose to accept or to reject them </strong>. Moderation occurs before the message is actually sent to subscribers. Rejection of a message is possibly followed by a notice to the sender in order to explain the reason for that rejection.[%END%]</p>
-	<p>[%|helploc%]A list can have <strong>one or several moderators</strong>; generally, the list owner is also a moderator.[%END%]</p>
-	<p>[%|helploc%]This concerns only moderated lists.[%END%]</p>
+    <p>[%|helploc%]<strong>Moderators are appointed by the list owner</strong>. They are <strong>in charge of <a href="admin#moderate">controlling the relevancy of the messages</a></strong> sent to the list: after reading them, <strong>they choose to accept or to reject them </strong>. Moderation occurs before the message is actually sent to subscribers. Rejection of a message is possibly followed by a notice to the sender in order to explain the reason for that rejection.[%END%]</p>
+    <p>[%|helploc%]A list can have <strong>one or several moderators</strong>; generally, the list owner is also a moderator.[%END%]</p>
+    <p>[%|helploc%]This concerns only moderated lists.[%END%]</p>
 
-	<h3><a name="policy"></a>[%|helploc%]Regulatory framework[%END%]</h3>
-	<p>[%|helploc%]The use of a mailing list service means respecting a number of rules:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]In most mailing list services, subscribers receive a 'List subscribers charter' on subscription. Then they are obliged to respect all the rules contained in that charter.[%END%]</li>
-		<li>[%|helploc%]If available, list owners and moderators have to conform to the 'Owner and moderator charter'.[%END%]</li>
-		<li>[%|helploc%]The use of mailing lists naturally means respecting the rules of good practices as regards to email.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]To know more, refer to the section dedicated to <a href="sendmsg#rulesuser">good practices for subscribers</a> and to the section about <a href="admin#rulesadmin">good practices for owners and moderators</a>.[%END%]</p>
-	<hr />
+    <h3><a name="policy"></a>[%|helploc%]Regulatory framework[%END%]</h3>
+    <p>[%|helploc%]The use of a mailing list service means respecting a number of rules:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]In most mailing list services, subscribers receive a 'List subscribers charter' on subscription. Then they are obliged to respect all the rules contained in that charter.[%END%]</li>
+        <li>[%|helploc%]If available, list owners and moderators have to conform to the 'Owner and moderator charter'.[%END%]</li>
+        <li>[%|helploc%]The use of mailing lists naturally means respecting the rules of good practices as regards to email.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]To know more, refer to the section dedicated to <a href="sendmsg#rulesuser">good practices for subscribers</a> and to the section about <a href="admin#rulesadmin">good practices for owners and moderators</a>.[%END%]</p>
+    <hr />
 <!-- end help_introduction.tt2 -->

--- a/default/web_tt2/help_listconfig.tt2
+++ b/default/web_tt2/help_listconfig.tt2
@@ -1,177 +1,177 @@
 <!-- help_listconfig.tt2 -->
 
-	<h2 class="block"><a name="listconfig"></a>[%|helploc%]Configuring the list[%END%]</h2>
-	<p>[%|helploc%]As the list configuration is quite complex, it is divided in several parts with a separate page for each part:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<a href="#description">List definition</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#sending">Sending/receiving</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#command">Privileges</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#archives">Archive</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#bounces">Bounces</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="#other">Miscellaneous</a>.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]We advise you to <strong>make configuration changes very progressively</strong>: thus, if the result does not match your expectations, it will be easier to backtrack.[%END%]</p>
-	<p>[%|helploc%]The list administration module offers you <strong>many options to configure your list</strong>. However, these options might not match your own needs perfectly. To cure this problem, you can <strong>ask the listmasters to create new options</strong> (within the limits of what they can do, naturally...): access and/or rights limited to some categories of people according to the place they log on from, the domain of their email address, the user group they belong to, etc.[%END%]</p>
+    <h2 class="block"><a name="listconfig"></a>[%|helploc%]Configuring the list[%END%]</h2>
+    <p>[%|helploc%]As the list configuration is quite complex, it is divided in several parts with a separate page for each part:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<a href="#description">List definition</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#sending">Sending/receiving</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#command">Privileges</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#archives">Archive</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#bounces">Bounces</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="#other">Miscellaneous</a>.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]We advise you to <strong>make configuration changes very progressively</strong>: thus, if the result does not match your expectations, it will be easier to backtrack.[%END%]</p>
+    <p>[%|helploc%]The list administration module offers you <strong>many options to configure your list</strong>. However, these options might not match your own needs perfectly. To cure this problem, you can <strong>ask the listmasters to create new options</strong> (within the limits of what they can do, naturally...): access and/or rights limited to some categories of people according to the place they log on from, the domain of their email address, the user group they belong to, etc.[%END%]</p>
 
-	<h3><a name="description"></a>[%|helploc%]List definition[%END%]</h3>
-	<p>[%|helploc%]In the '<strong>Subject of the list</strong>' area, you can change the subject you had chosen when creating the list. This subject displays as a header for all the list pages, and is also be visible on list index pages (list of lists, list of your subscriptions, etc.) and in the browser title bar.[%END%]</p>
-	<p>[%|helploc%]You can also change the '<strong>Visibility of the list</strong>'. The options available are the following:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]conceal except for subscribers (conceal) - <em>default option</em>;[%END%]</li>
-		<li>[%|helploc%]intranet access (intranet);[%END%]</li>
-		<li>[%|helploc%]no conceal (noconceal);[%END%]</li>
-		<li>[%|helploc%]conceal even for subscribers (secret);[%END%]</li>
-	</ul>
-	<p class="retraitita">[%|helploc%]If you want to limit the list visibility according to other criteria, you should ask the listmasters: they may be able to create a new option matching your needs (example: list visible only by members of a user group, of an Internet domain, etc.).[%END%]</p>
-	<p>[%|helploc%]In the 'Owners' and 'Moderators' areas, you can <strong>add owners and moderators</strong> to the list or <strong>change their personal information</strong>:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]For each owner/moderator, you have to indicate an <strong>email address</strong> and a <strong>name</strong>.[%END%]</li>
-		<li>[%|helploc%]You can also add the information of your choice in the '<strong>Private information</strong>' input box (phone number, function, etc.); this information will only be accessible by listmasters and list owners with a 'Privileged' profile.[%END%]</li>
-		<li>[%|helploc%]You can change the <strong>message delivery mode</strong> (the only options available on this page are 'mail' and 'nomail').[%END%]</li>
-		<li>[%|helploc%]The 'Profile' parameter can not be changed: the <strong>'Privileged' profile</strong> is reserved to the list creator (other owners have a 'Normal' profile).[%END%]</li>
-	</ul>
-	<p class="retraitita">[%|helploc%]Be careful: becoming owner or moderator of a list does not mean that you are automatically subscribed to that list. Thus owners and moderators have to subscribe themselves to the list.[%END%]</p>
-	<p>[%|helploc%]To <strong>delete owners/moderators</strong>, clear the content of the input boxes relating to the person you want to delete and click on the 'Update' button.[%END%]</p>
-	<p>[%|helploc%]You can also change the <strong>list topic</strong> as well as its <strong>language</strong>. If you change the list language, all predefined messages will be sent in the chosen language (be careful: subject to the availability of a translation!).[%END%]</p>
-	<p>[%|helploc%]You can not change the <strong>Internet domain</strong> of the list: only the listmasters can change this parameter.[%END%]</p>
-	<p>[%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
+    <h3><a name="description"></a>[%|helploc%]List definition[%END%]</h3>
+    <p>[%|helploc%]In the '<strong>Subject of the list</strong>' area, you can change the subject you had chosen when creating the list. This subject displays as a header for all the list pages, and is also be visible on list index pages (list of lists, list of your subscriptions, etc.) and in the browser title bar.[%END%]</p>
+    <p>[%|helploc%]You can also change the '<strong>Visibility of the list</strong>'. The options available are the following:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]conceal except for subscribers (conceal) - <em>default option</em>;[%END%]</li>
+        <li>[%|helploc%]intranet access (intranet);[%END%]</li>
+        <li>[%|helploc%]no conceal (noconceal);[%END%]</li>
+        <li>[%|helploc%]conceal even for subscribers (secret);[%END%]</li>
+    </ul>
+    <p class="retraitita">[%|helploc%]If you want to limit the list visibility according to other criteria, you should ask the listmasters: they may be able to create a new option matching your needs (example: list visible only by members of a user group, of an Internet domain, etc.).[%END%]</p>
+    <p>[%|helploc%]In the 'Owners' and 'Moderators' areas, you can <strong>add owners and moderators</strong> to the list or <strong>change their personal information</strong>:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]For each owner/moderator, you have to indicate an <strong>email address</strong> and a <strong>name</strong>.[%END%]</li>
+        <li>[%|helploc%]You can also add the information of your choice in the '<strong>Private information</strong>' input box (phone number, function, etc.); this information will only be accessible by listmasters and list owners with a 'Privileged' profile.[%END%]</li>
+        <li>[%|helploc%]You can change the <strong>message delivery mode</strong> (the only options available on this page are 'mail' and 'nomail').[%END%]</li>
+        <li>[%|helploc%]The 'Profile' parameter can not be changed: the <strong>'Privileged' profile</strong> is reserved to the list creator (other owners have a 'Normal' profile).[%END%]</li>
+    </ul>
+    <p class="retraitita">[%|helploc%]Be careful: becoming owner or moderator of a list does not mean that you are automatically subscribed to that list. Thus owners and moderators have to subscribe themselves to the list.[%END%]</p>
+    <p>[%|helploc%]To <strong>delete owners/moderators</strong>, clear the content of the input boxes relating to the person you want to delete and click on the 'Update' button.[%END%]</p>
+    <p>[%|helploc%]You can also change the <strong>list topic</strong> as well as its <strong>language</strong>. If you change the list language, all predefined messages will be sent in the chosen language (be careful: subject to the availability of a translation!).[%END%]</p>
+    <p>[%|helploc%]You can not change the <strong>Internet domain</strong> of the list: only the listmasters can change this parameter.[%END%]</p>
+    <p>[%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
 
-	<h3><a name="sending"></a>[%|helploc%]Sending/receiving[%END%]</h3>
-	<p>[%|helploc%]From this page, you can <strong>decide who will be allowed to post messages on the list</strong>.[%END%]</p>
-	<p>[%|helploc%]In the '<strong>Digest frequency</strong>' area, you can define how frequently compiled messages are sent (Digest and Summary delivery modes): in the list, select all the <strong>days</strong> for which you want digests to be sent. Then choose a <strong>delivery time</strong> for digests (please avoid choosing a time between 11 p.m. and midnight).[%END%]</p>
-	<p>[%|helploc%]In the '<strong>Available subscription options</strong>' list, select all the subscriber options you want to offer to your subscribers. By default, all options are selected.[%END%]</p>
-	<p>[%|helploc%]The '<strong>Reply address</strong>' area allows you to define the default recipients of any reply to a message sent to the list:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]With the '<strong>All</strong>' value, the reply is sent to both the <strong>message sender</strong> AND the <strong>list</strong>.[%END%]</li>
-		<li>[%|helploc%]With the '<strong>List</strong>' value, the reply is sent to the <strong>list</strong>.[%END%]<br />
-		<p class="retraitita">[%|helploc%]Be careful: use this option carefully! Experience shows that subscribers do not always check the address to which they send their reply. Thus, they might send private messages to the whole list when trying to reply to a single person...[%END%]</p></li>
-		<li>[%|helploc%]With the '<strong>Other_email</strong>' value, the reply is sent to a <strong>predefined address</strong>. If you choose this option, you will have to <strong>indicate an email address in the 'Other email address' input box</strong>.[%END%]</li>
-		<li>[%|helploc%]With the '<strong>Sender</strong>' value, the reply is sent to the <strong>message sender</strong>. This is the option you should probably choose.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]The '<strong>Respect of existing header field</strong>' drop-down list allows you to choose how the 'Reply-To' SMTP header field will be processed in incoming messages. The '<strong>Respect</strong>' option preserves that field while the '<strong>Forced</strong>' option allows it to be overwritten.[%END%]</p>
-	<p>[%|helploc%]Last, the '<strong>Subject tagging</strong>' option lets you choose the <strong>text included before the subject of all messages</strong> sent to the list: this allows subscribers to sort their messages easily, to use message filters on them in order to process messages automatically, etc. By default, this text consists of the <strong>list name surrounded by square brackets</strong> (the square brackets are automatically added by the system, thus it is useless that you add them yourself).[%END%]</p>
-	<p>[%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
+    <h3><a name="sending"></a>[%|helploc%]Sending/receiving[%END%]</h3>
+    <p>[%|helploc%]From this page, you can <strong>decide who will be allowed to post messages on the list</strong>.[%END%]</p>
+    <p>[%|helploc%]In the '<strong>Digest frequency</strong>' area, you can define how frequently compiled messages are sent (Digest and Summary delivery modes): in the list, select all the <strong>days</strong> for which you want digests to be sent. Then choose a <strong>delivery time</strong> for digests (please avoid choosing a time between 11 p.m. and midnight).[%END%]</p>
+    <p>[%|helploc%]In the '<strong>Available subscription options</strong>' list, select all the subscriber options you want to offer to your subscribers. By default, all options are selected.[%END%]</p>
+    <p>[%|helploc%]The '<strong>Reply address</strong>' area allows you to define the default recipients of any reply to a message sent to the list:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]With the '<strong>All</strong>' value, the reply is sent to both the <strong>message sender</strong> AND the <strong>list</strong>.[%END%]</li>
+        <li>[%|helploc%]With the '<strong>List</strong>' value, the reply is sent to the <strong>list</strong>.[%END%]<br />
+        <p class="retraitita">[%|helploc%]Be careful: use this option carefully! Experience shows that subscribers do not always check the address to which they send their reply. Thus, they might send private messages to the whole list when trying to reply to a single person...[%END%]</p></li>
+        <li>[%|helploc%]With the '<strong>Other_email</strong>' value, the reply is sent to a <strong>predefined address</strong>. If you choose this option, you will have to <strong>indicate an email address in the 'Other email address' input box</strong>.[%END%]</li>
+        <li>[%|helploc%]With the '<strong>Sender</strong>' value, the reply is sent to the <strong>message sender</strong>. This is the option you should probably choose.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]The '<strong>Respect of existing header field</strong>' drop-down list allows you to choose how the 'Reply-To' SMTP header field will be processed in incoming messages. The '<strong>Respect</strong>' option preserves that field while the '<strong>Forced</strong>' option allows it to be overwritten.[%END%]</p>
+    <p>[%|helploc%]Last, the '<strong>Subject tagging</strong>' option lets you choose the <strong>text included before the subject of all messages</strong> sent to the list: this allows subscribers to sort their messages easily, to use message filters on them in order to process messages automatically, etc. By default, this text consists of the <strong>list name surrounded by square brackets</strong> (the square brackets are automatically added by the system, thus it is useless that you add them yourself).[%END%]</p>
+    <p>[%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
 
-	<h3><a name="command"></a>[%|helploc%]Privileges[%END%]</h3>
-	<p>[%|helploc%]From this page, you can decide:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>who can view list information</strong>. The following options are available:[%END%]
-		<ul>
-			<li>[%|helploc%]for anyone (open) - <em>default option</em>;[%END%]</li>
-			<li>[%|helploc%]restricted to subscribers (private).[%END%]</li>
-		</ul></li>
-		<li><strong>[%|helploc%]who can subscribe to the list</strong>. The following options are available:[%END%]
-		<ul>
-			<li>[%|helploc%]subscription request confirmed (auth);[%END%]</li>
-			<li>[%|helploc%]need authentication (notification is sent to owners) (auth_notify);[%END%]</li>
-			<li>[%|helploc%]requires authentication then owner approval (auth_owner);[%END%]</li>
-			<li>[%|helploc%]subscribe is impossible (closed);[%END%]</li>
-			<li>[%|helploc%]restricted to local domain users (intranet);[%END%]</li>
-			<li>[%|helploc%]local domain users or owner approval (intranetorowner);[%END%]</li>
-			<li>[%|helploc%]for anyone without authentication (open) - <em>default option</em>;[%END%]</li>
-			<li>[%|helploc%]anyone, notification is sent to list owner (open_notify);[%END%]</li>
-			<li>[%|helploc%]anyone, no welcome message (open_quiet);[%END%]</li>
-			<li>[%|helploc%]owner approval (owner);[%END%]</li>
-			<li>[%|helploc%]requires S/MIME signed (smime);[%END%]</li>
-			<li>[%|helploc%]requires S/MIME signed or owner approval (smimeorowner).[%END%]<br />
-			<span class="retraitita">[%|helploc%]You should always choose an option involving the 'auth' parameter: this way, the system requires confirmation from the future subscriber by email before subscribing him/her to the list. This avoids subscriptions with invalid email addresses and guarantees that no one can be subscribed to the list without knowing it.[%END%]</span></li></ul></li>
-		<li>[%|helploc%]<strong>who can unsubscribe from the list</strong>. The following options are available:[%END%]
-		<ul>
-			<li>[%|helploc%]need authentication (auth);[%END%]</li>
-			<li>[%|helploc%]authentication requested, notification sent to owner (auth_notify);[%END%]</li>
-			<li>[%|helploc%]impossible (closed);[%END%]</li>
-			<li>[%|helploc%]open (open) - <em>default option</em>;[%END%]</li>
-			<li>[%|helploc%]open with mail confirmation, owner is notified (open_notify);[%END%]</li>
-			<li>[%|helploc%]owner approval (owner).[%END%]<br />
-			<p class="retraitita">[%|helploc%]You should always choose an option involving the 'auth' parameter: this way, the system requires confirmation from the subscriber by email before unsubscribing him/her from the list. This prevents ill-intentioned people from unsubscribing others without letting them know.[%END%]</p></li>
-		</ul></li>
-		<li><strong>[%|helploc%]who can invite people to subscribe to the list</strong>. The following options are available:[%END%]
-		<ul>
-			<li>[%|helploc%]closed (closed);[%END%]</li>
-			<li>[%|helploc%]list owner, no authentication (owner);[%END%]</li>
-			<li>[%|helploc%]restricted to subscribers (private) - <em>default option</em>;[%END%]</li>
-			<li>[%|helploc%]public (public).[%END%]</li>
-		</ul></li>
-		<li>[%|helploc%]<strong>who can review subscribers</strong>. The following options are available:[%END%]
-		<ul>
-			<li>[%|helploc%]no one can review (closed);[%END%]</li>
-			<li>[%|helploc%]restricted to subscribers or local domain users (intranet);[%END%]</li>
-			<li>[%|helploc%]listmaster only (listmaster);[%END%]</li>
-			<li>[%|helploc%]only owner (and listmaster) (owner) - <em>default option</em>;[%END%]</li>
-			<li>[%|helploc%]restricted to subscribers (private);[%END%]</li>
-			<li>[%|helploc%]anyone can do it! (public).[%END%]<br />
-			<span class="retraitita">[%|helploc%]You should in no case make the members list accessible to anyone. The 'Restricted to subscribers' option may be interesting in order to allow subscribers to communicate with each others without posting messages on the list. However, this is not appropriate in the case of an announcement list involving subscribers having no particular relationship.[%END%]</span></li>
-		</ul></li>
-	</ul>
-	<p><a name="docsrights"></a>[%|helploc%]From this page, you can also <strong>define the access rights applying to the shared document web space</strong> ('Shared documents' section of the list, accessible through a link in the left menu). You can define both the read and write access rights for the documents: [%END%]</p>
-	<ul>
-		<li>[%|helploc%]The following options are available in the '<strong>Who can view</strong>' drop-down list:[%END%]
-		<ul>
-			<li>[%|helploc%]restricted to subscribers or local domain users (intranet);[%END%]</li>
-			<li>[%|helploc%]restricted to list owners (owner);[%END%]</li>
-			<li>[%|helploc%]restricted to subscribers (private) - <em>default option</em>;[%END%]</li>
-			<li>[%|helploc%]public documents (public).[%END%]</li>
-		</ul></li>
-		<li>[%|helploc%]The following options are available in the '<strong>Who can edit</strong>' drop-down list:[%END%]
-		<ul>
-			<li>[%|helploc%]restricted to list owners (owner) - <em>default option</em>;[%END%]</li>
-			<li>[%|helploc%]moderated for subscribers (editor);[%END%]</li>
-			<li>[%|helploc%]restricted to subscribers (private);[%END%]</li>
-			<li>[%|helploc%]public documents (public).[%END%]</li>
-		</ul></li>
-	</ul>
-	<p>[%|helploc%]The '<strong>Quota</strong>' input box allows you to define a <strong>maximum size not to be exceeded for the shared document web space</strong>. This size does not represent the maximum size of <em class="caps">one</em> document published in the shared document web space, but the maximum size for all documents published on the list. It is expressed in kilobytes. When a subscriber tries to publish a too large document regarding the space left, he/she gets an error message.[%END%]</p>
-	<p>[%|helploc%]To know <strong>more about the management of the shared document web space</strong> (how to organize it, change access rights, name documents, etc.), please refer to the '<a href="shared">Using the shared document web space</a>' section of the User guide.[%END%]</p>
-	<p>[%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
+    <h3><a name="command"></a>[%|helploc%]Privileges[%END%]</h3>
+    <p>[%|helploc%]From this page, you can decide:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>who can view list information</strong>. The following options are available:[%END%]
+        <ul>
+            <li>[%|helploc%]for anyone (open) - <em>default option</em>;[%END%]</li>
+            <li>[%|helploc%]restricted to subscribers (private).[%END%]</li>
+        </ul></li>
+        <li><strong>[%|helploc%]who can subscribe to the list</strong>. The following options are available:[%END%]
+        <ul>
+            <li>[%|helploc%]subscription request confirmed (auth);[%END%]</li>
+            <li>[%|helploc%]need authentication (notification is sent to owners) (auth_notify);[%END%]</li>
+            <li>[%|helploc%]requires authentication then owner approval (auth_owner);[%END%]</li>
+            <li>[%|helploc%]subscribe is impossible (closed);[%END%]</li>
+            <li>[%|helploc%]restricted to local domain users (intranet);[%END%]</li>
+            <li>[%|helploc%]local domain users or owner approval (intranetorowner);[%END%]</li>
+            <li>[%|helploc%]for anyone without authentication (open) - <em>default option</em>;[%END%]</li>
+            <li>[%|helploc%]anyone, notification is sent to list owner (open_notify);[%END%]</li>
+            <li>[%|helploc%]anyone, no welcome message (open_quiet);[%END%]</li>
+            <li>[%|helploc%]owner approval (owner);[%END%]</li>
+            <li>[%|helploc%]requires S/MIME signed (smime);[%END%]</li>
+            <li>[%|helploc%]requires S/MIME signed or owner approval (smimeorowner).[%END%]<br />
+            <span class="retraitita">[%|helploc%]You should always choose an option involving the 'auth' parameter: this way, the system requires confirmation from the future subscriber by email before subscribing him/her to the list. This avoids subscriptions with invalid email addresses and guarantees that no one can be subscribed to the list without knowing it.[%END%]</span></li></ul></li>
+        <li>[%|helploc%]<strong>who can unsubscribe from the list</strong>. The following options are available:[%END%]
+        <ul>
+            <li>[%|helploc%]need authentication (auth);[%END%]</li>
+            <li>[%|helploc%]authentication requested, notification sent to owner (auth_notify);[%END%]</li>
+            <li>[%|helploc%]impossible (closed);[%END%]</li>
+            <li>[%|helploc%]open (open) - <em>default option</em>;[%END%]</li>
+            <li>[%|helploc%]open with mail confirmation, owner is notified (open_notify);[%END%]</li>
+            <li>[%|helploc%]owner approval (owner).[%END%]<br />
+            <p class="retraitita">[%|helploc%]You should always choose an option involving the 'auth' parameter: this way, the system requires confirmation from the subscriber by email before unsubscribing him/her from the list. This prevents ill-intentioned people from unsubscribing others without letting them know.[%END%]</p></li>
+        </ul></li>
+        <li><strong>[%|helploc%]who can invite people to subscribe to the list</strong>. The following options are available:[%END%]
+        <ul>
+            <li>[%|helploc%]closed (closed);[%END%]</li>
+            <li>[%|helploc%]list owner, no authentication (owner);[%END%]</li>
+            <li>[%|helploc%]restricted to subscribers (private) - <em>default option</em>;[%END%]</li>
+            <li>[%|helploc%]public (public).[%END%]</li>
+        </ul></li>
+        <li>[%|helploc%]<strong>who can review subscribers</strong>. The following options are available:[%END%]
+        <ul>
+            <li>[%|helploc%]no one can review (closed);[%END%]</li>
+            <li>[%|helploc%]restricted to subscribers or local domain users (intranet);[%END%]</li>
+            <li>[%|helploc%]listmaster only (listmaster);[%END%]</li>
+            <li>[%|helploc%]only owner (and listmaster) (owner) - <em>default option</em>;[%END%]</li>
+            <li>[%|helploc%]restricted to subscribers (private);[%END%]</li>
+            <li>[%|helploc%]anyone can do it! (public).[%END%]<br />
+            <span class="retraitita">[%|helploc%]You should in no case make the members list accessible to anyone. The 'Restricted to subscribers' option may be interesting in order to allow subscribers to communicate with each others without posting messages on the list. However, this is not appropriate in the case of an announcement list involving subscribers having no particular relationship.[%END%]</span></li>
+        </ul></li>
+    </ul>
+    <p><a name="docsrights"></a>[%|helploc%]From this page, you can also <strong>define the access rights applying to the shared document web space</strong> ('Shared documents' section of the list, accessible through a link in the left menu). You can define both the read and write access rights for the documents: [%END%]</p>
+    <ul>
+        <li>[%|helploc%]The following options are available in the '<strong>Who can view</strong>' drop-down list:[%END%]
+        <ul>
+            <li>[%|helploc%]restricted to subscribers or local domain users (intranet);[%END%]</li>
+            <li>[%|helploc%]restricted to list owners (owner);[%END%]</li>
+            <li>[%|helploc%]restricted to subscribers (private) - <em>default option</em>;[%END%]</li>
+            <li>[%|helploc%]public documents (public).[%END%]</li>
+        </ul></li>
+        <li>[%|helploc%]The following options are available in the '<strong>Who can edit</strong>' drop-down list:[%END%]
+        <ul>
+            <li>[%|helploc%]restricted to list owners (owner) - <em>default option</em>;[%END%]</li>
+            <li>[%|helploc%]moderated for subscribers (editor);[%END%]</li>
+            <li>[%|helploc%]restricted to subscribers (private);[%END%]</li>
+            <li>[%|helploc%]public documents (public).[%END%]</li>
+        </ul></li>
+    </ul>
+    <p>[%|helploc%]The '<strong>Quota</strong>' input box allows you to define a <strong>maximum size not to be exceeded for the shared document web space</strong>. This size does not represent the maximum size of <em class="caps">one</em> document published in the shared document web space, but the maximum size for all documents published on the list. It is expressed in kilobytes. When a subscriber tries to publish a too large document regarding the space left, he/she gets an error message.[%END%]</p>
+    <p>[%|helploc%]To know <strong>more about the management of the shared document web space</strong> (how to organize it, change access rights, name documents, etc.), please refer to the '<a href="shared">Using the shared document web space</a>' section of the User guide.[%END%]</p>
+    <p>[%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
 
-	<h3><a name="archives"></a>[%|helploc%]Archive[%END%]</h3>
-	<p>[%|helploc%]From this page, you can <strong>decide who can access the online list archive</strong> (messages readable on the mailing list web interface). The following options are available:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]closed (closed);[%END%]</li>
-		<li>[%|helploc%]restricted to local domain users (intranet);[%END%]</li>
-		<li>[%|helploc%]listmaster (listmaster);[%END%]</li>
-		<li>[%|helploc%]owner (owner);[%END%]</li>
-		<li>[%|helploc%]moderator (moderator);[%END%]</li>
-		<li>[%|helploc%]subscribers only (private);[%END%]</li>
-		<li>[%|helploc%]public (public).[%END%]</li>
-	</ul>
-	<p>[%|helploc%]The '<strong>Quota</strong>' input box allows you to define a <strong>maximum size not to be exceeded for the message archive</strong>. This size is expressed in kilobytes. List owners are notified when the archive size reaches 95&#160;% of the allowed size. When the maximum size is reached, later messages are not archived.[%END%]<br />
-	<p class="retraitita">[%|helploc%]Even though messages stop being archived, it is naturally still possible to send messages to the list.[%END%]</p>
-	<p>[%|helploc(conf.email,domain)%]It is also possible to <strong>access the list archive by email</strong>, by sending <strong>%1@%2</strong> the following command: <span class="commande"><strong>GET nameofthelist year-month</strong></span> (example: <em class="example">GET list_example 2016-07</em>). Then you receive a compilation of all messages sent during the chosen month. This compilation is sent in plain text and contains <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym> tags instead of the original formatting; it also involves full headers for each message. The '<strong>Text archives</strong>' parameter allows you to define:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>who is allowed</strong> to receive the list message archive by email;[%END%]</li>
-		<li>[%|helploc%]<strong>how frequently these archive files will be created</strong>. For example, if the frequency is set to 'month', all messages distributed to the list in a month will be gathered in a single archive file.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]If this parameter is not defined, the list will have no archive accessible by email. Be careful: <strong>only the listmasters have the power to change this parameter.</strong>[%END%]</p>
-	<p>[%|helploc%]It is possible to send <strong>messages encrypted in <acronym lang="en" xml:lang="en" title="Secure/Multipurpose Internet Mail Extensions">S/MIME</acronym></strong> to the list. The '<strong>Archive encrypted mails as cleartext</strong>' option allows you to define how those messages will be archived:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]The '<strong>Decrypted</strong>' option archives the message after removing the encryption.[%END%]</li>
-		<li>[%|helploc%]The '<strong>Original</strong>' option archives the message under its original encrypted form.[%END%]</li>
-	</ul>
-<p class="retraita">[%|helploc%]This option applies to both the text archive and the online archive, as well as to the compilations sent to those who chose the 'Digest' delivery mode.[%END%]</p>	
-	<p><strong>[%|helploc%]BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
+    <h3><a name="archives"></a>[%|helploc%]Archive[%END%]</h3>
+    <p>[%|helploc%]From this page, you can <strong>decide who can access the online list archive</strong> (messages readable on the mailing list web interface). The following options are available:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]closed (closed);[%END%]</li>
+        <li>[%|helploc%]restricted to local domain users (intranet);[%END%]</li>
+        <li>[%|helploc%]listmaster (listmaster);[%END%]</li>
+        <li>[%|helploc%]owner (owner);[%END%]</li>
+        <li>[%|helploc%]moderator (moderator);[%END%]</li>
+        <li>[%|helploc%]subscribers only (private);[%END%]</li>
+        <li>[%|helploc%]public (public).[%END%]</li>
+    </ul>
+    <p>[%|helploc%]The '<strong>Quota</strong>' input box allows you to define a <strong>maximum size not to be exceeded for the message archive</strong>. This size is expressed in kilobytes. List owners are notified when the archive size reaches 95&#160;% of the allowed size. When the maximum size is reached, later messages are not archived.[%END%]<br />
+    <p class="retraitita">[%|helploc%]Even though messages stop being archived, it is naturally still possible to send messages to the list.[%END%]</p>
+    <p>[%|helploc(conf.email,domain)%]It is also possible to <strong>access the list archive by email</strong>, by sending <strong>%1@%2</strong> the following command: <span class="commande"><strong>GET nameofthelist year-month</strong></span> (example: <em class="example">GET list_example 2016-07</em>). Then you receive a compilation of all messages sent during the chosen month. This compilation is sent in plain text and contains <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym> tags instead of the original formatting; it also involves full headers for each message. The '<strong>Text archives</strong>' parameter allows you to define:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>who is allowed</strong> to receive the list message archive by email;[%END%]</li>
+        <li>[%|helploc%]<strong>how frequently these archive files will be created</strong>. For example, if the frequency is set to 'month', all messages distributed to the list in a month will be gathered in a single archive file.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]If this parameter is not defined, the list will have no archive accessible by email. Be careful: <strong>only the listmasters have the power to change this parameter.</strong>[%END%]</p>
+    <p>[%|helploc%]It is possible to send <strong>messages encrypted in <acronym lang="en" xml:lang="en" title="Secure/Multipurpose Internet Mail Extensions">S/MIME</acronym></strong> to the list. The '<strong>Archive encrypted mails as cleartext</strong>' option allows you to define how those messages will be archived:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]The '<strong>Decrypted</strong>' option archives the message after removing the encryption.[%END%]</li>
+        <li>[%|helploc%]The '<strong>Original</strong>' option archives the message under its original encrypted form.[%END%]</li>
+    </ul>
+<p class="retraita">[%|helploc%]This option applies to both the text archive and the online archive, as well as to the compilations sent to those who chose the 'Digest' delivery mode.[%END%]</p>    
+    <p><strong>[%|helploc%]BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
 
-	<h3><a name="bounces"></a>[%|helploc%]Bounces[%END%]</h3>
-	<p>[%|helploc%]"<strong>Bounces</strong>" represent the <strong>subscribers whose address is in error</strong>, i.e. subscribers who can not receive the messages sent to the list. This can be due to many reasons: obsolete email addresses, addresses temporarily unavailable when messages were sent, inbox quota exceeded, etc.[%END%]</p>
-	<p>[%|helploc%]The '<strong>Bounce management</strong>' section defines two rates:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]The <strong>warn rate</strong> indicates the bouncing email addresses rate from which the list owner will receive a <strong>notice entitled 'Bounce rate too high'</strong> inviting him/her to delete bouncing subscribers from the list.[%END%]</li>
-		<li>[%|helploc%]The <strong>halt rate</strong> indicates the bouncing email addresses rate from which <strong>the message distribution will automatically be stopped</strong> up to the resolution of the problem (generally through the deletion of bouncing subscribers).[%END%]</li>
-	</ul>
-	<p><a name="bouncers"></a>[%|helploc%]The '<strong>Management of bouncers, 1st level</strong>' and '<strong>Management of bouncers, 2nd level</strong>' sections allow you to perform automatic tasks with regard to bouncing subscribers. You can define:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]the <strong>score ranges that define level&#160;1 and level&#160;2 bouncers</strong>. By default, level&#160;1 bouncers have a score comprised between 45 and 74 and level&#160;2 bouncers have a score comprised between 75 and 100;[%END%]<br />
-		<p class="retraitita">[%|helploc%]The score depends on the number, type and frequency of errors. If the bouncing time is too short or if there have not been many errors, the bouncer is not given a score.[%END%]</p></li> 
-		<li>[%|helploc%]the <strong>task to perform towards the subscribers concerned</strong>: no task, notice, deletion from the list;[%END%]</li>
-		<li>[%|helploc%]the <strong>person to be notified</strong> when a task is carried out: no one, the list owners, the listmasters. The notice sent when a task is carried out involves the names of all the subscribers concerned as well as precise information about the task.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]<strong>To manage bounces</strong> (reset errors for some subscribers, unsubscribe bouncing subscribers, request a subscription reminder, etc.), <strong>go to the '<a href="admin#manage_bounces">Bounces</a>' page</strong> of the list administration module.[%END%]</p>
-	<p><strong>[%|helploc%]BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
+    <h3><a name="bounces"></a>[%|helploc%]Bounces[%END%]</h3>
+    <p>[%|helploc%]"<strong>Bounces</strong>" represent the <strong>subscribers whose address is in error</strong>, i.e. subscribers who can not receive the messages sent to the list. This can be due to many reasons: obsolete email addresses, addresses temporarily unavailable when messages were sent, inbox quota exceeded, etc.[%END%]</p>
+    <p>[%|helploc%]The '<strong>Bounce management</strong>' section defines two rates:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]The <strong>warn rate</strong> indicates the bouncing email addresses rate from which the list owner will receive a <strong>notice entitled 'Bounce rate too high'</strong> inviting him/her to delete bouncing subscribers from the list.[%END%]</li>
+        <li>[%|helploc%]The <strong>halt rate</strong> indicates the bouncing email addresses rate from which <strong>the message distribution will automatically be stopped</strong> up to the resolution of the problem (generally through the deletion of bouncing subscribers).[%END%]</li>
+    </ul>
+    <p><a name="bouncers"></a>[%|helploc%]The '<strong>Management of bouncers, 1st level</strong>' and '<strong>Management of bouncers, 2nd level</strong>' sections allow you to perform automatic tasks with regard to bouncing subscribers. You can define:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]the <strong>score ranges that define level&#160;1 and level&#160;2 bouncers</strong>. By default, level&#160;1 bouncers have a score comprised between 45 and 74 and level&#160;2 bouncers have a score comprised between 75 and 100;[%END%]<br />
+        <p class="retraitita">[%|helploc%]The score depends on the number, type and frequency of errors. If the bouncing time is too short or if there have not been many errors, the bouncer is not given a score.[%END%]</p></li> 
+        <li>[%|helploc%]the <strong>task to perform towards the subscribers concerned</strong>: no task, notice, deletion from the list;[%END%]</li>
+        <li>[%|helploc%]the <strong>person to be notified</strong> when a task is carried out: no one, the list owners, the listmasters. The notice sent when a task is carried out involves the names of all the subscribers concerned as well as precise information about the task.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]<strong>To manage bounces</strong> (reset errors for some subscribers, unsubscribe bouncing subscribers, request a subscription reminder, etc.), <strong>go to the '<a href="admin#manage_bounces">Bounces</a>' page</strong> of the list administration module.[%END%]</p>
+    <p><strong>[%|helploc%]BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
 
-	<h3><a name="other"></a>[%|helploc%]Miscellaneous[%END%]</h3>
-	<p>[%|helploc%]The '<strong>Periodical subscription expiration task</strong>' option allows you to define an <strong>automatic expiration deadline for subscriptions</strong> to the list: on a regular basis (example: once a year), subscribers will receive a message asking them to renew their subscription to the list. If they don't, they will automatically be unsubscribed. This procedure ensures that all people subscribed to the list are really concerned and interested.[%END%]</p>
-	<p>[%|helploc%]The '<strong>Periodical subscription reminder task</strong>' option allows you to <strong>send subscription reminders</strong> to list members on a regular basis.[%END%]</p>
-	<p>[%|helploc%]The '<strong>email address protection method</strong>' option ensures that the subscribers' email addresses will not be collected by robots for spamming purposes. This option applies to all the list pages.[%END%]</p>
-	<p>[%|helploc%]On this page, you can also view <strong>information about the last update of the list</strong> (who made it and when), as well as the <strong>number of configuration change</strong> since the list was created.[%END%]</p>
-	<p>[%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
+    <h3><a name="other"></a>[%|helploc%]Miscellaneous[%END%]</h3>
+    <p>[%|helploc%]The '<strong>Periodical subscription expiration task</strong>' option allows you to define an <strong>automatic expiration deadline for subscriptions</strong> to the list: on a regular basis (example: once a year), subscribers will receive a message asking them to renew their subscription to the list. If they don't, they will automatically be unsubscribed. This procedure ensures that all people subscribed to the list are really concerned and interested.[%END%]</p>
+    <p>[%|helploc%]The '<strong>Periodical subscription reminder task</strong>' option allows you to <strong>send subscription reminders</strong> to list members on a regular basis.[%END%]</p>
+    <p>[%|helploc%]The '<strong>email address protection method</strong>' option ensures that the subscribers' email addresses will not be collected by robots for spamming purposes. This option applies to all the list pages.[%END%]</p>
+    <p>[%|helploc%]On this page, you can also view <strong>information about the last update of the list</strong> (who made it and when), as well as the <strong>number of configuration change</strong> since the list was created.[%END%]</p>
+    <p>[%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]</p>
 <!-- end help_listconfig.tt2 -->

--- a/default/web_tt2/help_mail_commands.tt2
+++ b/default/web_tt2/help_mail_commands.tt2
@@ -1,73 +1,73 @@
 <!-- help_mail_commands.tt2 -->
 
-	<h2>[%|helploc%]List of the commands of the Sympa mail interface[%END%]</h2>
+<h2>[%|helploc%]List of the commands of the Sympa mail interface[%END%]</h2>
 
 <p>[%|helploc(conf.email,domain)%]All commands are to be sent at %1@%2.[%END%]</p>
 
 <p>[%|helploc%]It is possible to send several commands in a single message. Commands are to be entered in the message body (one command per line).[%END%]</p>
 
-	<h3>[%|helploc%]Commands for users[%END%]</h3>
+<h3>[%|helploc%]Commands for users[%END%]</h3>
 
 <p>
-<dl>
-<dd>[%|helploc%]<code>HELP</code>: receive a list of all available commands[%END%]</dd>
-<dd>[%|helploc%]<code>LISTS</code>: receive a list of all lists managed on the server[%END%]</dd>
-<dd>[%|helploc%]<code>WHICH</code>: receive a list of all lists to which you are subscribed[%END%]</dd>
-<dd>[%|helploc%]<code>CONFIRM <em>key</em></code>: confirm sending of a message (according to the way the list is configured)[%END%]</dd>
-<dd>[%|helploc%]<code>QUIT</code>: indicates the end of the commands (used to ignore a signature)[%END%]</dd>
-</dl>
+    <dl>
+        <dd>[%|helploc%]<code>HELP</code>: receive a list of all available commands[%END%]</dd>
+        <dd>[%|helploc%]<code>LISTS</code>: receive a list of all lists managed on the server[%END%]</dd>
+        <dd>[%|helploc%]<code>WHICH</code>: receive a list of all lists to which you are subscribed[%END%]</dd>
+        <dd>[%|helploc%]<code>CONFIRM <em>key</em></code>: confirm sending of a message (according to the way the list is configured)[%END%]</dd>
+        <dd>[%|helploc%]<code>QUIT</code>: indicates the end of the commands (used to ignore a signature)[%END%]</dd>
+    </dl>
 
-<br/>
+    <br/>
 
-<dl>
-<dd>[%|helploc%]<code>INFO <em>list</em></code>: get information about the list[%END%]</dd>
-<dd>[%|helploc%]<code>REVIEW <em>list</em></code>: receive a list of all list members[%END%]</dd>
-<dd>[%|helploc%]<code>SUBSCRIBE <em>list name</em></code>: subscription (or subscription confirmation) to the list[%END%]</dd>
-<dd>[%|helploc%]<code>INVITE <em>list email</em></code>: invite someone to subscribe to the list[%END%]</dd>
-<dd>[%|helploc%]<code>UNSUBSCRIBE <em>list email</em></code>: unsubscribe from the list. The email address is required only if you want to unsubscribe with an address other than the address with which you send the message[%END%]</dd>
-<dd>[%|helploc%]<code>UNSUBSCRIBE * <em>email</em></code>: unsubscribe from all the lists to which you are subscribed[%END%]</dd>
-</dl>
+    <dl>
+        <dd>[%|helploc%]<code>INFO <em>list</em></code>: get information about the list[%END%]</dd>
+        <dd>[%|helploc%]<code>REVIEW <em>list</em></code>: receive a list of all list members[%END%]</dd>
+        <dd>[%|helploc%]<code>SUBSCRIBE <em>list name</em></code>: subscription (or subscription confirmation) to the list[%END%]</dd>
+        <dd>[%|helploc%]<code>INVITE <em>list email</em></code>: invite someone to subscribe to the list[%END%]</dd>
+        <dd>[%|helploc%]<code>UNSUBSCRIBE <em>list email</em></code>: unsubscribe from the list. The email address is required only if you want to unsubscribe with an address other than the address with which you send the message[%END%]</dd>
+        <dd>[%|helploc%]<code>UNSUBSCRIBE * <em>email</em></code>: unsubscribe from all the lists to which you are subscribed[%END%]</dd>
+    </dl>
 
-<br/>
+    <br/>
 
-<dl>
-<dd>[%|helploc%]<code>SET <em>list</em> NOMAIL</code>: suspend receipt of the list's messages[%END%]</dd>
-<dd>[%|helploc%]<code>SET <em>list</em> DIGEST</code>: receive messages in digest mode[%END%]</dd>
-<dd>[%|helploc%]<code>SET <em>list</em> DIGESTPLAIN</code>: receive messages in digest mode (plain text)[%END%]</dd>
-<dd>[%|helploc%]<code>SET <em>list</em> SUMMARY</code>: only receive the message list[%END%]</dd>
-<dd>[%|helploc%]<code>SET <em>list</em> NOTICE</code>: only receive the message subjects[%END%]</dd>
-<dd>[%|helploc%]<code>SET <em>list</em> MAIL</code>: normal message delivery mode[%END%]</dd>
-<dd>[%|helploc%]<code>SET <em>list</em> CONCEAL</code>: become unlisted (hidden subscriber address)[%END%]</dd>
-<dd>[%|helploc%]<code>SET <em>list</em> NOCONCEAL</code>: subscriber address visible via REView[%END%]</dd>
-</dl>
+    <dl>
+        <dd>[%|helploc%]<code>SET <em>list</em> NOMAIL</code>: suspend receipt of the list's messages[%END%]</dd>
+        <dd>[%|helploc%]<code>SET <em>list</em> DIGEST</code>: receive messages in digest mode[%END%]</dd>
+        <dd>[%|helploc%]<code>SET <em>list</em> DIGESTPLAIN</code>: receive messages in digest mode (plain text)[%END%]</dd>
+        <dd>[%|helploc%]<code>SET <em>list</em> SUMMARY</code>: only receive the message list[%END%]</dd>
+        <dd>[%|helploc%]<code>SET <em>list</em> NOTICE</code>: only receive the message subjects[%END%]</dd>
+        <dd>[%|helploc%]<code>SET <em>list</em> MAIL</code>: normal message delivery mode[%END%]</dd>
+        <dd>[%|helploc%]<code>SET <em>list</em> CONCEAL</code>: become unlisted (hidden subscriber address)[%END%]</dd>
+        <dd>[%|helploc%]<code>SET <em>list</em> NOCONCEAL</code>: subscriber address visible via REView[%END%]</dd>
+    </dl>
 
-<br/>
+    <br/>
 
-<dl>
-<dd>[%|helploc%]<code>INDEX <em>list</em></code>: receive the list of the archive files[%END%]</dd>
-<dd>[%|helploc%]<code>GET <em>list file</em></code>: receive a file of the list archive[%END%]</dd>
-<dd>[%|helploc%]<code>LAST <em>list</em></code>: receive the list's most recent message[%END%]</dd>
-</dl>
+    <dl>
+        <dd>[%|helploc%]<code>INDEX <em>list</em></code>: receive the list of the archive files[%END%]</dd>
+        <dd>[%|helploc%]<code>GET <em>list file</em></code>: receive a file of the list archive[%END%]</dd>
+        <dd>[%|helploc%]<code>LAST <em>list</em></code>: receive the list's most recent message[%END%]</dd>
+    </dl>
 </p>
 
-	<h3>[%|helploc%]Commands for list owners[%END%]</h3>
+<h3>[%|helploc%]Commands for list owners[%END%]</h3>
 
 <p>
-<dl>
-<dd>[%|helploc%]<code>ADD <em>list email name</em></code>: add a member to the list[%END%]</dd>
-<dd>[%|helploc%]<code>DEL <em>list email</em></code>: remove a subscriber from the list[%END%]</dd>
-<dd>[%|helploc%]<code>STATS <em>list</em></code>: check the statistics for the list[%END%]</dd>
-<dd>[%|helploc%]<code>REMIND <em>list</em></code>: send to all subscribers a personalized reminder with the address with which he/she is subscribed to the list[%END%]</dd>
-</dl>
+    <dl>
+        <dd>[%|helploc%]<code>ADD <em>list email name</em></code>: add a member to the list[%END%]</dd>
+        <dd>[%|helploc%]<code>DEL <em>list email</em></code>: remove a subscriber from the list[%END%]</dd>
+        <dd>[%|helploc%]<code>STATS <em>list</em></code>: check the statistics for the list[%END%]</dd>
+        <dd>[%|helploc%]<code>REMIND <em>list</em></code>: send to all subscribers a personalized reminder with the address with which he/she is subscribed to the list[%END%]</dd>
+    </dl>
 </p>
 
-	<h3>[%|helploc%]Commands for list moderators[%END%]</h3>
+<h3>[%|helploc%]Commands for list moderators[%END%]</h3>
 
 <p>
-<dl>
-<dd>[%|helploc%]<code>DISTRIBUTE <em>list key</em></code>: approve of a message[%END%]</dd>
-<dd>[%|helploc%]<code>REJECT <em>list key</em></code>: reject a message to be moderated[%END%]</dd>
-<dd>[%|helploc%]<code>MODINDEX <em>list</em></code>: check the list of messages to be moderated[%END%]</dd>
-</dl>
+    <dl>
+        <dd>[%|helploc%]<code>DISTRIBUTE <em>list key</em></code>: approve of a message[%END%]</dd>
+        <dd>[%|helploc%]<code>REJECT <em>list key</em></code>: reject a message to be moderated[%END%]</dd>
+        <dd>[%|helploc%]<code>MODINDEX <em>list</em></code>: check the list of messages to be moderated[%END%]</dd>
+    </dl>
 </p>
 <!-- end help_mail_commands.tt2 -->

--- a/default/web_tt2/help_sendmsg.tt2
+++ b/default/web_tt2/help_sendmsg.tt2
@@ -1,54 +1,54 @@
 <!-- help_sendmsg.tt2 -->
 
-	<h3 class="block"><a name="sendmsg"></a>[%|helploc%]Sending a message[%END%]</h3>
-	<p>[%|helploc%]When you are subscribed to a list, you receive all messages subscribers send. You can reply to those messages or send some yourself.[%END%]</p>
-	
-	<h4>[%|helploc%]Sending a message with an email client[%END%]</h4>
-	<p>[%|helploc(domain)%]To send a new message, it is very simple: <strong>from your email client or a webmail, send a message to the list address</strong>. This address consists of the list name followed by the suffix '@%1' (example: <em class="example">psycho_cognitive(@)%1</em>).[%END%]</p>
-	<p class="retraitita">[%|helploc%]Be careful: you need to send the message from the address with which you subscribed to the list, otherwise, your message might be rejected.[%END%]</p>
+    <h3 class="block"><a name="sendmsg"></a>[%|helploc%]Sending a message[%END%]</h3>
+    <p>[%|helploc%]When you are subscribed to a list, you receive all messages subscribers send. You can reply to those messages or send some yourself.[%END%]</p>
+    
+    <h4>[%|helploc%]Sending a message with an email client[%END%]</h4>
+    <p>[%|helploc(domain)%]To send a new message, it is very simple: <strong>from your email client or a webmail, send a message to the list address</strong>. This address consists of the list name followed by the suffix '@%1' (example: <em class="example">psycho_cognitive(@)%1</em>).[%END%]</p>
+    <p class="retraitita">[%|helploc%]Be careful: you need to send the message from the address with which you subscribed to the list, otherwise, your message might be rejected.[%END%]</p>
 
-	<h4>[%|helploc%]Sending a message from the mailing list environment[%END%]</h4>
-	<p>[%|helploc%]<strong>You can also</strong> log on to the mailing list environment, <strong>go to the information page of the list</strong> to which you want to send a message and <strong>click on the 'Post' link</strong> in the left menu.[%END%]</p>
-	<p class="retraitita">[%|helploc%]This method is not very flexible: from the mailing list web interface, you can not add or change some recipients, add an attachment or format the messages you send.[%END%]</p>
+    <h4>[%|helploc%]Sending a message from the mailing list environment[%END%]</h4>
+    <p>[%|helploc%]<strong>You can also</strong> log on to the mailing list environment, <strong>go to the information page of the list</strong> to which you want to send a message and <strong>click on the 'Post' link</strong> in the left menu.[%END%]</p>
+    <p class="retraitita">[%|helploc%]This method is not very flexible: from the mailing list web interface, you can not add or change some recipients, add an attachment or format the messages you send.[%END%]</p>
 
-	<h4>[%|helploc%]Replying to a message[%END%]</h4>
-	<p>[%|helploc%]To reply to a message sent to a list, do as for any message that would have been sent to you in private. However, be careful: <strong>some lists are configured to send any reply to the list by default</strong>, i.e. to all the subscribers. If you only want to reply to the message sender, <strong>make sure the recipient of your message is the right one</strong>![%END%]</p>
-	<p>[%|helploc%]You can also reply to a message directly <a href="#answeronline">from the mailing list environment</a>. However, it is far simpler and more functional to reply using an email client or a webmail...[%END%]</p>
+    <h4>[%|helploc%]Replying to a message[%END%]</h4>
+    <p>[%|helploc%]To reply to a message sent to a list, do as for any message that would have been sent to you in private. However, be careful: <strong>some lists are configured to send any reply to the list by default</strong>, i.e. to all the subscribers. If you only want to reply to the message sender, <strong>make sure the recipient of your message is the right one</strong>![%END%]</p>
+    <p>[%|helploc%]You can also reply to a message directly <a href="#answeronline">from the mailing list environment</a>. However, it is far simpler and more functional to reply using an email client or a webmail...[%END%]</p>
 
-	<h4><a name="rulesuser"></a>[%|helploc%]A few rules[%END%]</h4>
-	<p>[%|helploc%]Sending messages to a list makes you liable as an author. Furthermore, if you send a message to a list, it will be read by all the subscribers and you are likely to strike up conversations with them. Thus, to use the mailing list service within the law and share pleasant and respectful exchanges, you have to respect a comprehensive set of rules.[%END%]</p>
+    <h4><a name="rulesuser"></a>[%|helploc%]A few rules[%END%]</h4>
+    <p>[%|helploc%]Sending messages to a list makes you liable as an author. Furthermore, if you send a message to a list, it will be read by all the subscribers and you are likely to strike up conversations with them. Thus, to use the mailing list service within the law and share pleasant and respectful exchanges, you have to respect a comprehensive set of rules.[%END%]</p>
 
-	<h5>[%|helploc%]Before you start writing to a list[%END%]</h5>
-	<p>[%|helploc%]It is better to always <strong>respect an observation period</strong> of a few days after subscribing, prior to sending any message. This will allow you to gather useful information in order not to make a blunder:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]Who can send messages to the list?[%END%]</li>
-		<li>[%|helploc%]How frequently can you send messages without disturbing the other subscribers?[%END%]</li>
-		<li>[%|helploc%]What are the topics discussed?[%END%]</li>
-		<li>[%|helploc%]Are off-topic messages tolerated?[%END%]</li>
-		<li>[%|helploc%]What is the tone used? Is it allowed to joke or is the list very formal?[%END%]</li>
-		<li>[%|helploc%]Is the sending of attachments allowed/tolerated? Within what limits?[%END%]</li>
-	</ul>
-	<p>[%|helploc%]<strong>Some lists require subscribers to introduce themselves to the other contributors</strong> at the time of their subscription, others on the first message sent to the list, and a third category (most generally the largest lists) consider this to be useless and annoying... Study the uses and take appropriate action![%END%]</p>
+    <h5>[%|helploc%]Before you start writing to a list[%END%]</h5>
+    <p>[%|helploc%]It is better to always <strong>respect an observation period</strong> of a few days after subscribing, prior to sending any message. This will allow you to gather useful information in order not to make a blunder:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]Who can send messages to the list?[%END%]</li>
+        <li>[%|helploc%]How frequently can you send messages without disturbing the other subscribers?[%END%]</li>
+        <li>[%|helploc%]What are the topics discussed?[%END%]</li>
+        <li>[%|helploc%]Are off-topic messages tolerated?[%END%]</li>
+        <li>[%|helploc%]What is the tone used? Is it allowed to joke or is the list very formal?[%END%]</li>
+        <li>[%|helploc%]Is the sending of attachments allowed/tolerated? Within what limits?[%END%]</li>
+    </ul>
+    <p>[%|helploc%]<strong>Some lists require subscribers to introduce themselves to the other contributors</strong> at the time of their subscription, others on the first message sent to the list, and a third category (most generally the largest lists) consider this to be useless and annoying... Study the uses and take appropriate action![%END%]</p>
 
-	<h5>[%|helploc%]Privacy[%END%]</h5>
-	<p>[%|helploc%]All messages sent to the list are kept in the list archive. <strong>Thus, the simple fact of sending a message constitutes an express authorization of distribution and reproduction in the archive</strong>. However, you can request the deletion of any message you sent, whether directly from the list archive ('Tag this mail for deletion' button) or by <a href="faquser#contactadmin">contacting the list owners</a>.[%END%]</p>
-	<p>[%|helploc%]If you send a message to the list, <strong>your email address will naturally display in your message header and in the list archive</strong>. However, unless otherwise specified, your email address and the other data you provided when you subscribed will not be disclosed to any other third party without your agreement.[%END%]</p>
-	<p class="retraitita">[%|helploc%]In most countries, your personal data is protected through a number of laws. For example, in the United States, the Privacy Act of 1974 applies. In the European Union, the "Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data" and national laws arising from it apply. To know more about this, <a href="faquser#contactadmin">please contact the list owners</a>.[%END%]</p>
-	<p>[%|helploc%]As for any correspondence, <strong>you must sign your messages</strong>. On professional mailing lists, <strong>it is customary to mention the name of the organization you belong to and your job title alongside your name</strong>. However, <strong>ask yourself whether it is relevant to give your complete details</strong> (address, telephone number, etc.): they will remain available at any time in the list archive...[%END%]</p>
-	<p>[%|helploc%]<strong>Do never send information about other people without their express agreement</strong>.[%END%]</p>
+    <h5>[%|helploc%]Privacy[%END%]</h5>
+    <p>[%|helploc%]All messages sent to the list are kept in the list archive. <strong>Thus, the simple fact of sending a message constitutes an express authorization of distribution and reproduction in the archive</strong>. However, you can request the deletion of any message you sent, whether directly from the list archive ('Tag this mail for deletion' button) or by <a href="faquser#contactadmin">contacting the list owners</a>.[%END%]</p>
+    <p>[%|helploc%]If you send a message to the list, <strong>your email address will naturally display in your message header and in the list archive</strong>. However, unless otherwise specified, your email address and the other data you provided when you subscribed will not be disclosed to any other third party without your agreement.[%END%]</p>
+    <p class="retraitita">[%|helploc%]In most countries, your personal data is protected through a number of laws. For example, in the United States, the Privacy Act of 1974 applies. In the European Union, the "Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data" and national laws arising from it apply. To know more about this, <a href="faquser#contactadmin">please contact the list owners</a>.[%END%]</p>
+    <p>[%|helploc%]As for any correspondence, <strong>you must sign your messages</strong>. On professional mailing lists, <strong>it is customary to mention the name of the organization you belong to and your job title alongside your name</strong>. However, <strong>ask yourself whether it is relevant to give your complete details</strong> (address, telephone number, etc.): they will remain available at any time in the list archive...[%END%]</p>
+    <p>[%|helploc%]<strong>Do never send information about other people without their express agreement</strong>.[%END%]</p>
 
-	<h5>[%|helploc%]Good practices[%END%]</h5>
-	<p>[%|helploc%]<strong>When asking a question on a list</strong>, it is customary to post a summary of all answers obtained.[%END%]</p>
-	<p>[%|helploc%]<strong>When you reply to a message sent on the list</strong>, it is up to you to decide whether you will reply on the list or in private. This might depend on the interest of your reply for the other subscribers...[%END%]</p>
-	<p>[%|helploc%]<strong>Always use descriptive subjects for your messages</strong>. On some lists, typical subjects for messages are even predefined and it is compulsory to "tag" messages using one of them (examples of typical objects: <em class="example">[summary]</em>, <em class="example">[urgent]</em>, <em class="example">[administrative]</em>, <em class="example">[question]</em>, etc.).[%END%]</p>
-	<p>[%|helploc%]<strong>Some kinds of messages are not welcome</strong> on mailing lists: advertisement, spamming, commercial messages, virus warnings, test messages, political or religious messages, hoaxes, flaming, privacy invasions, messages damaging, misleading or in any way defamatory, harassing, offensive, abusive, infringing, racist, obscene or profane, promoting discrimination, violence or hatred for any reason, contrary to good morals, or more generally illegal.[%END%]</p>
-	<p>[%|helploc%]<strong>Unconstructive and mean-spirited messages</strong> (example: remarks about spelling mistakes) <strong>and other personal attacks towards other contributors are either not welcome</strong> on lists. If you really need to tell unpleasant or offensive things to someone, you had better do it in a private message... On most of the mailing lists, <strong>it is also frowned on to feed the <em class="altralingua">trolls</em></strong> (topics or posts deliberately incorrect, intended to provoke readers).[%END%]</p>
-	<p>[%|helploc%]<strong>Generally, a list uses only one language</strong> for the exchanges between contributors. Respect this rule even though you are not a native speaker of the language used. <strong>Also try to respect the elementary rules of grammar and spelling</strong>, ban "<acronym lang="en" xml:lang="en" title="Short Message Service">SMS</acronym> language" and <strong>proofread yourself</strong> before posting your message![%END%]</p>
-	<p>[%|helploc%]When sending a message, <strong>you may want to add one or several attachments</strong>. However, be careful to respect a few elementary rules:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>Make sure that attachments are accepted</strong> on the list to which you send your message.[%END%]</li>
-		<li>[%|helploc%]When attachments are allowed, <strong>remain reasonable</strong>: too many or too large attachments may disturb the other subscribers, for example by flooding their inboxes.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]If you want to <strong>share documents with other list members</strong>, you had probably better upload them in the <a href="shared">'Documents' section of the list</a>.[%END%]</p>
-	<p class="retraitita">[%|helploc%]<strong>The use of email in general and for mailing lists is bound by a set of precise rules necessary to share pleasant exchanges: the "Netiquette"</strong>. You will find the general principles of the Netiquette, as well as many links on the <a target="_blank" href="http://en.wikipedia.org/wiki/Netiquette">page of the Wikipedia dedicated to the Netiquette</a>.[%END%]</p>
+    <h5>[%|helploc%]Good practices[%END%]</h5>
+    <p>[%|helploc%]<strong>When asking a question on a list</strong>, it is customary to post a summary of all answers obtained.[%END%]</p>
+    <p>[%|helploc%]<strong>When you reply to a message sent on the list</strong>, it is up to you to decide whether you will reply on the list or in private. This might depend on the interest of your reply for the other subscribers...[%END%]</p>
+    <p>[%|helploc%]<strong>Always use descriptive subjects for your messages</strong>. On some lists, typical subjects for messages are even predefined and it is compulsory to "tag" messages using one of them (examples of typical objects: <em class="example">[summary]</em>, <em class="example">[urgent]</em>, <em class="example">[administrative]</em>, <em class="example">[question]</em>, etc.).[%END%]</p>
+    <p>[%|helploc%]<strong>Some kinds of messages are not welcome</strong> on mailing lists: advertisement, spamming, commercial messages, virus warnings, test messages, political or religious messages, hoaxes, flaming, privacy invasions, messages damaging, misleading or in any way defamatory, harassing, offensive, abusive, infringing, racist, obscene or profane, promoting discrimination, violence or hatred for any reason, contrary to good morals, or more generally illegal.[%END%]</p>
+    <p>[%|helploc%]<strong>Unconstructive and mean-spirited messages</strong> (example: remarks about spelling mistakes) <strong>and other personal attacks towards other contributors are either not welcome</strong> on lists. If you really need to tell unpleasant or offensive things to someone, you had better do it in a private message... On most of the mailing lists, <strong>it is also frowned on to feed the <em class="altralingua">trolls</em></strong> (topics or posts deliberately incorrect, intended to provoke readers).[%END%]</p>
+    <p>[%|helploc%]<strong>Generally, a list uses only one language</strong> for the exchanges between contributors. Respect this rule even though you are not a native speaker of the language used. <strong>Also try to respect the elementary rules of grammar and spelling</strong>, ban "<acronym lang="en" xml:lang="en" title="Short Message Service">SMS</acronym> language" and <strong>proofread yourself</strong> before posting your message![%END%]</p>
+    <p>[%|helploc%]When sending a message, <strong>you may want to add one or several attachments</strong>. However, be careful to respect a few elementary rules:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>Make sure that attachments are accepted</strong> on the list to which you send your message.[%END%]</li>
+        <li>[%|helploc%]When attachments are allowed, <strong>remain reasonable</strong>: too many or too large attachments may disturb the other subscribers, for example by flooding their inboxes.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]If you want to <strong>share documents with other list members</strong>, you had probably better upload them in the <a href="shared">'Documents' section of the list</a>.[%END%]</p>
+    <p class="retraitita">[%|helploc%]<strong>The use of email in general and for mailing lists is bound by a set of precise rules necessary to share pleasant exchanges: the "Netiquette"</strong>. You will find the general principles of the Netiquette, as well as many links on the <a target="_blank" href="http://en.wikipedia.org/wiki/Netiquette">page of the Wikipedia dedicated to the Netiquette</a>.[%END%]</p>
 <!-- end help_sendmsg.tt2 -->

--- a/default/web_tt2/help_shared.tt2
+++ b/default/web_tt2/help_shared.tt2
@@ -1,154 +1,154 @@
 <!-- help_shared.tt2 -->
 
-	<h3 class="block"><a name="shared"></a>[%|helploc%]Using the shared document web space[%END%]</h3>
-	<p>[%|helploc%]Some lists have a <strong>shared document web space where subscribers can download and upload documents</strong>: this space is available through the <strong>'Shared documents' section</strong>.[%END%]</p>
+    <h3 class="block"><a name="shared"></a>[%|helploc%]Using the shared document web space[%END%]</h3>
+    <p>[%|helploc%]Some lists have a <strong>shared document web space where subscribers can download and upload documents</strong>: this space is available through the <strong>'Shared documents' section</strong>.[%END%]</p>
 
-	<h4>[%|helploc%]Presentation of the documents in the shared document web space[%END%]</h4>
-	<p>[%|helploc%]To access the 'Shared documents' section of a list, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
-		<li>[%|helploc%]Go to <strong>the information page of the list</strong> of your interest.[%END%]</li>
-		<li>[%|helploc%]In the left menu, <strong>click on the 'Shared documents' link</strong>.[%END%]</li>
-	</ol>
+    <h4>[%|helploc%]Presentation of the documents in the shared document web space[%END%]</h4>
+    <p>[%|helploc%]To access the 'Shared documents' section of a list, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
+        <li>[%|helploc%]Go to <strong>the information page of the list</strong> of your interest.[%END%]</li>
+        <li>[%|helploc%]In the left menu, <strong>click on the 'Shared documents' link</strong>.[%END%]</li>
+    </ol>
 
-	<p>[%|helploc%]<strong>The 'Shared documents' section can contain three types of resources</strong>: <strong>folders</strong>, <strong>files</strong> and <strong>bookmarks</strong>.[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>Folders</strong> are preceded by the icon <i class="fa fa-folder" title="Icon of folder"> </i>.[%END%]
-		<ul>
-			<li>[%|helploc%]<strong>To browse a folder, click on its name</strong>.[%END%]</li>
-			<li>[%|helploc%]<strong>To go back up a level, click on the 'Up to higher level directory' link</strong> in the upper right corner of your screen.[%END%]</li>
-		</ul></li>
-		<li>[%|helploc%]<strong>Files</strong> are preceded by icons related to each type of file. You can <a href="#shared_read">download</a> and <a href="#shared_upload">upload</a> some.[%END%]</li>
-		<li>[%|helploc%]<strong>Bookmarks</strong> are preceded by the icon <i class="fa fa-link" title="Icon of bookmark"> </i>. They consist of <strong>shortcuts providing a single-click access to a particular website</strong>. If you click on a bookmark label, the website linked will open in a new window.[%END%]</li>
-	</ul>
+    <p>[%|helploc%]<strong>The 'Shared documents' section can contain three types of resources</strong>: <strong>folders</strong>, <strong>files</strong> and <strong>bookmarks</strong>.[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>Folders</strong> are preceded by the icon <i class="fa fa-folder" title="Icon of folder"> </i>.[%END%]
+        <ul>
+            <li>[%|helploc%]<strong>To browse a folder, click on its name</strong>.[%END%]</li>
+            <li>[%|helploc%]<strong>To go back up a level, click on the 'Up to higher level directory' link</strong> in the upper right corner of your screen.[%END%]</li>
+        </ul></li>
+        <li>[%|helploc%]<strong>Files</strong> are preceded by icons related to each type of file. You can <a href="#shared_read">download</a> and <a href="#shared_upload">upload</a> some.[%END%]</li>
+        <li>[%|helploc%]<strong>Bookmarks</strong> are preceded by the icon <i class="fa fa-link" title="Icon of bookmark"> </i>. They consist of <strong>shortcuts providing a single-click access to a particular website</strong>. If you click on a bookmark label, the website linked will open in a new window.[%END%]</li>
+    </ul>
 
-	<p>[%|helploc%]The functions of editing and creation of documents, when they are available to you, are accessible through the <strong>Expert mode</strong>. To switch to expert mode, click on the <a class="actionMenuLinks">Expert mode</a> button on top of page.[%END%]</p>
+    <p>[%|helploc%]The functions of editing and creation of documents, when they are available to you, are accessible through the <strong>Expert mode</strong>. To switch to expert mode, click on the <a class="actionMenuLinks">Expert mode</a> button on top of page.[%END%]</p>
 
-	<p>[%|helploc%]<strong>The list owner or the documents authors can choose to restrict the access rights to some files/folders</strong>. Both the reading and writing rights can be restricted:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>When a folder is not writable</strong>, you can neither upload nor create documents in it.[%END%]</li>
-		<li>[%|helploc%]<strong>When a folder is not readable</strong>, you can not browse it (you get an error message).[%END%]</li>
-	</ul>
-	<p>[%|helploc%]<strong>Folders are sorted separately</strong> from files and bookmarks, and display before them. <strong>By default, documents are sorted ascendingly according to the 'Document' column</strong>.[%END%]</p>
-	<p class="retraitita">[%|helploc%]Be careful: alphanumeric sort distinguishes uppercase from lowercase, thus all documents which have a name starting with an uppercase character display first, sorted in alphabetical order, and then, all documents which have a name starting with a lowercase character, sorted in alphabetical order. It is the same for folders.[%END%]</p>
-	<p>[%|helploc%]<strong>You can sort documents and folders according to criteria</strong> other than the name of the document/folder: they can also be sorted according to their <strong>author</strong>, their <strong>size</strong> and their <strong>last update date</strong>. To sort documents according to the criterion of your choice, click on the name of the corresponding column.[%END%]</p>
-	
+    <p>[%|helploc%]<strong>The list owner or the documents authors can choose to restrict the access rights to some files/folders</strong>. Both the reading and writing rights can be restricted:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>When a folder is not writable</strong>, you can neither upload nor create documents in it.[%END%]</li>
+        <li>[%|helploc%]<strong>When a folder is not readable</strong>, you can not browse it (you get an error message).[%END%]</li>
+    </ul>
+    <p>[%|helploc%]<strong>Folders are sorted separately</strong> from files and bookmarks, and display before them. <strong>By default, documents are sorted ascendingly according to the 'Document' column</strong>.[%END%]</p>
+    <p class="retraitita">[%|helploc%]Be careful: alphanumeric sort distinguishes uppercase from lowercase, thus all documents which have a name starting with an uppercase character display first, sorted in alphabetical order, and then, all documents which have a name starting with a lowercase character, sorted in alphabetical order. It is the same for folders.[%END%]</p>
+    <p>[%|helploc%]<strong>You can sort documents and folders according to criteria</strong> other than the name of the document/folder: they can also be sorted according to their <strong>author</strong>, their <strong>size</strong> and their <strong>last update date</strong>. To sort documents according to the criterion of your choice, click on the name of the corresponding column.[%END%]</p>
 
-	<h4><a name="shared_read"></a>[%|helploc%]Downloading documents from the shared document web space[%END%]</h4>
-	<p>[%|helploc%]To download a document from a list, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]<strong>Go to the 'Shared documents' section</strong> of the list of your interest.[%END%]</li>
-		<li>[%|helploc%]<strong>Browse the folder containing the file you want to download</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Select the 'expert mode'</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Click on the name of the file to save it on your hard disk</strong>.[%END%]<br />
-		<p class="retraitita">[%|helploc%]Be careful: files available in formats likely to open in a web browser will. To download this type of files, you had rather make a right click on their names and choose 'Save target as...', 'Save link as...', etc., according to your browser. This can affect, among others, files of formats .HTM/HTML, .PDF, .PNG, .TXT, .SWF, etc. (this behavior varies according to your browser and settings).[%END%]</p></li>
-	</ol>
 
-	<h4><a name="shared_upload"></a>[%|helploc%]Uploading documents in the shared document web space[%END%]</h4>
+    <h4><a name="shared_read"></a>[%|helploc%]Downloading documents from the shared document web space[%END%]</h4>
+    <p>[%|helploc%]To download a document from a list, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]<strong>Go to the 'Shared documents' section</strong> of the list of your interest.[%END%]</li>
+        <li>[%|helploc%]<strong>Browse the folder containing the file you want to download</strong>.[%END%]</li>
+        <li>[%|helploc%]<strong>Select the 'expert mode'</strong>.[%END%]</li>
+        <li>[%|helploc%]<strong>Click on the name of the file to save it on your hard disk</strong>.[%END%]<br />
+        <p class="retraitita">[%|helploc%]Be careful: files available in formats likely to open in a web browser will. To download this type of files, you had rather make a right click on their names and choose 'Save target as...', 'Save link as...', etc., according to your browser. This can affect, among others, files of formats .HTM/HTML, .PDF, .PNG, .TXT, .SWF, etc. (this behavior varies according to your browser and settings).[%END%]</p></li>
+    </ol>
 
-	<h5>[%|helploc%]Creating a folder on a list[%END%]</h5>
-	<p>[%|helploc%]<strong>To create a folder on a list</strong>, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]<strong>Go to the 'Shared documents' section</strong> of the list of your interest.[%END%]</li>
-		<li>[%|helploc%]<strong>Browse the folder in which you want to create a folder</strong>.[%END%]</li>
-	        <li>[%|helploc%]<strong>Switch to expert mode</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Enter the folder name</strong> in the text field close to the 'Create a new folder inside [name of the current folder]' label.[%END%]</li>
-		<li>[%|helploc%]<strong>Click on the 'Create' button</strong>.[%END%]</li>
-	</ol>
+    <h4><a name="shared_upload"></a>[%|helploc%]Uploading documents in the shared document web space[%END%]</h4>
 
-	<h5>[%|helploc%]Uploading a file on a list[%END%]</h5>
-	<p>[%|helploc%]<strong>To upload a file on a list</strong>, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]<strong>Go to the 'Shared documents' section</strong> of the list of your interest.[%END%]</li>
-		<li>[%|helploc%]<strong>Browse the folder in which you want to upload your file</strong>. Create a new folder if necessary.[%END%]</li>
-	        <li>[%|helploc%]<strong>Switch to expert mode</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Click on the 'Browse' button</strong> below the 'Upload a file inside the folder [name of the current folder]' label and <strong>choose the file</strong> you want to upload; after selecting it, click on the 'Open' button. Your file path then displays in the input box close to the 'Browse' button.[%END%]</li>
-		<li>[%|helploc%]<strong>Click on the 'Publish' button</strong>.[%END%]</li>
-	</ol>
-	<p>[%|helploc%]Be careful: list owners may define quotas, that is to say a <strong>maximum size not to be exceeded for the shared document web space</strong>. If you try to upload or create a too large document with regard to the space left, you will get the following error message: "The document repository exceed disk quota".[%END%]</p>
+    <h5>[%|helploc%]Creating a folder on a list[%END%]</h5>
+    <p>[%|helploc%]<strong>To create a folder on a list</strong>, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]<strong>Go to the 'Shared documents' section</strong> of the list of your interest.[%END%]</li>
+        <li>[%|helploc%]<strong>Browse the folder in which you want to create a folder</strong>.[%END%]</li>
+            <li>[%|helploc%]<strong>Switch to expert mode</strong>.[%END%]</li>
+        <li>[%|helploc%]<strong>Enter the folder name</strong> in the text field close to the 'Create a new folder inside [name of the current folder]' label.[%END%]</li>
+        <li>[%|helploc%]<strong>Click on the 'Create' button</strong>.[%END%]</li>
+    </ol>
 
-	<p>[%|helploc%]In order to avoid any list overload, try and <strong>delete useless files as you go along</strong>. A good <a href="#organize">organization</a> of the list will allow you to manage the shared document web space more easily. To save some space, you can also publish your files in <strong>compressed formats</strong>.[%END%]</p>
+    <h5>[%|helploc%]Uploading a file on a list[%END%]</h5>
+    <p>[%|helploc%]<strong>To upload a file on a list</strong>, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]<strong>Go to the 'Shared documents' section</strong> of the list of your interest.[%END%]</li>
+        <li>[%|helploc%]<strong>Browse the folder in which you want to upload your file</strong>. Create a new folder if necessary.[%END%]</li>
+            <li>[%|helploc%]<strong>Switch to expert mode</strong>.[%END%]</li>
+        <li>[%|helploc%]<strong>Click on the 'Browse' button</strong> below the 'Upload a file inside the folder [name of the current folder]' label and <strong>choose the file</strong> you want to upload; after selecting it, click on the 'Open' button. Your file path then displays in the input box close to the 'Browse' button.[%END%]</li>
+        <li>[%|helploc%]<strong>Click on the 'Publish' button</strong>.[%END%]</li>
+    </ol>
+    <p>[%|helploc%]Be careful: list owners may define quotas, that is to say a <strong>maximum size not to be exceeded for the shared document web space</strong>. If you try to upload or create a too large document with regard to the space left, you will get the following error message: "The document repository exceed disk quota".[%END%]</p>
 
-	<h5>[%|helploc%]Publishing a bookmark on a list[%END%]</h5>
-	<p>[%|helploc%]<strong>To publish a bookmark on a list</strong>, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]<strong>Go to the 'Shared documents' section</strong> of the list of your interest.[%END%]</li>
-		<li>[%|helploc%]<strong>Browse the folder in which you want to publish your bookmark</strong>. Create a new folder if necessary.[%END%]</li>
-	        <li>[%|helploc%]<strong>Switch to expert mode</strong>.[%END%]</li>
-		<li>[%|helploc%]In the <strong>'title' field</strong>, enter a <strong>descriptive name</strong> for the website to be linked through the bookmark.[%END%]</li>
-		<li>[%|helploc%]In the <strong>'<acronym title="Uniform Resource Locator" lang="en" xml:lang="en">URL</acronym>' field</strong>, enter or paste the website's <strong><acronym title="Uniform Resource Locator" lang="en" xml:lang="en">URL</acronym></strong>.[%END%]</li>
-		<li>[%|helploc%]Click on the <strong>'Add'</strong> button.[%END%]</li>
-	</ol>
+    <p>[%|helploc%]In order to avoid any list overload, try and <strong>delete useless files as you go along</strong>. A good <a href="#organize">organization</a> of the list will allow you to manage the shared document web space more easily. To save some space, you can also publish your files in <strong>compressed formats</strong>.[%END%]</p>
 
-	<h5>[%|helploc%]Creating a file on a list[%END%]</h5>
+    <h5>[%|helploc%]Publishing a bookmark on a list[%END%]</h5>
+    <p>[%|helploc%]<strong>To publish a bookmark on a list</strong>, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]<strong>Go to the 'Shared documents' section</strong> of the list of your interest.[%END%]</li>
+        <li>[%|helploc%]<strong>Browse the folder in which you want to publish your bookmark</strong>. Create a new folder if necessary.[%END%]</li>
+            <li>[%|helploc%]<strong>Switch to expert mode</strong>.[%END%]</li>
+        <li>[%|helploc%]In the <strong>'title' field</strong>, enter a <strong>descriptive name</strong> for the website to be linked through the bookmark.[%END%]</li>
+        <li>[%|helploc%]In the <strong>'<acronym title="Uniform Resource Locator" lang="en" xml:lang="en">URL</acronym>' field</strong>, enter or paste the website's <strong><acronym title="Uniform Resource Locator" lang="en" xml:lang="en">URL</acronym></strong>.[%END%]</li>
+        <li>[%|helploc%]Click on the <strong>'Add'</strong> button.[%END%]</li>
+    </ol>
 
-	<p>[%|helploc%]<strong>To create a file on a list</strong>, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]<strong>Go to the 'Shared documents' section</strong> of the list of your interest.[%END%]</li>
-		<li>[%|helploc%]<strong>Browse the folder in which you want to create your file</strong>. Create a new folder if necessary.[%END%]</li>
-	        <li>[%|helploc%]<strong>Switch to expert mode</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Enter a file name</strong> in the input box close to the 'Create a new file' label.[%END%]</li>
-		<li>[%|helploc%]<strong>Click on the 'Create' button</strong>.[%END%]</li>
-	</ol>
-	<p>[%|helploc%]You are brought to the file creation page.[%END%]</p>
+    <h5>[%|helploc%]Creating a file on a list[%END%]</h5>
 
-	<p>[%|helploc%]<strong>Enter or paste the text</strong> you want to put in your file in the 'Edit the file /nameofthefile' text area, and then <strong>click on the 'Publish' button</strong>.[%END%]</p>
-	<p class="retraitita">[%|helploc%]<strong>Important: the only files that can be created online on the lists are plain text files. On the other hand, it is impossible to create office documents (.DOC, .XLS, .PPT, .RTF, .ODT, etc.), .PDF, images, etc.</strong>[%END%]</p>
-	<p>[%|helploc%]You can also <strong>replace the file, describe it or rename it</strong>. To know more about these features, refer to the <a href="#editsuppr">'Editing or deleting documents in the shared document web space'</a> section.[%END%]</p>
-	
-	<h4><a name="editsuppr"></a>[%|helploc%]Editing or deleting documents in the shared document web space[%END%]</h4>
-	<p>[%|helploc%]In addition to uploading and downloading documents, you can also act on files and folders that are already online:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]by changing their access rights (read and write);[%END%]</li>
-		<li>[%|helploc%]by editing them;[%END%]</li>
-		<li>[%|helploc%]by deleting them.[%END%]</li>
-	</ul>
-	
-	<h5><a name="acces"></a>[%|helploc%]Changing access rights[%END%]</h5>
-	<p>[%|helploc%]<strong>You can change read and/or write access rights to folders and files</strong>. This has <strong>several advantages</strong>:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>Denying write access to a folder</strong> avoids proliferation of files published by unauthorized persons. To keep control of the list, sometimes it is more sensible to deny write access to the root folder of the shared document web space. It is also possible to offer a writable folder and to lock it at a given date or time, for example to control delivery of works by students.[%END%]</li>
-		<li>[%|helploc%]<strong>Denying write access to a file</strong> ensures that no one will be able to modify it. For example, this is the most suitable option for teachers willing to put at their students' disposal a set of documents, such as exam questions.[%END%]</li>
-		<li>[%|helploc%]<strong>Denying read access to a folder</strong> makes it possible to store several confidential documents without having to change read access rights individually for each of them.[%END%]</li>
-		<li>[%|helploc%]<strong>Denying read access to a file</strong> ensures its confidentiality. For example, a teacher can ask his/her students to upload their "exam copies" on a list and to restrict read access to their files in order to prevent other students from looking at them.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]<strong>You are allowed to change access rights only to documents you uploaded or created yourself</strong> on the lists (one exception: list owners can change access rights to any document published on the lists; this does not concern moderators).[%END%]</p>
-	<p>[%|helploc%]<strong>To change access rights for a document, click on the 'Access' text</strong> in front of the document's name, in the 'Access' column. You are brought to the access rights editing page.[%END%]</p>
+    <p>[%|helploc%]<strong>To create a file on a list</strong>, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]<strong>Go to the 'Shared documents' section</strong> of the list of your interest.[%END%]</li>
+        <li>[%|helploc%]<strong>Browse the folder in which you want to create your file</strong>. Create a new folder if necessary.[%END%]</li>
+            <li>[%|helploc%]<strong>Switch to expert mode</strong>.[%END%]</li>
+        <li>[%|helploc%]<strong>Enter a file name</strong> in the input box close to the 'Create a new file' label.[%END%]</li>
+        <li>[%|helploc%]<strong>Click on the 'Create' button</strong>.[%END%]</li>
+    </ol>
+    <p>[%|helploc%]You are brought to the file creation page.[%END%]</p>
 
-	<p>[%|helploc%]<strong>Choose options from the drop-down lists 'Read access' and 'Edit access'</strong>.[%END%]</p>
-	<p class="retraitita">[%|helploc%]Though it isn't mentionned in any of the options, note that the document owner (most of the time the person that published it) keeps the write and read rights on this document whatever happens (unless the list owner changes the document owner).[%END%]</p>
-	<p>[%|helploc%]<strong>You can also change the document's owner</strong>, for example to allow another person to edit it online, or to indicate the actual author of a document if it has been published by someone else.[%END%]</p>
+    <p>[%|helploc%]<strong>Enter or paste the text</strong> you want to put in your file in the 'Edit the file /nameofthefile' text area, and then <strong>click on the 'Publish' button</strong>.[%END%]</p>
+    <p class="retraitita">[%|helploc%]<strong>Important: the only files that can be created online on the lists are plain text files. On the other hand, it is impossible to create office documents (.DOC, .XLS, .PPT, .RTF, .ODT, etc.), .PDF, images, etc.</strong>[%END%]</p>
+    <p>[%|helploc%]You can also <strong>replace the file, describe it or rename it</strong>. To know more about these features, refer to the <a href="#editsuppr">'Editing or deleting documents in the shared document web space'</a> section.[%END%]</p>
 
-	<h5>[%|helploc%]Editing folders, files or bookmarks[%END%]</h5>
-	<p>[%|helploc%]<strong>To edit a document, click on the 'Edit' text</strong> in front of the document's name in the 'Edit' column.[%END%]</p>
+    <h4><a name="editsuppr"></a>[%|helploc%]Editing or deleting documents in the shared document web space[%END%]</h4>
+    <p>[%|helploc%]In addition to uploading and downloading documents, you can also act on files and folders that are already online:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]by changing their access rights (read and write);[%END%]</li>
+        <li>[%|helploc%]by editing them;[%END%]</li>
+        <li>[%|helploc%]by deleting them.[%END%]</li>
+    </ul>
 
-	<p>[%|helploc%]According to the type of document you edit, you have different possibilities:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]If the document is a <strong>folder</strong>, you can only <strong>describe</strong> it or <strong>rename</strong> it.[%END%]<br />
-		<p class="retraitita">[%|helploc%]The description of a document is visible in the upper left corner when editing it. The description of folders is also visible there when browsing the folder.[%END%]</p></li>
-		<li>[%|helploc%]If the document is a <strong>bookmark</strong>, you can also <strong>change the <acronym title="Uniform Resource Locator" lang="en" xml:lang="en">URL</acronym> specified</strong>.[%END%]</li>
-		<li>[%|helploc%]If the document is a <strong>file</strong>, you can also <strong>replace the existing file with a file of your choice</strong>. To do that, <strong>click on the 'Browse' button</strong> below the 'Replace the file nameofthefile with your file' text and <strong>choose the file</strong> you want to publish; after selecting it, click on the 'Open' button. Your file path then displays in the input box close to the 'Browse' button. <strong>Click on the 'Publish' button</strong>.[%END%]<br />
-		<p class="retraitita">[%|helploc%]Whatever the name of the new file, the file published on the list will keep its original name. If you want the file replacement to be followed by a change of name, you will also have to rename the file published on the list.[%END%]</p></li>
-		<li>[%|helploc%]Last, if the document is a <strong>plain text file</strong>, you can <strong>change its content online</strong>: <strong>enter or paste the text</strong> you want to put in your file in the 'Edit the file /nameofthefile' text area, and then <strong>click on the 'Publish' button</strong>.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]Any click on a button related to an input box only validates the changes specified in that box. <strong>To make several changes, you need to click on each button corresponding to your choices</strong>.[%END%]</p>
-	<p>[%|helploc%]Some buttons immediately bring you back to the page of the folder containing the document, while others perform the update without bringing you to another page. <strong>To go back to the folder page without changing anything, click on the 'Up to higher level directory' button</strong>.[%END%]</p>
+    <h5><a name="acces"></a>[%|helploc%]Changing access rights[%END%]</h5>
+    <p>[%|helploc%]<strong>You can change read and/or write access rights to folders and files</strong>. This has <strong>several advantages</strong>:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>Denying write access to a folder</strong> avoids proliferation of files published by unauthorized persons. To keep control of the list, sometimes it is more sensible to deny write access to the root folder of the shared document web space. It is also possible to offer a writable folder and to lock it at a given date or time, for example to control delivery of works by students.[%END%]</li>
+        <li>[%|helploc%]<strong>Denying write access to a file</strong> ensures that no one will be able to modify it. For example, this is the most suitable option for teachers willing to put at their students' disposal a set of documents, such as exam questions.[%END%]</li>
+        <li>[%|helploc%]<strong>Denying read access to a folder</strong> makes it possible to store several confidential documents without having to change read access rights individually for each of them.[%END%]</li>
+        <li>[%|helploc%]<strong>Denying read access to a file</strong> ensures its confidentiality. For example, a teacher can ask his/her students to upload their "exam copies" on a list and to restrict read access to their files in order to prevent other students from looking at them.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]<strong>You are allowed to change access rights only to documents you uploaded or created yourself</strong> on the lists (one exception: list owners can change access rights to any document published on the lists; this does not concern moderators).[%END%]</p>
+    <p>[%|helploc%]<strong>To change access rights for a document, click on the 'Access' text</strong> in front of the document's name, in the 'Access' column. You are brought to the access rights editing page.[%END%]</p>
 
-	<h5>[%|helploc%]Deleting folders, files or bookmarks[%END%]</h5>
-	<p>[%|helploc%]<strong>To delete any type of document, click on the 'Delete'</strong> text in front of the document's name in the 'Delete' column. A confirmation message displays in order to let you go back on your decision: <strong>once deleted, the document will not be retrievable anymore</strong>.[%END%]</p>
-		<p class="retraitita">[%|helploc%]If there is no 'Delete' text in front of the document's name, you do not have write access rights to the document.[%END%]</p>
-	<p>[%|helploc%]<strong>It is impossible to delete a folder which still contains documents</strong>: before deleting a folder, you need to empty it entirely first.[%END%]</p>
+    <p>[%|helploc%]<strong>Choose options from the drop-down lists 'Read access' and 'Edit access'</strong>.[%END%]</p>
+    <p class="retraitita">[%|helploc%]Though it isn't mentionned in any of the options, note that the document owner (most of the time the person that published it) keeps the write and read rights on this document whatever happens (unless the list owner changes the document owner).[%END%]</p>
+    <p>[%|helploc%]<strong>You can also change the document's owner</strong>, for example to allow another person to edit it online, or to indicate the actual author of a document if it has been published by someone else.[%END%]</p>
 
-	<h4><a name="organize"></a>[%|helploc%]A few tips to organize the shared document web space[%END%]</h4>
-	<p>[%|helploc%]If you are one of the people likely to organize the list and create files and folders, <strong>be far-sighted: think that the list will maybe develop in a considerable manner and that it will maybe be used for several years</strong>.[%END%]</p>
-	<p>[%|helploc%]Here are <strong>a few suggestions to prevent a list from developing in an anarchic manner</strong>:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]If the list is to contain the same kinds of resources at regular intervals, choose an <strong>organization by month or by year</strong> (or any other duration according to your needs).[%END%]<br />
-		<p class="retraitita">[%|helploc%]Example: if the list is meant to collect student works, those students will attend the same lessons and make the same works from a year to another. Thus, it might be interesting to create a folder for each academic year at the root of the shared document web space: this will allow students to take a look at the previous year's works and lessons (provided that teachers <a href="#acces">restrict access</a> to sensitive resources). This can be completed by subfolders for each lesson or each teacher within each year folder.[%END%]</p></li>
-		<li>[%|helploc%]If the list is a collaborative list destined to all members of a department, you had better choose a <strong>project-based organization</strong>.[%END%]</li>
-		<li>[%|helploc%]If the list aims at exchanging information, choose a <strong>topic-based organization</strong>.[%END%]</li>
-		<li>[%|helploc%]You can also choose an <strong>organization by person, by team, etc.</strong>, and even <strong>combine all those solutions</strong>![%END%]</li>
-	</ul>
-	<p>[%|helploc%]In order to avoid problems, <strong>choose carefully the names of files and folders</strong> you publish on lists: give them <strong>explicit yet short names</strong> and <strong>avoid spaces, accents, hyphens and special characters</strong>.[%END%]</p>
-	
+    <h5>[%|helploc%]Editing folders, files or bookmarks[%END%]</h5>
+    <p>[%|helploc%]<strong>To edit a document, click on the 'Edit' text</strong> in front of the document's name in the 'Edit' column.[%END%]</p>
+
+    <p>[%|helploc%]According to the type of document you edit, you have different possibilities:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]If the document is a <strong>folder</strong>, you can only <strong>describe</strong> it or <strong>rename</strong> it.[%END%]<br />
+        <p class="retraitita">[%|helploc%]The description of a document is visible in the upper left corner when editing it. The description of folders is also visible there when browsing the folder.[%END%]</p></li>
+        <li>[%|helploc%]If the document is a <strong>bookmark</strong>, you can also <strong>change the <acronym title="Uniform Resource Locator" lang="en" xml:lang="en">URL</acronym> specified</strong>.[%END%]</li>
+        <li>[%|helploc%]If the document is a <strong>file</strong>, you can also <strong>replace the existing file with a file of your choice</strong>. To do that, <strong>click on the 'Browse' button</strong> below the 'Replace the file nameofthefile with your file' text and <strong>choose the file</strong> you want to publish; after selecting it, click on the 'Open' button. Your file path then displays in the input box close to the 'Browse' button. <strong>Click on the 'Publish' button</strong>.[%END%]<br />
+        <p class="retraitita">[%|helploc%]Whatever the name of the new file, the file published on the list will keep its original name. If you want the file replacement to be followed by a change of name, you will also have to rename the file published on the list.[%END%]</p></li>
+        <li>[%|helploc%]Last, if the document is a <strong>plain text file</strong>, you can <strong>change its content online</strong>: <strong>enter or paste the text</strong> you want to put in your file in the 'Edit the file /nameofthefile' text area, and then <strong>click on the 'Publish' button</strong>.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]Any click on a button related to an input box only validates the changes specified in that box. <strong>To make several changes, you need to click on each button corresponding to your choices</strong>.[%END%]</p>
+    <p>[%|helploc%]Some buttons immediately bring you back to the page of the folder containing the document, while others perform the update without bringing you to another page. <strong>To go back to the folder page without changing anything, click on the 'Up to higher level directory' button</strong>.[%END%]</p>
+
+    <h5>[%|helploc%]Deleting folders, files or bookmarks[%END%]</h5>
+    <p>[%|helploc%]<strong>To delete any type of document, click on the 'Delete'</strong> text in front of the document's name in the 'Delete' column. A confirmation message displays in order to let you go back on your decision: <strong>once deleted, the document will not be retrievable anymore</strong>.[%END%]</p>
+        <p class="retraitita">[%|helploc%]If there is no 'Delete' text in front of the document's name, you do not have write access rights to the document.[%END%]</p>
+    <p>[%|helploc%]<strong>It is impossible to delete a folder which still contains documents</strong>: before deleting a folder, you need to empty it entirely first.[%END%]</p>
+
+    <h4><a name="organize"></a>[%|helploc%]A few tips to organize the shared document web space[%END%]</h4>
+    <p>[%|helploc%]If you are one of the people likely to organize the list and create files and folders, <strong>be far-sighted: think that the list will maybe develop in a considerable manner and that it will maybe be used for several years</strong>.[%END%]</p>
+    <p>[%|helploc%]Here are <strong>a few suggestions to prevent a list from developing in an anarchic manner</strong>:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]If the list is to contain the same kinds of resources at regular intervals, choose an <strong>organization by month or by year</strong> (or any other duration according to your needs).[%END%]<br />
+        <p class="retraitita">[%|helploc%]Example: if the list is meant to collect student works, those students will attend the same lessons and make the same works from a year to another. Thus, it might be interesting to create a folder for each academic year at the root of the shared document web space: this will allow students to take a look at the previous year's works and lessons (provided that teachers <a href="#acces">restrict access</a> to sensitive resources). This can be completed by subfolders for each lesson or each teacher within each year folder.[%END%]</p></li>
+        <li>[%|helploc%]If the list is a collaborative list destined to all members of a department, you had better choose a <strong>project-based organization</strong>.[%END%]</li>
+        <li>[%|helploc%]If the list aims at exchanging information, choose a <strong>topic-based organization</strong>.[%END%]</li>
+        <li>[%|helploc%]You can also choose an <strong>organization by person, by team, etc.</strong>, and even <strong>combine all those solutions</strong>![%END%]</li>
+    </ul>
+    <p>[%|helploc%]In order to avoid problems, <strong>choose carefully the names of files and folders</strong> you publish on lists: give them <strong>explicit yet short names</strong> and <strong>avoid spaces, accents, hyphens and special characters</strong>.[%END%]</p>
+
 <!-- end help_shared.tt2 -->

--- a/default/web_tt2/help_suspend.tt2
+++ b/default/web_tt2/help_suspend.tt2
@@ -2,17 +2,17 @@
 
 <h3 class="block">[%|helploc%]Manage your subscriptions[%END%]</h3>
 
-  <h4>[%|helploc%]How does the suspension work?[%END%]</h4>
-	<p>[%|helploc%]In order to <strong>suspend your subscription</strong> to one or more lists, follow these steps:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]Select a start date using the calendar that appears when you click on the "start date" field;[%END%]</li>
-		<li>[%|helploc%]if you wish, you can specify the date when you want your subscription to resume. Do it using the "end date" field. Alternatively, you can click on "indefinite." In this case, you will have to return to this page to resume your subscription;[%END%]</li>
-		<li>[%|helploc%]Select the lists for which you wish to suspend your subscription. The "Toggle selection" button allows you to invert the selection;[%END%]</li>
-		<li>[%|helploc%]Click on "Suspend my subscriptions" to confirm the suspension.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]<strong>To resume your subscription</strong> to one or more lists, follow these steps:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]Select the list(s) you want to reactivate. The "Toggle selection" button allows you to invert the selection;[%END%]</li>
-		<li>[%|helploc%]Click "Resume".[%END%]</li>
-	</ul>
+<h4>[%|helploc%]How does the suspension work?[%END%]</h4>
+<p>[%|helploc%]In order to <strong>suspend your subscription</strong> to one or more lists, follow these steps:[%END%]</p>
+<ul>
+    <li>[%|helploc%]Select a start date using the calendar that appears when you click on the "start date" field;[%END%]</li>
+    <li>[%|helploc%]if you wish, you can specify the date when you want your subscription to resume. Do it using the "end date" field. Alternatively, you can click on "indefinite." In this case, you will have to return to this page to resume your subscription;[%END%]</li>
+    <li>[%|helploc%]Select the lists for which you wish to suspend your subscription. The "Toggle selection" button allows you to invert the selection;[%END%]</li>
+    <li>[%|helploc%]Click on "Suspend my subscriptions" to confirm the suspension.[%END%]</li>
+</ul>
+<p>[%|helploc%]<strong>To resume your subscription</strong> to one or more lists, follow these steps:[%END%]</p>
+<ul>
+    <li>[%|helploc%]Select the list(s) you want to reactivate. The "Toggle selection" button allows you to invert the selection;[%END%]</li>
+    <li>[%|helploc%]Click "Resume".[%END%]</li>
+</ul>
 <!-- end help_suspend.tt2 -->

--- a/default/web_tt2/help_user.tt2
+++ b/default/web_tt2/help_user.tt2
@@ -1,173 +1,173 @@
 <!-- help_user.tt2 -->
 
-	<h2 class="block">[%|helploc%]Mailing lists - User Guide[%END%]</h2>
+    <h2 class="block">[%|helploc%]Mailing lists - User Guide[%END%]</h2>
 
-	<h3><a name="howitworks"></a>[%|helploc%]How the mailing list service works[%END%]</h3>
-	<p>[%|helploc%]The mailing-list service is managed by a <strong>mailing-list software: Sympa</strong>. This software comes with a <strong>web mailing list environment</strong>.[%END%]</p>
-	<p>[%|helploc%]<strong>To perform actions related to mailing lists</strong> (subscribe, change your options, etc.), you have two options:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>log on to the web environment</strong>;[%END%]</li>
-		<li>[%|helploc(conf.email,domain)%]<strong>send commands by email</strong> to the Sympa mailing list manager at <strong>%1@%2</strong>.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]<strong>To send a command to Sympa</strong>, do as follows:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>If you send a single command</strong>, type it into the subject line of your email and leave its body blank.[%END%]</li>
-		<li>[%|helploc%]<strong>If you send several commands</strong>, leave the subject line of your email blank and type all the commands in the email body. <strong>Be careful</strong>: Sympa will not process your message unless you respect the following rules:[%END%]
-		<ul>
-			<li>[%|helploc%]Write every command on a new line.[%END%]</li>
-			<li>[%|helploc%]Send your message in plain text, not in <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym> (no formatting).[%END%]</li>
-			<li>[%|helploc%]Your message can not contain anything else than Sympa commands (no signature block).[%END%]</li>
-		</ul></li>
-	</ul>
+    <h3><a name="howitworks"></a>[%|helploc%]How the mailing list service works[%END%]</h3>
+    <p>[%|helploc%]The mailing-list service is managed by a <strong>mailing-list software: Sympa</strong>. This software comes with a <strong>web mailing list environment</strong>.[%END%]</p>
+    <p>[%|helploc%]<strong>To perform actions related to mailing lists</strong> (subscribe, change your options, etc.), you have two options:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>log on to the web environment</strong>;[%END%]</li>
+        <li>[%|helploc(conf.email,domain)%]<strong>send commands by email</strong> to the Sympa mailing list manager at <strong>%1@%2</strong>.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]<strong>To send a command to Sympa</strong>, do as follows:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>If you send a single command</strong>, type it into the subject line of your email and leave its body blank.[%END%]</li>
+        <li>[%|helploc%]<strong>If you send several commands</strong>, leave the subject line of your email blank and type all the commands in the email body. <strong>Be careful</strong>: Sympa will not process your message unless you respect the following rules:[%END%]
+        <ul>
+            <li>[%|helploc%]Write every command on a new line.[%END%]</li>
+            <li>[%|helploc%]Send your message in plain text, not in <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym> (no formatting).[%END%]</li>
+            <li>[%|helploc%]Your message can not contain anything else than Sympa commands (no signature block).[%END%]</li>
+        </ul></li>
+    </ul>
 
-	<p>[%|helploc%]A description of all the commands you can send to Sympa is available at <a href="mail_commands">mail_commands</a>.[%END%]</p>
+    <p>[%|helploc%]A description of all the commands you can send to Sympa is available at <a href="mail_commands">mail_commands</a>.[%END%]</p>
 
-	<h3><a name="subscribe"></a>[%|helploc%]Subscribing to mailing lists[%END%]</h3>
-	<p>[%|helploc%]Subscribing to a mailing list is very simple:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]<strong>Choose the address</strong> with which you want to subscribe to the list.[%END%]<br />
-			<p class="retraitita">[%|helploc%]You should choose an address you can check frequently and which offers a large storage capacity for your email: some lists distribute many messages, which sometimes contain large attachments.[%END%]</p>
-			<p class="retraitita">[%|helploc%]Of course you can subscribe to the same list with several email addresses. Then you will need to redo the whole process with a different email address.[%END%]</p></li>
-			<li>[%|helploc(conf.email,domain)%]Send a <strong>message to %1@%2</strong> from the address you want to subscribe to the list.[%END%]<br />
-			<p class="retraitita">[%|helploc%]Sympa is not a person but a mailing list management robot. Thus it is useless to send it loving words! ;-)[%END%]</p></li>
-		<li>[%|helploc%]In the subject line of your message, type in: <strong>subscribe nameofthelist Firstname Name</strong> (replace 'nameofthelist' by the name of the list you want to subscribe to and indicate your own first name and name).[%END%]</li>
-		<li>[%|helploc%]<strong>Leave the message body blank</strong>.[%END%]<br />
-			<p class="retraitita">[%|helploc%]To save some time, you can also send several commands in a single message. To do that, follow the instructions available in the <a href="#howitworks">How the mailing list service works</a> section.[%END%]</p></li>
-	</ol>
+    <h3><a name="subscribe"></a>[%|helploc%]Subscribing to mailing lists[%END%]</h3>
+    <p>[%|helploc%]Subscribing to a mailing list is very simple:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]<strong>Choose the address</strong> with which you want to subscribe to the list.[%END%]<br />
+            <p class="retraitita">[%|helploc%]You should choose an address you can check frequently and which offers a large storage capacity for your email: some lists distribute many messages, which sometimes contain large attachments.[%END%]</p>
+            <p class="retraitita">[%|helploc%]Of course you can subscribe to the same list with several email addresses. Then you will need to redo the whole process with a different email address.[%END%]</p></li>
+            <li>[%|helploc(conf.email,domain)%]Send a <strong>message to %1@%2</strong> from the address you want to subscribe to the list.[%END%]<br />
+            <p class="retraitita">[%|helploc%]Sympa is not a person but a mailing list management robot. Thus it is useless to send it loving words! ;-)[%END%]</p></li>
+        <li>[%|helploc%]In the subject line of your message, type in: <strong>subscribe nameofthelist Firstname Name</strong> (replace 'nameofthelist' by the name of the list you want to subscribe to and indicate your own first name and name).[%END%]</li>
+        <li>[%|helploc%]<strong>Leave the message body blank</strong>.[%END%]<br />
+            <p class="retraitita">[%|helploc%]To save some time, you can also send several commands in a single message. To do that, follow the instructions available in the <a href="#howitworks">How the mailing list service works</a> section.[%END%]</p></li>
+    </ol>
 
-	<p>[%|helploc(domain)%]<strong>After this, you will receive a message telling you whether your request was accepted or not</strong>: if the subscription to the list is subject to any approval, the list owner may choose not to subscribe you. If so, do not send several other requests: it is useless as the result will remain the same. You can possibly send a message directly to the list owner (nameofthelist-request@%1) to explain why you really want to subscribe to the list...[%END%]</p>
-	<p class="retraitita">[%|helploc%]Note: you will sometimes be asked to confirm your subscription request before it can be processed. If so, please conform to the instructions contained in the message you receive.[%END%]</p>
-	<p>[%|helploc%]According to the type of list (list with subscription subject to conditions or not) and to the availability of the list owner, <strong>you may not receive the notice immediately</strong>. It is useless to send several requests.[%END%]</p>
-	<p>[%|helploc%]<strong>If your request is accepted, the message you receive confirms your subscription to the list. This message</strong> (the list Charter) <strong>contains several pieces of essential information:</strong>[%END%]</p>
-	<ul>
-		<li>[%|helploc%]your <strong>list password</strong>. This password is the same for all the lists you subscribed to with a single email address. You can <a href="#global_pref" title="How to change your password">change it online</a> after logging on to the mailing list environment;[%END%]</li>
-		<li>[%|helploc%]<strong>detailed information about the list</strong>: its purpose, the Internet address at which the message archive is available, etc.[%END%]</li>
-		<li>[%|helploc%]the <strong>rules applying to the list and its members</strong>: allowed and forbidden topics, netiquette, legal information, privacy policy, etc.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]<strong>You should keep your subscription notice</strong>: you may need it later to remember your password or to send a precise command to Sympa (example: signoff command). More generally, <strong>we advise you to keep all your subscription notices to mailing lists</strong>.[%END%]</p>
-	<p>[%|helploc%]<strong>You can also subscribe to a list through the mailing list web interface</strong>. To do that, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Go to the information page of the list</strong> you want to subscribe to.[%END%]</li>
-		<li>[%|helploc%]In the left menu, <strong>click on the 'Subscribe'</strong> link.[%END%]</li>
-	</ol>
+    <p>[%|helploc(domain)%]<strong>After this, you will receive a message telling you whether your request was accepted or not</strong>: if the subscription to the list is subject to any approval, the list owner may choose not to subscribe you. If so, do not send several other requests: it is useless as the result will remain the same. You can possibly send a message directly to the list owner (nameofthelist-request@%1) to explain why you really want to subscribe to the list...[%END%]</p>
+    <p class="retraitita">[%|helploc%]Note: you will sometimes be asked to confirm your subscription request before it can be processed. If so, please conform to the instructions contained in the message you receive.[%END%]</p>
+    <p>[%|helploc%]According to the type of list (list with subscription subject to conditions or not) and to the availability of the list owner, <strong>you may not receive the notice immediately</strong>. It is useless to send several requests.[%END%]</p>
+    <p>[%|helploc%]<strong>If your request is accepted, the message you receive confirms your subscription to the list. This message</strong> (the list Charter) <strong>contains several pieces of essential information:</strong>[%END%]</p>
+    <ul>
+        <li>[%|helploc%]your <strong>list password</strong>. This password is the same for all the lists you subscribed to with a single email address. You can <a href="#global_pref" title="How to change your password">change it online</a> after logging on to the mailing list environment;[%END%]</li>
+        <li>[%|helploc%]<strong>detailed information about the list</strong>: its purpose, the Internet address at which the message archive is available, etc.[%END%]</li>
+        <li>[%|helploc%]the <strong>rules applying to the list and its members</strong>: allowed and forbidden topics, netiquette, legal information, privacy policy, etc.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]<strong>You should keep your subscription notice</strong>: you may need it later to remember your password or to send a precise command to Sympa (example: signoff command). More generally, <strong>we advise you to keep all your subscription notices to mailing lists</strong>.[%END%]</p>
+    <p>[%|helploc%]<strong>You can also subscribe to a list through the mailing list web interface</strong>. To do that, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
+        <li>[%|helploc%]<strong>Go to the information page of the list</strong> you want to subscribe to.[%END%]</li>
+        <li>[%|helploc%]In the left menu, <strong>click on the 'Subscribe'</strong> link.[%END%]</li>
+    </ol>
 
-	<h3><a name="sympa_auth"></a>[%|helploc%]Logging on to the mailing list environment[%END%]</h3>
-	<p>[%|helploc%]To log on to the mailing list environment, use the authentication form displayed on top of the left column of the web interface. When you are logged on, your email address and user profile (subscriber, moderator or owner) are displayed there.[%END%]</p>
+    <h3><a name="sympa_auth"></a>[%|helploc%]Logging on to the mailing list environment[%END%]</h3>
+    <p>[%|helploc%]To log on to the mailing list environment, use the authentication form displayed on top of the left column of the web interface. When you are logged on, your email address and user profile (subscriber, moderator or owner) are displayed there.[%END%]</p>
 
-	<p>[%|helploc%]The authentication process varies according to your personal situation:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]<strong>If the organization offering the mailing list service uses single sign-on technology</strong> (unique account and unique authentication, for example through the <acronym lang="en" xml:lang="en" title="Central Authentication Service">CAS</acronym> system), you will preferably log on with your unique account. To do that, click on the 'Go' button next to the text '<strong>Authentication [name of the system used]</strong>'. Then, type in your login and password to log on to the authentication server.[%END%]<br />
-		<p class="retraitita">[%|helploc%]If you have already logged on to another service using the unique authentication system, your authentication is automatic. Refresh page if necessary.[%END%]</p>
-		<li>[%|helploc%]<strong>If the unique authentication process does not apply to you but you are already subscribed to lists</strong>, then you have been granted a list password (displayed in the list Charter you got when you subscribed to the list). In this case, log on through the classic method: enter the <strong>email address with which you subscribed to the list</strong> as a login and your <strong>list password</strong> in the 'Password' field.[%END%]<br />
-		<p class="retraitita">[%|helploc%]If you do not remember your list password, click on 'Lost password?'. Then enter your email address and password. Shortly afterward you will receive an email with a validation link.[%END%]</p></li>
+    <p>[%|helploc%]The authentication process varies according to your personal situation:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]<strong>If the organization offering the mailing list service uses single sign-on technology</strong> (unique account and unique authentication, for example through the <acronym lang="en" xml:lang="en" title="Central Authentication Service">CAS</acronym> system), you will preferably log on with your unique account. To do that, click on the 'Go' button next to the text '<strong>Authentication [name of the system used]</strong>'. Then, type in your login and password to log on to the authentication server.[%END%]<br />
+        <p class="retraitita">[%|helploc%]If you have already logged on to another service using the unique authentication system, your authentication is automatic. Refresh page if necessary.[%END%]</p>
+        <li>[%|helploc%]<strong>If the unique authentication process does not apply to you but you are already subscribed to lists</strong>, then you have been granted a list password (displayed in the list Charter you got when you subscribed to the list). In this case, log on through the classic method: enter the <strong>email address with which you subscribed to the list</strong> as a login and your <strong>list password</strong> in the 'Password' field.[%END%]<br />
+        <p class="retraitita">[%|helploc%]If you do not remember your list password, click on 'Lost password?'. Then enter your email address and password. Shortly afterward you will receive an email with a validation link.[%END%]</p></li>
 
-		<li>[%|helploc%]<strong>If the unique authentication process does not apply to you and you do not have a list password yet</strong>, click on '<strong>First login?</strong>' and type in your email address. A confirmation URL will be sent to that address. Then you will be able to choose your password.[%END%]</li>
+        <li>[%|helploc%]<strong>If the unique authentication process does not apply to you and you do not have a list password yet</strong>, click on '<strong>First login?</strong>' and type in your email address. A confirmation URL will be sent to that address. Then you will be able to choose your password.[%END%]</li>
 
-	</ul>
-	<p class="retraitita">[%|helploc%]Remember: the list password is a special password you will only use for the mailing list service.[%END%]</p>
+    </ul>
+    <p class="retraitita">[%|helploc%]Remember: the list password is a special password you will only use for the mailing list service.[%END%]</p>
 
-	<h3>[%|helploc%]Checking your subscriptions[%END%]</h3>
-	<p>[%|helploc%]To see all the lists you subscribed to, you need to <a href="#sympa_auth">log on</a> first. Then a list of all your lists, including a short description for each of them, will be displayed in the 'Your lists' form on the left column.[%END%]</p>
+    <h3>[%|helploc%]Checking your subscriptions[%END%]</h3>
+    <p>[%|helploc%]To see all the lists you subscribed to, you need to <a href="#sympa_auth">log on</a> first. Then a list of all your lists, including a short description for each of them, will be displayed in the 'Your lists' form on the left column.[%END%]</p>
 
-	<p>[%|helploc%]<strong>To look at a list information page, click on its name</strong>. The information page includes a description of the list (object, rules applying when sending a message, etc.), which length varies according to the list.[%END%]</p>
-	<p>[%|helploc%]From this information page, you can:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]change your <a href="#options">subscriber options</a>;[%END%]</li>
-		<li>[%|helploc%]read the <a href="arc">list archive</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="arc#arcsearch">search in the message archive</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="sendmsg">send new messages</a>;[%END%]</li>
-		<li>[%|helploc%]<a href="shared#shared_read">download documents</a> from the shared document web space;[%END%]</li>
-		<li>[%|helploc%]<a href="shared#shared_upload">upload documents</a> in the shared document web space;[%END%]</li>
-		<li>[%|helploc%]<a href="#subscribers">review members</a> of the list (if available);[%END%]</li>
-		<li>[%|helploc%]<a href="suspend">suspend or resume</a> your subscription of each list;[%END%]</li>
-		<li>[%|helploc%]<a href="#unsubscribe">unsubscribe</a> from the list.[%END%]</li>
-	</ul>
-	<p><a name="subscribers"></a>[%|helploc%]The <strong>number of people subscribed</strong> to the list is permanently displayed in the <strong>left menu</strong>. <strong>To review the list members, click on the 'Review members' link</strong> in the left menu (if the list-owner decided to deny access to the members list, this link is not available). The subscribers list displays and shows the <strong>email address</strong> and <strong>name</strong> of each of the subscribers (the indication of the name depends on the subscription method used by the subscribers).[%END%]</p>
-	<p class="retraitita">[%|helploc%]By default, each page displays 25&#160;subscribers. You can browse through the pages by using the browsing arrows or display more subscribers per page. You may also wish to sort subscribers according to their email address, domain or name by clicking on the corresponding column header.[%END%]</p>
-	<p>[%|helploc(domain)%]<strong>The names of the list owners and moderators are displayed in the left menu</strong>. You should never write directly to a list owner or moderator. If you want to ask a question or make a comment, you should use the following address: <strong>nameofthelist-request@%1</strong> (replace 'nameofthelist' by the name of the list in question).[%END%]</p>
-	<p>[%|helploc%]To know <strong>when you subscribed to the list</strong> and <strong>when you last updated your subscriber options</strong>, <strong>click on the 'Subscriber options' link</strong> in the left menu.[%END%]</p>
+    <p>[%|helploc%]<strong>To look at a list information page, click on its name</strong>. The information page includes a description of the list (object, rules applying when sending a message, etc.), which length varies according to the list.[%END%]</p>
+    <p>[%|helploc%]From this information page, you can:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]change your <a href="#options">subscriber options</a>;[%END%]</li>
+        <li>[%|helploc%]read the <a href="arc">list archive</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="arc#arcsearch">search in the message archive</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="sendmsg">send new messages</a>;[%END%]</li>
+        <li>[%|helploc%]<a href="shared#shared_read">download documents</a> from the shared document web space;[%END%]</li>
+        <li>[%|helploc%]<a href="shared#shared_upload">upload documents</a> in the shared document web space;[%END%]</li>
+        <li>[%|helploc%]<a href="#subscribers">review members</a> of the list (if available);[%END%]</li>
+        <li>[%|helploc%]<a href="suspend">suspend or resume</a> your subscription of each list;[%END%]</li>
+        <li>[%|helploc%]<a href="#unsubscribe">unsubscribe</a> from the list.[%END%]</li>
+    </ul>
+    <p><a name="subscribers"></a>[%|helploc%]The <strong>number of people subscribed</strong> to the list is permanently displayed in the <strong>left menu</strong>. <strong>To review the list members, click on the 'Review members' link</strong> in the left menu (if the list-owner decided to deny access to the members list, this link is not available). The subscribers list displays and shows the <strong>email address</strong> and <strong>name</strong> of each of the subscribers (the indication of the name depends on the subscription method used by the subscribers).[%END%]</p>
+    <p class="retraitita">[%|helploc%]By default, each page displays 25&#160;subscribers. You can browse through the pages by using the browsing arrows or display more subscribers per page. You may also wish to sort subscribers according to their email address, domain or name by clicking on the corresponding column header.[%END%]</p>
+    <p>[%|helploc(domain)%]<strong>The names of the list owners and moderators are displayed in the left menu</strong>. You should never write directly to a list owner or moderator. If you want to ask a question or make a comment, you should use the following address: <strong>nameofthelist-request@%1</strong> (replace 'nameofthelist' by the name of the list in question).[%END%]</p>
+    <p>[%|helploc%]To know <strong>when you subscribed to the list</strong> and <strong>when you last updated your subscriber options</strong>, <strong>click on the 'Subscriber options' link</strong> in the left menu.[%END%]</p>
 
-	<h3><a name="pref"></a>[%|helploc%]Managing your preferences[%END%]</h3>
-	<p>[%|helploc%]To allow you to <strong>use lists more easily</strong>, <strong>you can define a number of personal preferences</strong>. There are two types of preferences you can change:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]your <strong>subscriber options</strong>, which can vary according to the list;[%END%]</li>
-		<li>[%|helploc%]your <strong>general preferences</strong>, which apply to the entire Sympa mailing list environment.[%END%]</li>
-	</ul>
+    <h3><a name="pref"></a>[%|helploc%]Managing your preferences[%END%]</h3>
+    <p>[%|helploc%]To allow you to <strong>use lists more easily</strong>, <strong>you can define a number of personal preferences</strong>. There are two types of preferences you can change:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]your <strong>subscriber options</strong>, which can vary according to the list;[%END%]</li>
+        <li>[%|helploc%]your <strong>general preferences</strong>, which apply to the entire Sympa mailing list environment.[%END%]</li>
+    </ul>
 
-	<h4><a name="options"></a>[%|helploc%]Changing your subscriber options[%END%]</h4>
-	<p>[%|helploc%]<strong>Your subscriber options can vary from a list to another</strong>. To change them, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Go to the information page of the list</strong> for which you want to change your subscriber options.[%END%]</li>
-		<li>[%|helploc%]In the left menu, <strong>click on the 'Subscriber options' link</strong>.[%END%]</li>
-		<li><a name="deliverymode"></a><[%|helploc%]strong>Choose a message delivery mode</strong> (those options are mutually exclusive, thus you can not select several of them):[%END%]
-		<ul>
-			[% PROCESS help_user_options.tt2 %]
-			<li>[%|helploc%]<strong>suspended</strong>: this mode allows you to suspend your subscription to one or more lists for a specified or unspecified period. Unlike unsubscription, you can keep track of your subscription and reactivate it at any time by visiting the "Manage your subscription" section.[%END%]</li>
-		</ul></li>
-		<li>[%|helploc%]<strong>Choose a visibility option</strong>:[%END%]
-		<ul>
-			<li>[%|helploc%]<strong>listed in the list review page</strong>: your name and email address will be displayed in the members list (if the list owner allowed subscribers to review the list members).[%END%]</li>
-			<li>[%|helploc%]<strong>concealed</strong>: your name and email address will not be displayed in the members list. However you email address will be visible in the list archive if you send messages.[%END%]</li>
-		</ul></li>
-		<li>[%|helploc%]<strong>Click on the 'Update' button</strong>.[%END%]</li>
-	</ol>
+    <h4><a name="options"></a>[%|helploc%]Changing your subscriber options[%END%]</h4>
+    <p>[%|helploc%]<strong>Your subscriber options can vary from a list to another</strong>. To change them, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
+        <li>[%|helploc%]<strong>Go to the information page of the list</strong> for which you want to change your subscriber options.[%END%]</li>
+        <li>[%|helploc%]In the left menu, <strong>click on the 'Subscriber options' link</strong>.[%END%]</li>
+        <li><a name="deliverymode"></a><[%|helploc%]strong>Choose a message delivery mode</strong> (those options are mutually exclusive, thus you can not select several of them):[%END%]
+        <ul>
+            [% PROCESS help_user_options.tt2 %]
+            <li>[%|helploc%]<strong>suspended</strong>: this mode allows you to suspend your subscription to one or more lists for a specified or unspecified period. Unlike unsubscription, you can keep track of your subscription and reactivate it at any time by visiting the "Manage your subscription" section.[%END%]</li>
+        </ul></li>
+        <li>[%|helploc%]<strong>Choose a visibility option</strong>:[%END%]
+        <ul>
+            <li>[%|helploc%]<strong>listed in the list review page</strong>: your name and email address will be displayed in the members list (if the list owner allowed subscribers to review the list members).[%END%]</li>
+            <li>[%|helploc%]<strong>concealed</strong>: your name and email address will not be displayed in the members list. However you email address will be visible in the list archive if you send messages.[%END%]</li>
+        </ul></li>
+        <li>[%|helploc%]<strong>Click on the 'Update' button</strong>.[%END%]</li>
+    </ol>
 
-	<h4><a name="global_pref"></a>[%|helploc%]Changing your general preferences[%END%]</h4>
-	<p>[%|helploc%]The general preferences apply to all your subscriptions as well as to the way your Sympa mailing list web interface displays. To change your preferences, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
-		<li>[%|helploc%]In the form displayed on top of the left column, <strong>click on the 'Your preferences' link</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Change your preferences</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Click on 'Submit' for every option</strong> you change.[%END%]</li>
-	</ol>
-	<p>[%|helploc%]You can change:[%END%]</p>
-	<ul>
-		<li>[%|helploc%]your <strong>name</strong>; if you subscribe to a list from the mailing list server web interface, the 'Name' field will automatically be filled in the members list;[%END%]</li>
-		<li>[%|helploc%]the <strong>language in which the Sympa web interface is displayed</strong> (you can change language on every page of the web interface; your choice will remain even though you change the interface language on another page than the 'Preferences' page);[%END%]</li>
-		<li>[%|helploc%]the <strong>lifetime of the cookie placed on your computer by Sympa</strong> ('Connection expiration period'). By default, the session expires when you close your browser; if you use the mailing list service a lot, we advise you to choose a longer duration;[%END%]<br />
-		<p class="retraitita">[%|helploc%]A cookie is a small file a web server stores on your hard disk, most generally temporarily, in order to identify you as a user of its service. It contains a few pieces of personal information about you: name, email address, latest logon time, etc.[%END%]</p></li>
-		<li>[%|helploc%]the <strong>email address with which you subscribed</strong> to the lists (if you subscribed with several email addresses, the address to be replaced will be the one you logged on with);[%END%]<br />
-		<p class="retraitita">[%|helploc%]Be careful: this will change your subscriptions to all your lists. If you want to change address for a single mailing list, you had better unsubscribe from that list and subscribe again with the right email address.[%END%]</p></li>
-		<li>[%|helploc%]your <strong>list password</strong>.[%END%]</li>
-	</ul>
-	<p>[%|helploc%]The '<strong>Your other email addresses</strong>' section acts like an email address change.[%END%]</p>
+    <h4><a name="global_pref"></a>[%|helploc%]Changing your general preferences[%END%]</h4>
+    <p>[%|helploc%]The general preferences apply to all your subscriptions as well as to the way your Sympa mailing list web interface displays. To change your preferences, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
+        <li>[%|helploc%]In the form displayed on top of the left column, <strong>click on the 'Your preferences' link</strong>.[%END%]</li>
+        <li>[%|helploc%]<strong>Change your preferences</strong>.[%END%]</li>
+        <li>[%|helploc%]<strong>Click on 'Submit' for every option</strong> you change.[%END%]</li>
+    </ol>
+    <p>[%|helploc%]You can change:[%END%]</p>
+    <ul>
+        <li>[%|helploc%]your <strong>name</strong>; if you subscribe to a list from the mailing list server web interface, the 'Name' field will automatically be filled in the members list;[%END%]</li>
+        <li>[%|helploc%]the <strong>language in which the Sympa web interface is displayed</strong> (you can change language on every page of the web interface; your choice will remain even though you change the interface language on another page than the 'Preferences' page);[%END%]</li>
+        <li>[%|helploc%]the <strong>lifetime of the cookie placed on your computer by Sympa</strong> ('Connection expiration period'). By default, the session expires when you close your browser; if you use the mailing list service a lot, we advise you to choose a longer duration;[%END%]<br />
+        <p class="retraitita">[%|helploc%]A cookie is a small file a web server stores on your hard disk, most generally temporarily, in order to identify you as a user of its service. It contains a few pieces of personal information about you: name, email address, latest logon time, etc.[%END%]</p></li>
+        <li>[%|helploc%]the <strong>email address with which you subscribed</strong> to the lists (if you subscribed with several email addresses, the address to be replaced will be the one you logged on with);[%END%]<br />
+        <p class="retraitita">[%|helploc%]Be careful: this will change your subscriptions to all your lists. If you want to change address for a single mailing list, you had better unsubscribe from that list and subscribe again with the right email address.[%END%]</p></li>
+        <li>[%|helploc%]your <strong>list password</strong>.[%END%]</li>
+    </ul>
+    <p>[%|helploc%]The '<strong>Your other email addresses</strong>' section acts like an email address change.[%END%]</p>
 
-		<h3>[%|helploc%]Searching for a mailing list[%END%]</h3>
-		<p>[%|helploc%]You may need to search for a mailing list. To do that, you have three options:[%END%]</p>
-		<ul>
-			<li>[%|helploc%]<strong>browse the different sections</strong> displayed on the <a href="../home">list environment homepage</a>;[%END%]</li>
-			<li>[%|helploc%]search for a list via the <strong>search box</strong>: the searched string will return all the lists whose name or description matches your search criteria (descriptions of the lists generally consist of a short sentence);[%END%]</li>
-			<li>[%|helploc%]click on the '<a href="../lists">List of lists</a>' tab on top of page to <strong>display all available lists</strong>.[%END%]</li>
-		</ul>
-		<p class="retraitita">[%|helploc%]According to the domain to which your email address belongs (example: <em class="example">cru.fr</em>, <em class="example">fai.com</em>, etc.) and to the location you log on from, you will not have access to the same lists. However you can subscribe to a list that does not display if you know its name. To do this, <a href="#subscribe">use your email client</a>.[%END%]</p>
+        <h3>[%|helploc%]Searching for a mailing list[%END%]</h3>
+        <p>[%|helploc%]You may need to search for a mailing list. To do that, you have three options:[%END%]</p>
+        <ul>
+            <li>[%|helploc%]<strong>browse the different sections</strong> displayed on the <a href="../home">list environment homepage</a>;[%END%]</li>
+            <li>[%|helploc%]search for a list via the <strong>search box</strong>: the searched string will return all the lists whose name or description matches your search criteria (descriptions of the lists generally consist of a short sentence);[%END%]</li>
+            <li>[%|helploc%]click on the '<a href="../lists">List of lists</a>' tab on top of page to <strong>display all available lists</strong>.[%END%]</li>
+        </ul>
+        <p class="retraitita">[%|helploc%]According to the domain to which your email address belongs (example: <em class="example">cru.fr</em>, <em class="example">fai.com</em>, etc.) and to the location you log on from, you will not have access to the same lists. However you can subscribe to a list that does not display if you know its name. To do this, <a href="#subscribe">use your email client</a>.[%END%]</p>
 
-	<h3><a name="archives"></a>[%|helploc%]Reading a list archive online[%END%]</h3>
-	<p>[%|helploc%]Please refer to the <a href="arc"><strong>archive documentation</strong></a>.[%END%]</p>
+    <h3><a name="archives"></a>[%|helploc%]Reading a list archive online[%END%]</h3>
+    <p>[%|helploc%]Please refer to the <a href="arc"><strong>archive documentation</strong></a>.[%END%]</p>
 
-	<h3><a name="sendmsg"></a>[%|helploc%]Sending a message[%END%]</h3>
-	<p>[%|helploc%]Please refer to the <a href="sendmsg"><strong>documentation about sending messages</strong></a>.[%END%]</p>
+    <h3><a name="sendmsg"></a>[%|helploc%]Sending a message[%END%]</h3>
+    <p>[%|helploc%]Please refer to the <a href="sendmsg"><strong>documentation about sending messages</strong></a>.[%END%]</p>
 
-	<h3><a name="shared"></a>[%|helploc%]Using the shared document web space[%END%]</h3>
-	<p>[%|helploc%]Please refer to the <a href="shared"><strong>shared document web space documentation</strong></a>.[%END%]</p>
+    <h3><a name="shared"></a>[%|helploc%]Using the shared document web space[%END%]</h3>
+    <p>[%|helploc%]Please refer to the <a href="shared"><strong>shared document web space documentation</strong></a>.[%END%]</p>
 
-	<h3><a name="suspend"></a>[%|helploc%]Suspending or resuming your subscription of each list[%END%]</h3>
-	<p>[%|helploc%]Please refer to the <a href="suspend"><strong>subscription management documentation</strong></a>.[%END%]</p>
+    <h3><a name="suspend"></a>[%|helploc%]Suspending or resuming your subscription of each list[%END%]</h3>
+    <p>[%|helploc%]Please refer to the <a href="suspend"><strong>subscription management documentation</strong></a>.[%END%]</p>
 
-	<h3><a name="unsubscribe"></a>[%|helploc%]Unsubscribing from lists[%END%]</h3>
-	<p>[%|helploc%]To unsubscribe from a list, do as follows:[%END%]</p>
-	<ol>
-		<li>[%|helploc(conf.email,domain)%]From the address with which you subscribed to the list, send a <strong>message to %1@%2</strong>.[%END%]</li>
-		<li>[%|helploc%]In the subject line of your email, type in: <strong>unsubscribe nameofthelist</strong> (replace 'nameofthelist' by the name of the list you want to unsubscribe from).[%END%]</li>
-		<li>[%|helploc%]<strong>Leave the message body blank</strong>.[%END%]<br />
-		<p class="retraitita">[%|helploc%]To save some time, you can also send several commands in a single message. To do that, follow the instructions available in the <a href="#howitworks">How the mailing list service works</a> section.[%END%]</p></li>
-	</ol>	
-	<p>[%|helploc%]You can also unsubscribe through the mailing list web interface (you will need to repeat the operation for each list you want to unsubscribe from):[%END%]</p>
-	<ol>
-		<li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
-		<li>[%|helploc%]<strong>Go to the information page of the list</strong> you want to unsubscribe from.[%END%]</li>
-		<li>[%|helploc%]<strong>In the left menu, click on the 'Unsubscribe' link</strong>.[%END%]</li>
-	</ol>
-	<hr />
+    <h3><a name="unsubscribe"></a>[%|helploc%]Unsubscribing from lists[%END%]</h3>
+    <p>[%|helploc%]To unsubscribe from a list, do as follows:[%END%]</p>
+    <ol>
+        <li>[%|helploc(conf.email,domain)%]From the address with which you subscribed to the list, send a <strong>message to %1@%2</strong>.[%END%]</li>
+        <li>[%|helploc%]In the subject line of your email, type in: <strong>unsubscribe nameofthelist</strong> (replace 'nameofthelist' by the name of the list you want to unsubscribe from).[%END%]</li>
+        <li>[%|helploc%]<strong>Leave the message body blank</strong>.[%END%]<br />
+        <p class="retraitita">[%|helploc%]To save some time, you can also send several commands in a single message. To do that, follow the instructions available in the <a href="#howitworks">How the mailing list service works</a> section.[%END%]</p></li>
+    </ol>
+    <p>[%|helploc%]You can also unsubscribe through the mailing list web interface (you will need to repeat the operation for each list you want to unsubscribe from):[%END%]</p>
+    <ol>
+        <li>[%|helploc%]Go to the list environment <strong><a href="../home">homepage</a></strong> and <strong>log on</strong>.[%END%]</li>
+        <li>[%|helploc%]<strong>Go to the information page of the list</strong> you want to unsubscribe from.[%END%]</li>
+        <li>[%|helploc%]<strong>In the left menu, click on the 'Unsubscribe' link</strong>.[%END%]</li>
+    </ol>
+    <hr />
 <!-- end help_user.tt2 -->

--- a/default/web_tt2/help_user_options.tt2
+++ b/default/web_tt2/help_user_options.tt2
@@ -6,16 +6,16 @@
 <ul>
 [%~ END %]
 
-<li>[%|helploc%]<strong>digest MIME format</strong>: instead of receiving the list messages in a normal manner, you will get a digest of them on a regular basis. This digest compiles a group of messages from the list, using multipart/digest <acronym lang="en" xml:lang="en" title="Multipurpose Internet Mail Extension">MIME</acronym> format. The digest frequency is set up by the list owner.[%END%]</li>
-<li>[%|helploc%]<strong>digest plain text format</strong>: instead of receiving the list messages in a normal manner, you will get a digest of them on a regular basis. This digest compiles a group of messages from the list, using plain text format. The digest frequency is set up by the list owner.[%END%]</li>
-<li>[%|helploc%]<strong>summary mode</strong>: instead of receiving the list messages in a normal manner, you will get a list of them on a regular basis. To read the messages, you will need to browse the online list archive.[%END%]</li>
-<li>[%|helploc%]<strong>notice mode</strong>: with this mode, you will receive all the messages with a blank body: this way you are informed of every message sent to the list real time, without risk of flooding your inbox.[%END%]</li>
-<li>[%|helploc%]<strong>no mail (useful for vacations)</strong>: this mode makes it possible not to receive the messages of the list. It is especially useful when you have no access to your email for a long time and want to remain subscribed to the list nevertheless.[%END%]</li>
-<li>[%|helploc%]<strong>text only mode</strong>: this mode allows you to receive only the text version (text/plain) of messages sent in both formats (plain text and <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym>).[%END%]</li>
-<li>[%|helploc%]<strong>HTML only mode</strong>: this mode allows you to receive only the <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym> version (text/html) of messages sent in both formats.[%END%]</li>
-<li>[%|helploc%]<strong>urlize mode</strong>: this mode allows you not to receive attached documents. However these documents are available in the list archive and you can access them through a <acronym title="Uniform Resource Locator" lang="en" xml:lang="en">URL</acronym> provided in the message.[%END%]</li>
-<li>[%|helploc%]<strong>you do not receive your own posts</strong>: this mode allows you not to receive a copy of your own messages.[%END%]</li>
-<li>[%|helploc%]<strong>standard (direct reception)</strong>: this mode is the default delivery mode; it cancels any other delivery mode.[%END%]</li>
+    <li>[%|helploc%]<strong>digest MIME format</strong>: instead of receiving the list messages in a normal manner, you will get a digest of them on a regular basis. This digest compiles a group of messages from the list, using multipart/digest <acronym lang="en" xml:lang="en" title="Multipurpose Internet Mail Extension">MIME</acronym> format. The digest frequency is set up by the list owner.[%END%]</li>
+    <li>[%|helploc%]<strong>digest plain text format</strong>: instead of receiving the list messages in a normal manner, you will get a digest of them on a regular basis. This digest compiles a group of messages from the list, using plain text format. The digest frequency is set up by the list owner.[%END%]</li>
+    <li>[%|helploc%]<strong>summary mode</strong>: instead of receiving the list messages in a normal manner, you will get a list of them on a regular basis. To read the messages, you will need to browse the online list archive.[%END%]</li>
+    <li>[%|helploc%]<strong>notice mode</strong>: with this mode, you will receive all the messages with a blank body: this way you are informed of every message sent to the list real time, without risk of flooding your inbox.[%END%]</li>
+    <li>[%|helploc%]<strong>no mail (useful for vacations)</strong>: this mode makes it possible not to receive the messages of the list. It is especially useful when you have no access to your email for a long time and want to remain subscribed to the list nevertheless.[%END%]</li>
+    <li>[%|helploc%]<strong>text only mode</strong>: this mode allows you to receive only the text version (text/plain) of messages sent in both formats (plain text and <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym>).[%END%]</li>
+    <li>[%|helploc%]<strong>HTML only mode</strong>: this mode allows you to receive only the <acronym lang="en" xml:lang="en" title="HyperText Markup Language">HTML</acronym> version (text/html) of messages sent in both formats.[%END%]</li>
+    <li>[%|helploc%]<strong>urlize mode</strong>: this mode allows you not to receive attached documents. However these documents are available in the list archive and you can access them through a <acronym title="Uniform Resource Locator" lang="en" xml:lang="en">URL</acronym> provided in the message.[%END%]</li>
+    <li>[%|helploc%]<strong>you do not receive your own posts</strong>: this mode allows you not to receive a copy of your own messages.[%END%]</li>
+    <li>[%|helploc%]<strong>standard (direct reception)</strong>: this mode is the default delivery mode; it cancels any other delivery mode.[%END%]</li>
 
 [% IF component.caller != 'help_user.tt2' ~%]
 </ul>

--- a/default/web_tt2/info.tt2
+++ b/default/web_tt2/info.tt2
@@ -22,7 +22,7 @@
         </p>
       [% END %]
     [% END %]
-    
+
     [% IF is_owner %]
       [% IF mod_subscription > 0 %]
         <p class="small-8 small-centered columns alert-box info text-center">
@@ -39,7 +39,7 @@
      [% IF is_owner %]
     <div class="item_list">
       <p>[%|loc%]Common administrative options are linked below; full administrative options are available by selecting Admin beneath List Options in the Left Navigation menu.[%END%]</p>
-  
+
       <div class="item">
         <div class="item_content">
          <a class="item_title" href="[% 'review' | url_rel([list]) %]"><i class="fa fa-users fa-3x pull-left fa-border"></i> [%|loc%]View or Manage Subscribers[%END%]</a>
@@ -51,7 +51,7 @@
           </ul>
         </div>
       </div>
-  
+
       <div class="item">
         <div class="item_content">
           <a class="item_title" href="[% 'admin' | url_rel([list]) %]"><i class="fa fa-wrench fa-3x pull-left fa-border"></i> [%|loc%]List Configuration[%END%]</a>
@@ -69,7 +69,7 @@
           </ul>
         </div>
       </div>
-  
+
       <div class="item">
         <div class="item_content">
           <a class="item_title" href="[% 'arc' | url_rel([list]) %]"><i class="fa fa-archive fa-3x pull-left fa-border"></i> [%|loc%]List Archives[%END%]</a>
@@ -79,7 +79,7 @@
           </ul>
         </div>
       </div>
-  
+
       <div class="item">
         <div class="item_content">
           <a class="item_title" href="[% 'edit_list_request' | url_rel([list,'data_source']) %]"><i class="fa fa-database fa-3x pull-left fa-border"></i> [%|loc%]Data Sources Configuration[%END%]</a>

--- a/default/web_tt2/latest_arc.tt2
+++ b/default/web_tt2/latest_arc.tt2
@@ -2,17 +2,17 @@
 
 <h2>
  [% IF count %]
-   [%|loc(count)%] The %1 most recent messages [%END%] 
+   [%|loc(count)%] The %1 most recent messages [%END%]
  [% ELSE %]
-   [%|loc%] Recent messages [%END%] 
+   [%|loc%] Recent messages [%END%]
  [% END %]
 
  [% IF for %]
-   [%|loc(for)%] for %1 days [%END%] 	
+   [%|loc(for)%] for %1 days [%END%]
  [% END %]
-</h2> 	
-<br /> 
- 
+</h2>
+<br />
+
 <table  class="responsive table_style">
 <caption>[%|loc%] The most recent messages for this list [%END%]</caption>
  <tr class="color_light">
@@ -21,14 +21,14 @@
    <th>[%|loc%]From[%END%]</th>
  </tr>
 
- [% FOREACH a = archives %] 
+ [% FOREACH a = archives %]
  <tr>
    <td> [% a.date %] </td>
    <td> <a href="[% 'arcsearch_id' | url_abs([list,a.year_month,a.message_id]) %]" > [% UNLESS a.subject.length %]<i>[%|loc%]No subject[%END%]</i>[% ELSE %][% a.subject %][%END%] </td>
    <td> [% a.gecos || a.from.split('@').0 %] </td>
  </tr>
- 
- [% END %]  
+
+ [% END %]
 
 </table>
 <!-- end latest_arc.tt2 -->

--- a/default/web_tt2/latest_d_read.tt2
+++ b/default/web_tt2/latest_d_read.tt2
@@ -2,17 +2,17 @@
 
 <h2>
  [% IF count %]
-   [%|loc(count)%] The %1 most recent shared documents [%END%] 
+   [%|loc(count)%] The %1 most recent shared documents [%END%]
  [% ELSE %]
-   [%|loc%] Most recent shared documents [%END%] 
+   [%|loc%] Most recent shared documents [%END%]
  [% END %]
 
  [% IF for %]
-   [%|loc(for)%] for %1 days [%END%] 	
+   [%|loc(for)%] for %1 days [%END%]
  [% END %]
-</h2> 	
-<br /> 
- 
+</h2>
+<br />
+
 <table class="responsive table_style" >
 <caption>[%|loc%]Most recent documents for this list [%END%] </caption>
  <tr class="color_light">
@@ -37,20 +37,20 @@
     [%~ ELSE ~%]
       <a href="[% 'd_read' | url_rel([list,d.paths_d]) %]">
         <img src="[% d.icon %]" alt="[% d.title %]" /> [% d.name %] </a>
-    [%~ END %] 
+    [%~ END %]
 
    <td>
-   [%~ IF d.owner ~%] 
-     [% d.owner %] 
+   [%~ IF d.owner ~%]
+     [% d.owner %]
    [%~ ELSE ~%]
-     [%|loc%]Unknown[%END%] 
-   [%~ END ~%] 
+     [%|loc%]Unknown[%END%]
+   [%~ END ~%]
    </td>
    <td> <a href="[% 'd_read' | url_rel([list,d.parent.paths_d]) %]"/>
      [% d.parent.name %] </td>
   </tr>
- 
- [% END %]  
+
+ [% END %]
 
 </table>
 <!-- end latest_d_read.tt2 -->

--- a/default/web_tt2/latest_lists.tt2
+++ b/default/web_tt2/latest_lists.tt2
@@ -2,17 +2,17 @@
 
 <h2>
  [% IF count %]
-   [%|loc(count)%]The %1 newest lists[%END%] 
+   [%|loc(count)%]The %1 newest lists[%END%]
  [% ELSE %]
-   [%|loc%]New lists[%END%] 
+   [%|loc%]New lists[%END%]
  [% END %]
 
  [% IF for %]
-   [%|loc(for)%] for %1 days [%END%] 	
+   [%|loc(for)%] for %1 days [%END%]
  [% END %]
-</h2> 	
+</h2>
 
-<br /> 
+<br />
 
 <table class="responsive table_style" >
 <caption>[%|loc%] The latest lists of this robot[%END%] </caption>
@@ -36,9 +36,9 @@
   <td> [% l.date %] </td>
   <td> [% l.subject %] </td>
  </tr>
- 
- [% END %] 
- 
+
+ [% END %]
+
  <br />
 </table>
 

--- a/default/web_tt2/lists_categories.tt2
+++ b/default/web_tt2/lists_categories.tt2
@@ -7,8 +7,8 @@
       [% LAST %]
     [% ELSIF topic.sub %]
       [% FOREACH subtopic = topic.sub %]
-	[% SET single_topic = "" %]
-	[% LAST %]
+        [% SET single_topic = "" %]
+        [% LAST %]
       [% END %]
     [% END %]
   [% END %]
@@ -21,10 +21,10 @@
     [% SET topic_other = 0 %]
     [% FOREACH topic = topics %]
       [% IF topic.id == 'other' || topic.id == 'topicsless' %]
-	[% UNLESS topic_other %]
+        [% UNLESS topic_other %]
           <li><a class="heavyWork" href="[% 'lists' | url_rel([topic.id]) %]"><strong>[% IF topic.current_title %][% topic.current_title %][% ELSE %][%|loc%]Others[%END%][% END %]</strong></a></li>
-	  [% SET topic_other = 1 %]
-	[% END %]
+          [% SET topic_other = 1 %]
+        [% END %]
       [% ELSE %]
        <li><a class="heavyWork" href="[% 'lists' | url_rel([topic.id]) %]"><strong>[% topic.current_title %]</strong></a></li>
       [% END %]
@@ -38,11 +38,11 @@
       [% END %]
       [% IF topic.next %]
        </ul>
-   
-   
+
+
       <ul class="mailing_lists_menu">
       [% END %]
     [% END %]
       </ul>
   [% END %]
-<!-- end lists_categories.tt2 -->	
+<!-- end lists_categories.tt2 -->

--- a/default/web_tt2/ls_templates.tt2
+++ b/default/web_tt2/ls_templates.tt2
@@ -132,7 +132,7 @@
       <input class="MainMenuLinks" type="submit" name="action_remove_template"
         value="[%|loc%]rm[% END %]" />
     </fieldset>
-    </form>	
+    </form>
   [% END %]
   </td>
  [% END %]

--- a/default/web_tt2/main.tt2
+++ b/default/web_tt2/main.tt2
@@ -39,8 +39,8 @@
 [% IF nomenu %]
       [% PROCESS error.tt2 IF errors %]
       <div class="nomenu">
-			[% PROCESS notice.tt2 IF notices %]
-			[% PROCESS "${action}.tt2" IF action %]
+            [% PROCESS notice.tt2 IF notices %]
+            [% PROCESS "${action}.tt2" IF action %]
       </div>
 [% ELSE %]
 

--- a/default/web_tt2/manage_template.tt2
+++ b/default/web_tt2/manage_template.tt2
@@ -8,44 +8,44 @@
 <table border="1">
 <table  class="responsive listOfItems">
 <caption>[%|loc%]Listing rejection messages[%END%]</caption>
-	<tr><th colspan="4">[%|loc%]Listing rejection messages[%END%]</th></tr>
-	<tr><th>[%|loc%]Use as default[%END%]</th><th>[%|loc%]Message name[%END%]</th><th colspan="2">[%|loc%]Operation[%END%]</th></tr>
+    <tr><th colspan="4">[%|loc%]Listing rejection messages[%END%]</th></tr>
+    <tr><th>[%|loc%]Use as default[%END%]</th><th>[%|loc%]Message name[%END%]</th><th colspan="2">[%|loc%]Operation[%END%]</th></tr>
 
-        <form action="[% path_cgi %]" method="post" name="manage_templates">
-        <fieldset>
-        <input type="hidden" name="action" value="rt_setdefault">
-        <input type="hidden" name="list" value="[% list %]">
+    <form action="[% path_cgi %]" method="post" name="manage_templates">
+    <fieldset>
+    <input type="hidden" name="action" value="rt_setdefault">
+    <input type="hidden" name="list" value="[% list %]">
 
-	[% SET dark = 1 %]
-	[% FOREACH file = available_files %]
-		[% IF dark == '1' %]
-			  [% dark = '0' %]
-			  <tr>
-		[% ELSE %]
-			  [% dark = '1' %]
-        		  <tr class="color0">
-		[% END %]
-                <td align="center">
-                <input type="radio" name="new_default" value="[% file %]"
-                  [% IF file == default_reject_template ~%]
-                    checked="checked"
-                  [%~ ELSE ~%]
-                    class="submitOnChange"
-                  [%~ END %]>
-                </td> 
-       		<td>
-		[% file %]
-		</td>
-                <td  align="center">
-		<a href="[% 'rt_edit' | url_rel([list,file]) %]"
-		  class="MainMenuLinks">[%|loc%]Edit[%END%]</a>
-		</td>
-		<td align="center">
-		<a href="[% 'rt_delete' | url_rel([list,file]) %]"
-		  class="MainMenuLinks" >[%|loc%]Delete[%END%]</a>
-		</td>
-		</tr>
-	[% END %]
+    [% SET dark = 1 %]
+    [% FOREACH file = available_files %]
+        [% IF dark == '1' %]
+          [% dark = '0' %]
+          <tr>
+        [% ELSE %]
+          [% dark = '1' %]
+          <tr class="color0">
+        [% END %]
+            <td align="center">
+              <input type="radio" name="new_default" value="[% file %]"
+                [% IF file == default_reject_template ~%]
+                  checked="checked"
+                [%~ ELSE ~%]
+                  class="submitOnChange"
+                [%~ END %]>
+            </td>
+            <td>
+              [% file %]
+            </td>
+            <td  align="center">
+              <a href="[% 'rt_edit' | url_rel([list,file]) %]"
+                class="MainMenuLinks">[%|loc%]Edit[%END%]</a>
+            </td>
+            <td align="center">
+              <a href="[% 'rt_delete' | url_rel([list,file]) %]"
+                class="MainMenuLinks" >[%|loc%]Delete[%END%]</a>
+            </td>
+        </tr>
+    [% END %]
 </fieldset>
 </form>
 

--- a/default/web_tt2/picture_upload.tt2
+++ b/default/web_tt2/picture_upload.tt2
@@ -1,33 +1,33 @@
 <!-- picture_upload.tt2 -->
 [% IF pictures_display %]
 
-<h4>[%|loc%]Setting your picture for this list[%END%]</h4>
+  <h4>[%|loc%]Setting your picture for this list[%END%]</h4>
 
-	 
- 	 <form method="post" action="[% path_cgi %]" enctype="multipart/form-data" >
 
-<p>[%|loc(conf.pictures_max_size / 1024)%]You can upload your picture below. It will be available in the list review page. The picture should use a standard format (GIF, JPEG or PNG) and the file size should not exceed %1 Kb.[%END%]</p><br />
+  <form method="post" action="[% path_cgi %]" enctype="multipart/form-data" >
 
-	 <fieldset>
-           <label for="uploaded_file"><input id="uploaded_file" type="file" name="uploaded_file"/></label>
- 	   <input class="MainMenuLinks" type="submit" value="[%|loc%]Submit[%END%]" name="action_upload_pictures" />
- 	   <input class="MainMenuLinks" type="submit" value="[%|loc%]Delete[%END%]" name="action_delete_pictures" />
- 	   <input type="hidden" name="list" value="[% list %]" /><br /><br />
-	 </fieldset>
- 	 </form>
- 	 [% IF pictures_url %]
-	 <div id="pictures_block">
-	   <div id="large">
- 	     <a href="[%pictures_url%]" title="[%|loc%]Open in a new window[%END%]" target="pictures"><img src="[%pictures_url%]" alt="[%|loc%]Your picture[%END%]" /></a>
-	     <br />[%|loc%]Your picture[%END%]
-	   </div>
-	   <div id="small">
- 	     <img src="[%pictures_url%]" alt="[%|loc%]Your picture in the subscribers list[%END%]" />
- 	     <br />[%|loc%]In the members page[%END%]
-	   </div>
-	 <p class="spacer"></p>
-	 </div>
- 	 [%END%]
-  	   <br />
-      [% END %]
+    <p>[%|loc(conf.pictures_max_size / 1024)%]You can upload your picture below. It will be available in the list review page. The picture should use a standard format (GIF, JPEG or PNG) and the file size should not exceed %1 Kb.[%END%]</p><br />
+
+    <fieldset>
+      <label for="uploaded_file"><input id="uploaded_file" type="file" name="uploaded_file"/></label>
+      <input class="MainMenuLinks" type="submit" value="[%|loc%]Submit[%END%]" name="action_upload_pictures" />
+      <input class="MainMenuLinks" type="submit" value="[%|loc%]Delete[%END%]" name="action_delete_pictures" />
+      <input type="hidden" name="list" value="[% list %]" /><br /><br />
+    </fieldset>
+  </form>
+  [% IF pictures_url %]
+    <div id="pictures_block">
+      <div id="large">
+        <a href="[%pictures_url%]" title="[%|loc%]Open in a new window[%END%]" target="pictures"><img src="[%pictures_url%]" alt="[%|loc%]Your picture[%END%]" /></a>
+        <br />[%|loc%]Your picture[%END%]
+      </div>
+      <div id="small">
+        <img src="[%pictures_url%]" alt="[%|loc%]Your picture in the subscribers list[%END%]" />
+        <br />[%|loc%]In the members page[%END%]
+      </div>
+      <p class="spacer"></p>
+    </div>
+  [%END%]
+  <br />
+[% END %]
 <!-- end picture_upload.tt2 -->

--- a/default/web_tt2/pref.tt2
+++ b/default/web_tt2/pref.tt2
@@ -4,30 +4,30 @@
 
 <form action="[% path_cgi %]" method="post">
   <fieldset>
-  <label>[%|loc%]Email:[%END%]  </label>[% user.email %]
-  <label for="gecos">[%|loc%]Name:[%END%]  </label><input type="text" id="gecos" name="gecos" size="30" value="[% user.gecos %]" />
-  <label for="lang" style="vertical-align:top;">[%|loc%]Language:[%END%]  </label>
-  <div>
-  <select id="lang" name="lang" class="neutral">
-    [% FOREACH l = languages %]
-      <option value="[% l.key %]" lang="[% l.key %]" xml:lang="[% l.key %]"
-       [%~ IF l.value.selected %] selected="selected"[% END %]>
-      [%~ l.key | optdesc('lang') %]</option>
-    [% END %]
-  </select>
-  </div>
-  <label for="cookie_delay">[%|loc%]Connection expiration period:[%END%]  </label>
-  <div>
-  <select name="cookie_delay" id="cookie_delay">
-    [% FOREACH period = cookie_periods %]
-      <option value="[% period.value %]"
-       [%~ IF period.selected %] selected="selected"[% END %]>
-      [%~ period.desc %]</option>
-    [% END %]
-  </select>
-  </div>
+    <label>[%|loc%]Email:[%END%]  </label>[% user.email %]
+    <label for="gecos">[%|loc%]Name:[%END%]  </label><input type="text" id="gecos" name="gecos" size="30" value="[% user.gecos %]" />
+    <label for="lang" style="vertical-align:top;">[%|loc%]Language:[%END%]  </label>
+    <div>
+      <select id="lang" name="lang" class="neutral">
+        [% FOREACH l = languages %]
+          <option value="[% l.key %]" lang="[% l.key %]" xml:lang="[% l.key %]"
+          [%~ IF l.value.selected %] selected="selected"[% END %]>
+          [%~ l.key | optdesc('lang') %]</option>
+        [% END %]
+      </select>
+    </div>
+    <label for="cookie_delay">[%|loc%]Connection expiration period:[%END%]  </label>
+    <div>
+      <select name="cookie_delay" id="cookie_delay">
+        [% FOREACH period = cookie_periods %]
+          <option value="[% period.value %]"
+          [%~ IF period.selected %] selected="selected"[% END %]>
+          [%~ period.desc %]</option>
+        [% END %]
+      </select>
+    </div>
 
-  <input class="MainMenuLinks" type="submit" name="action_setpref" value="[%|loc%]Submit[%END%]" />
+    <input class="MainMenuLinks" type="submit" name="action_setpref" value="[%|loc%]Submit[%END%]" />
 
   </fieldset>
 </form>
@@ -38,27 +38,27 @@
 
 <p>[%|loc%]You can update your email address for all your list memberships at once. Any list owner or list moderator email addresses will also be updated.[%END%]</p>
 <form action="[% path_cgi %]" method="post">
-<fieldset>
-<div>
-  <label for="new_email">[%|loc%]New email address:[%END%] </label>
-  <input id="new_email" name="email" size="25" />
-</div>
-<input type="hidden" name="current_email" value="[% user.email %]" />
-<input class="MainMenuLinks" type="submit" name="action_move_user"
- value="[%|loc%]Change Email[%END%]" />
-</fieldset>
+  <fieldset>
+    <div>
+      <label for="new_email">[%|loc%]New email address:[%END%] </label>
+      <input id="new_email" name="email" size="25" />
+    </div>
+    <input type="hidden" name="current_email" value="[% user.email %]" />
+    <input class="MainMenuLinks" type="submit" name="action_move_user"
+     value="[%|loc%]Change Email[%END%]" />
+  </fieldset>
 </form>
-<br /> 
+<br />
 
 [% UNLESS use_sso %]
 <h4>[%|loc%]Changing your password[%END%]</h4>
-  
+
 <form action="[% path_cgi %]" method="post">
-<fieldset>
-<label for="newpasswd1">[%|loc%]New password:[%END%]  </label><input type="password" name="newpasswd1" id="newpasswd1" size="25" />
-<label for="newpasswd2">[%|loc%]Re-enter your new password:[%END%]  </label><input type="password" name="newpasswd2" id="newpasswd2" size="25" />
-<input class="MainMenuLinks" type="submit" name="action_setpasswd" value="[%|loc%]Submit[%END%]" />
-</fieldset>          
+  <fieldset>
+    <label for="newpasswd1">[%|loc%]New password:[%END%]  </label><input type="password" name="newpasswd1" id="newpasswd1" size="25" />
+    <label for="newpasswd2">[%|loc%]Re-enter your new password:[%END%]  </label><input type="password" name="newpasswd2" id="newpasswd2" size="25" />
+    <input class="MainMenuLinks" type="submit" name="action_setpasswd" value="[%|loc%]Submit[%END%]" />
+  </fieldset>
 </form>
 [% END %]
 

--- a/default/web_tt2/renewpasswd.tt2
+++ b/default/web_tt2/renewpasswd.tt2
@@ -13,7 +13,7 @@
 [% ELSIF login_error == 'ticket_sent' %]
       [%|loc%]You will receive an email that will allow you to choose your password.[%END%]
 [% ELSE %]
-[% IF requestpasswd_context == 'firstpasswd' %]	
+[% IF requestpasswd_context == 'firstpasswd' %]
       <p>[%|loc%]Please enter your email address to begin the registration process.[%END%]</p>
 [% ELSE %]
       <p>[%|loc%]You have forgotten your password. You must renew it.[%END%]</p>
@@ -21,18 +21,18 @@
 [% END %]
 [% IF SAFE_TO_REVEAL_EMAIL %]
       <form class="bold_label" action="[% path_cgi %]" method="post">
-	<fieldset>
-	<input type="hidden" name="referer" value="[% referer %]" />
-	<input type="hidden" name="action" value="sendpasswd" />
-           <label for="email">[%|loc%]Your e-mail address:[%END%] </label>
-           <input id="email" type="text" name="email" size="20" value="[% unauthenticated_email %]" />
-           <input class="MainMenuLinks" type="submit" name="action_requestpasswd" 
-[% IF requestpasswd_context == 'firstpasswd' %]
-value="[%|loc%]Request first password[%END%]" />
-[% ELSE %]
-value="[%|loc%]Request new password[%END%]" />
-[% END %]
-	</fieldset>
+        <fieldset>
+          <input type="hidden" name="referer" value="[% referer %]" />
+          <input type="hidden" name="action" value="sendpasswd" />
+          <label for="email">[%|loc%]Your e-mail address:[%END%] </label>
+          <input id="email" type="text" name="email" size="20" value="[% unauthenticated_email %]" />
+          <input class="MainMenuLinks" type="submit" name="action_requestpasswd"
+            [% IF requestpasswd_context == 'firstpasswd' %]
+              value="[%|loc%]Request first password[%END%]" />
+            [% ELSE %]
+              value="[%|loc%]Request new password[%END%]" />
+            [% END %]
+        </fieldset>
       </form>
 [% END %]
 <!-- end renewpasswd.tt2 -->

--- a/default/web_tt2/review.tt2
+++ b/default/web_tt2/review.tt2
@@ -121,7 +121,7 @@
 [% SET thosesubscribers = members %]
 [% PROCESS subscriber_table.tt2 %]
 
-[% IF action == 'search' %]	
+[% IF action == 'search' %]
   [% IF similar_subscribers_occurence != 0 %]
     <h2> [%|loc(similar_subscribers_occurence)%] Other similar subscriber's email(s) (%1)[%END%]</h2>
   [% SET thosesubscribers = similar_subscribers %]
@@ -153,7 +153,7 @@
      <table  class="responsive listOfItems">
      <caption>[%|loc%]List of exclude[%END%]</caption>
       <tr>
-	<th>[%|loc%]Email[%END%]</th>
+        <th>[%|loc%]Email[%END%]</th>
         <th>[%|loc%]Since[%END%]</th>
       </tr>
 
@@ -162,9 +162,9 @@
           [% FOREACH exc = exclude_users %] 
             <tr class="color0">
               <td>&nbsp;[% exc.email %]&nbsp;</td>
-	      <td>&nbsp;[% exc.since %]&nbsp;</td>
+              <td>&nbsp;[% exc.since %]&nbsp;</td>
             </tr>
-	  [% END %]
+          [% END %]
         [% END %]
       [% END %]
     </table>

--- a/default/web_tt2/reviewbouncing.tt2
+++ b/default/web_tt2/reviewbouncing.tt2
@@ -4,7 +4,7 @@
 [% IF bounce_rate %]
 <a class="actionMenuLinks" href="[% 'export_member' | url_rel([list,'bounce']) %]">[%|loc%]Dump[%END%]</a>
 
-<form action="[% path_cgi %]" method="post"> 
+<form action="[% path_cgi %]" method="post">
 <fieldset>
       <input type="hidden" name="previous_action" value="reviewbouncing" />
       <input type="hidden" name="list" value="[% list %]" />
@@ -24,8 +24,8 @@
   <input type="hidden" name="previous_action" value="[% action %]" />
   <input type="hidden" name="action" value="remind" />
   <input type="hidden" name="list" value="[% list %]" />
-</div>  
-</form>	
+</div>
+</form>
 
 <form action="[% path_cgi %]">
 <fieldset>
@@ -77,71 +77,71 @@
 <form name="myform" action="[% path_cgi %]" method="POST"
   class="toggleContainer" data-toggle-selector="input[name='email']">
 <fieldset>
-     <input type="hidden" name="list" value="[% list %]" /> 	 
-     <input type="hidden" name="previous_action" value="reviewbouncing" /> 	 
+  <input type="hidden" name="list" value="[% list %]" />
+  <input type="hidden" name="previous_action" value="reviewbouncing" />
   <table  class="listOfItems">
-  <caption>[%|loc%]Table to display list bounces[%END%]</caption>
-      <tr>
-        <th rowspan="2"><a href="#"
-          data-tooltip aria-haspopup="true"
-          title="[%|loc%]Toggle Selection[%END%]"
-          class="toggleButton"><i class="fa fa-check-square-o"></i> </a></th>
-        <th rowspan="2">[%|loc%]Email[%END%]</th>
-	<th rowspan="2">[%|loc%]Bounce score[%END%]</th>
-	<th colspan="3">[%|loc%]Details[%END%]</th>
-      </tr>
-      <tr>
-	<th>[%|loc%]Number of bounces[%END%]</th>
-	<th>[%|loc%]First bounce[%END%]</th>
-	<th>[%|loc%]Last bounce[%END%]</th>
-      </tr>
+    <caption>[%|loc%]Table to display list bounces[%END%]</caption>
+    <tr>
+      <th rowspan="2"><a href="#"
+        data-tooltip aria-haspopup="true"
+        title="[%|loc%]Toggle Selection[%END%]"
+        class="toggleButton"><i class="fa fa-check-square-o"></i> </a></th>
+      <th rowspan="2">[%|loc%]Email[%END%]</th>
+      <th rowspan="2">[%|loc%]Bounce score[%END%]</th>
+      <th colspan="3">[%|loc%]Details[%END%]</th>
+    </tr>
+    <tr>
+      <th>[%|loc%]Number of bounces[%END%]</th>
+      <th>[%|loc%]First bounce[%END%]</th>
+      <th>[%|loc%]Last bounce[%END%]</th>
+    </tr>
 
-      
-      [% FOREACH u = members %]
-      
-	[% IF dark == '1' %]
-	  <tr>
-	[% ELSE %]
-	  <tr class="color0">
-	[% END %]
 
-	  <td>
-	    <input type="checkbox" name="email" value="[% u.email %]" />
-	  </td>
-	  <td>
-	    <a href="[% 'editsubscriber' | url_rel([list],{email=>u.email,previous_action=>action}) %]">[% u.email %]</a>
+    [% FOREACH u = members %]
 
-	  </td>
-          <td class="text_center 
-	  [% IF u.bounce_level == '2' %]
-            bounce_level2
-	  [% ELSIF u.bounce_level == '1' %]
-	    bounce_level1
-	  [% END %]
-	  ">
-             [% IF ! u.bounce_score %]
+      [% IF dark == '1' %]
+        <tr>
+      [% ELSE %]
+        <tr class="color0">
+      [% END %]
+
+          <td>
+            <input type="checkbox" name="email" value="[% u.email %]" />
+          </td>
+          <td>
+            <a href="[% 'editsubscriber' | url_rel([list],{email=>u.email,previous_action=>action}) %]">[% u.email %]</a>
+
+          </td>
+          <td class="text_center
+            [% IF u.bounce_level == '2' %]
+                  bounce_level2
+            [% ELSIF u.bounce_level == '1' %]
+              bounce_level1
+            [% END %]
+          ">
+            [% IF ! u.bounce_score %]
               [%|loc%]no score[%END%]
-             [% ELSE %]
-  	      [% u.bounce_score %]
-             [% END %]
-	  </td>
+            [% ELSE %]
+              [% u.bounce_score %]
+            [% END %]
+          </td>
           <td>[% u.bounce_count %]</td>
           <td>[% u.first_bounce %]</td>
           <td>[% u.last_bounce %]</td>
-       </tr>
+        </tr>
 
-        [% IF dark == '1' %]
-	  [% SET dark = 0 %]
-	[% ELSE %]
-	  [% SET dark = 1 %]
-	[% END %]
+      [% IF dark == '1' %]
+        [% SET dark = 0 %]
+      [% ELSE %]
+        [% SET dark = 1 %]
+      [% END %]
 
-        [% END %]
-      </table>
+    [% END %]
+  </table>
 <div class="text-center">
 [% IF prev_page ~%]
   <a href="[% 'reviewbouncing' | url_rel([list,prev_page,size]) %]">
-  <i class="fa fa-caret-left fa-lg" title="[%|loc%]Previous page[%END%]"></i>
+    <i class="fa fa-caret-left fa-lg" title="[%|loc%]Previous page[%END%]"></i>
   </a>
 [%~ END %]
 [% IF page ~%]
@@ -149,7 +149,7 @@
 [%~ END %]
 [% IF next_page ~%]
   <a href="[% 'reviewbouncing' | url_rel([list,next_page,size]) %]">
-  <i class="fa fa-caret-right fa-lg" title="[%|loc%]Next page[%END%]"></i>
+    <i class="fa fa-caret-right fa-lg" title="[%|loc%]Next page[%END%]"></i>
   </a>
 [%~ END %]
 </div>

--- a/default/web_tt2/rss.tt2
+++ b/default/web_tt2/rss.tt2
@@ -34,7 +34,7 @@
    [%|loc%]The most active lists[%END%] 
  [%- END -%]
  [%- IF for -%]
-   [%|loc(for)%]for %1 days[%END%] 	
+   [%|loc(for)%]for %1 days[%END%]
  [%- END -%]
  [%- IF subtitle %] - [% subtitle %] [% END -%]
 [%- ELSIF action == 'latest_arc' -%]  
@@ -44,7 +44,7 @@
    [%|loc%]Most recent messages[%END%] 
  [%- END -%]
  [%- IF for -%]
-   [%|loc(for)%]for %1 days [%END%] 	
+   [%|loc(for)%]for %1 days [%END%]
  [%- END -%]
 [%- ELSIF action == 'latest_d_read' -%]  
  [%- IF count -%]
@@ -53,7 +53,7 @@
    [%|loc%]Most recent shared documents[%END%] 
  [%- END -%]
  [%- IF for -%]
-   [%|loc(for)%]for %1 days [%END%] 	
+   [%|loc(for)%]for %1 days [%END%]
  [%- END -%]
 [%- END -%]</description>
   <language>[% lang %]</language>
@@ -73,7 +73,7 @@
 [% ELSIF action == 'active_lists' -%]
  [% FOREACH l = active_lists -%]
   <item>
-    <title>[%|loc(l.name,domain,l.subject,l.msg_count)%]%1@%2 - %3: %4 messages[%END%]	[% IF l.average -%] - [%|loc(l.average)%]%1 by day [%END%][%END%]</title>
+    <title>[%|loc(l.name,domain,l.subject,l.msg_count)%]%1@%2 - %3: %4 messages[%END%] [% IF l.average -%] - [%|loc(l.average)%]%1 by day [%END%][%END%]</title>
     <link>[% 'info' | url_abs([l.name]) %]</link>
   </item>
  [% END -%]

--- a/default/web_tt2/scenario_test.tt2
+++ b/default/web_tt2/scenario_test.tt2
@@ -5,35 +5,35 @@
 <fieldset>
     <input type="hidden" name="action" value="scenario_test" />
       <label for="scenario">[%|loc%]Scenario name:[%END%]  </label>
-	  <select id="scenario" name="scenario">
-	      [% FOREACH sc = scenario %]
-	        <option value="[% sc.key %]" [% sc.value.selected %]>[% sc.key %]</option>
-	      [% END %]
-	  </select><br />
+      <select id="scenario" name="scenario">
+          [% FOREACH sc = scenario %]
+            <option value="[% sc.key %]" [% sc.value.selected %]>[% sc.key %]</option>
+          [% END %]
+      </select><br />
       <label for="listname">[%|loc%]List name:[%END%]  </label>
-	  <select id="listname" name="listname">
-	      [% FOREACH l = listname %]
-	        <option value="[% l.key %]"[% l.value.selected %] >[% l.key %]</option>
-	      [% END %]
-	  </select><br />
+      <select id="listname" name="listname">
+          [% FOREACH l = listname %]
+            <option value="[% l.key %]"[% l.value.selected %] >[% l.key %]</option>
+          [% END %]
+      </select><br />
       <label for="sender">[%|loc%]sender email:[%END%]  </label>
           <input id="sender" type="text" name="sender" size="20" value="[% sender %]" />
-      <br />	
+      <br />
       <label for="email">[%|loc%]Related email:[%END%]  </label>
           <input id="email" type="text" name="email" size="20" value="[% email %]" />
       <br />
       <label for="remote_addr">[%|loc%]Remote IP address:[%END%]  </label>
           <input type="text" name="remote_addr" size="16" value="[% remote_addr %]" />
       <br />
-      <label for="remote_host">[%|loc%]Remote host:[%END%]  </label>	
+      <label for="remote_host">[%|loc%]Remote host:[%END%]  </label>
           <input type="text" name="remote_host" size="16" value="[% remote_host %]" />
       <br />
       <label for="auth_method">[%|loc%]Auth method:[%END%]  </label>
-          <select id="auth_method" name="auth_method">
-              [% FOREACH a = auth_method %]
-	        <option value="[% a.key %]"[% a.value.selected %] >[% a.key %]</option>
-	      [% END %] 
-	  </select>
+      <select id="auth_method" name="auth_method">
+      [% FOREACH a = auth_method %]
+        <option value="[% a.key %]"[% a.value.selected %] >[% a.key %]</option>
+      [% END %] 
+      </select>
       <br />
       <input id="rule" class="MainMenuLinks" type="submit" name="action_scenario_test" value="[%|loc%]get matched rule[%END%]" />
       <span class="bg_color_dark">

--- a/default/web_tt2/search_list_request.tt2
+++ b/default/web_tt2/search_list_request.tt2
@@ -1,10 +1,10 @@
 <!-- search_list_request.tt2 -->
 <h2><i class="fa fa-search"></i> [%|loc%]Search for list(s)[%END%]</h2>
-	<form action="[% path_cgi %]" method="post">
-		<fieldset>
-			<input type="text" size="14" name="filter_list" value="[% filter_list %]" title="[%|loc%]Enter a list name[%END%]" placeholder="[%|loc%]Enter a list name[%END%]"/>
-			<input type="hidden" name="action" value="search_list" />
-			<input class="MainMenuLinks heavyWork" type="submit" name="action_search_list" value="[%|loc%]Search lists[%END%]" />
-		</fieldset>
-	</form>
+    <form action="[% path_cgi %]" method="post">
+        <fieldset>
+            <input type="text" size="14" name="filter_list" value="[% filter_list %]" title="[%|loc%]Enter a list name[%END%]" placeholder="[%|loc%]Enter a list name[%END%]"/>
+            <input type="hidden" name="action" value="search_list" />
+            <input class="MainMenuLinks heavyWork" type="submit" name="action_search_list" value="[%|loc%]Search lists[%END%]" />
+        </fieldset>
+    </form>
 <!-- End search_list_request.tt2 -->

--- a/default/web_tt2/search_user.tt2
+++ b/default/web_tt2/search_user.tt2
@@ -16,62 +16,62 @@
    </th>
    <th>[%|loc%]bounce[%END%]</span>
    </th>
-   <th colspan="2">	    
+   <th colspan="2">
    </th>
   </tr>
  [% FOREACH l = which %]
 
-	[% IF dark == '1' %]
+    [% IF dark == '1' %]
          [% SET dark = 0 %]
-	<tr class="color_light">
-	[% ELSE %]
+    <tr class="color_light">
+    [% ELSE %]
           [% SET dark = 1 %]
-          <tr class="color0">
-	[% END %]
+    <tr class="color0">
+    [% END %]
         <td>
            <a href="[% 'info' | url_rel([l.key]) %]" ><strong>[%|obfuscate(conf.spam_protection) %][% l.key %]@[% domain %][% END %]</strong></a>
         </td>
         <td>
-	   [% IF l.value.is_member %][%|loc%]member[%END%] [% END %]
-	   [% IF l.value.is_owner %][%|loc%]owner[%END%] [% END %]
-           [% IF l.value.is_editor %][%|loc%]editor[%END%] [% END %]
+         [% IF l.value.is_member %][%|loc%]member[%END%] [% END %]
+         [% IF l.value.is_owner %][%|loc%]owner[%END%] [% END %]
+         [% IF l.value.is_editor %][%|loc%]editor[%END%] [% END %]
         </td>
         <td>
-	[%|optdesc('reception')%][% l.value.reception %][% END %]
+          [%|optdesc('reception')%][% l.value.reception %][% END %]
         </td>
         <td>
         [% l.value.topic %]
         </td>
         <td>
-	[% l.value.bounce %]
+          [% l.value.bounce %]
         </td>
-	[% IF l.value.subscribed %]
-        <td> 
+        [% IF l.value.subscribed %]
+        <td>
            <form action="[% path_cgi %]" method="post">
-	  <fieldset>
-           <input type="hidden" name="previous_action" value="search_user" />
-	   <input type="hidden" name="email" value="[% email %]" />
-	   <input type="hidden" name="list" value="[% l.key %]" />
-	   <input class="MainMenuLinks" type="submit" name="action_del" value="[%|loc%]delete[%END%]" />
-	   <input id="quiet" type="checkbox" name="quiet" /> <label for="quiet">[%|loc%]quiet[%END%]</label>
-	  </fieldset>
-	  </form>
-	</td>
-	<td>
-	   <form action="[% path_cgi %]" method="post">
-	   <fieldset>
-	   <input type="hidden" name="previous_action" value="search_user" />
-	   <input type="hidden" name="email" value="[% email %]" />
-	   <input type="hidden" name="list" value="[% l.key %]" />
-	   <input class="MainMenuLinks" type="submit" name="action_editsubscriber" value="[%|loc%]edit[%END%]" />
-	   </fieldset>
-	   </form>
-	</td>
-	[% ELSE %]
-	<td colspan="2"></td>
+             <fieldset>
+               <input type="hidden" name="previous_action" value="search_user" />
+               <input type="hidden" name="email" value="[% email %]" />
+               <input type="hidden" name="list" value="[% l.key %]" />
+               <input class="MainMenuLinks" type="submit" name="action_del" value="[%|loc%]delete[%END%]" />
+               <input id="quiet" type="checkbox" name="quiet" /> <label for="quiet">[%|loc%]quiet[%END%]</label>
+              </fieldset>
+              </form>
+            </td>
+            <td>
+               <form action="[% path_cgi %]" method="post">
+               <fieldset>
+               <input type="hidden" name="previous_action" value="search_user" />
+               <input type="hidden" name="email" value="[% email %]" />
+               <input type="hidden" name="list" value="[% l.key %]" />
+               <input class="MainMenuLinks" type="submit" name="action_editsubscriber" value="[%|loc%]edit[%END%]" />
+               </fieldset>
+               </form>
+            </td>
+        [% ELSE %]
+            <td colspan="2"></td>
         [% END %]
-        </tr>
- [% END %] 
+    </tr>
+  [% END %]
 </table>
 [% ELSE %]
 <p>[%|loc%]No mailing list available.[%END%]</p>

--- a/default/web_tt2/serveradmin.tt2
+++ b/default/web_tt2/serveradmin.tt2
@@ -65,71 +65,72 @@
   [% IF subaction == 'families' %]
 <h2>[%|loc%]Families[%END%]</h2><br />
   <form action="[% path_cgi %]" method="post">
-  <fieldset>
-  <select name="family_name">
-    [% FOREACH f = families %]
-	<option value='[% f %]'>[% f %]</option>[% END %]
-  </select>
-  <input class="MainMenuLinks" type="submit" name="action_review_family" value="[%|loc%]Review lists from this family[%END%]" />
-  </fieldset>
-  </form>     
+    <fieldset>
+      <select name="family_name">
+        [% FOREACH f = families %]
+            <option value='[% f %]'>[% f %]</option>
+        [% END %]
+      </select>
+      <input class="MainMenuLinks" type="submit" name="action_review_family" value="[%|loc%]Review lists from this family[%END%]" />
+    </fieldset>
+  </form>
   [% END %]
 [% END %] 
 [% IF subaction == 'users' %]
 <hr>
 <h2>[%|loc%]Users[%END%]</h2>
-        <p>[%|loc%]Enter an email address of a user to view lists that they are subscribed to:[%END%]</p>
-        <form action="[% path_cgi %]" method="post">
-	<fieldset>
-          <div style="padding-bottom:1.0em;">
-	    <input type="text" name="email" size="30" value="[% email %]" />
-          </div>
-	  <input type="hidden" name="action" value="search_user" />
-	  <input class="MainMenuLinks" type="submit" name="action_search_user" value="[%|loc%]Search User[%END%]" />
-	</fieldset>
-	</form>
+<p>[%|loc%]Enter an email address of a user to view lists that they are subscribed to:[%END%]</p>
+<form action="[% path_cgi %]" method="post">
+  <fieldset>
+    <div style="padding-bottom:1.0em;">
+      <input type="text" name="email" size="30" value="[% email %]" />
+    </div>
+    <input type="hidden" name="action" value="search_user" />
+    <input class="MainMenuLinks" type="submit" name="action_search_user" value="[%|loc%]Search User[%END%]" />
+  </fieldset>
+</form>
 
 <hr>
 <h2>[%|loc%]Sessions[%END%]</h2>
 <form class="bold_label" action="[% path_cgi %]" method="post">
-<fieldset>
-<span>[%|loc%]View session information for users connected to this web interface:[%END%]</span>
-<label for="session_delay">[%|loc%]Delay for active sessions (minutes)[%END%] </label>
-<input type="text" id="session_delay" name="session_delay" size="2" value="10" />
-<input type="checkbox" id="connected_only" name="connected_only" /> <label for="connected_only">[%|loc%]Show only currently connected users[%END%] </label><br />
-<input type="submit" name="action_show_sessions" value="[%|loc%]Show Sessions[%END%]" />
-</fieldset>
+  <fieldset>
+    <span>[%|loc%]View session information for users connected to this web interface:[%END%]</span>
+    <label for="session_delay">[%|loc%]Delay for active sessions (minutes)[%END%] </label>
+    <input type="text" id="session_delay" name="session_delay" size="2" value="10" />
+    <input type="checkbox" id="connected_only" name="connected_only" /> <label for="connected_only">[%|loc%]Show only currently connected users[%END%] </label><br />
+    <input type="submit" name="action_show_sessions" value="[%|loc%]Show Sessions[%END%]" />
+  </fieldset>
 </form>
 
-  <hr>
-  <h2>[%|loc%]Changing user's email[%END%]</h2>
-  <p>[%|loc%]You can update a user's email address for all their list memberships at once. If they are also list owner or list moderator, their email address for these roles will also be updated.[%END%]</p>
-  <form class="bold_label" action="[% path_cgi %]" method="post">
+<hr>
+<h2>[%|loc%]Changing user's email[%END%]</h2>
+<p>[%|loc%]You can update a user's email address for all their list memberships at once. If they are also list owner or list moderator, their email address for these roles will also be updated.[%END%]</p>
+<form class="bold_label" action="[% path_cgi %]" method="post">
   <fieldset>
-  <div>
-    <label for="current_email">[%|loc%]Current email address:[%END%]
-    </label>
-    <input id="current_email" type="text" name="current_email" size="30" />
-  </div>
-  <div>
-    <label for="email">[%|loc%]New email address:[%END%]</label>
-    <input id="email" type="text" name="email" size="30" />
-  </div>
-  <input type="hidden" name="action" value="move_user" />
-  <input type="hidden" name="previous_action" value="serveradmin" />
-  <input class="MainMenuLinks" type="submit" name="action_move_user"
-   value="[%|loc%]Update user's email[%END%]" />
+    <div>
+      <label for="current_email">[%|loc%]Current email address:[%END%]
+      </label>
+      <input id="current_email" type="text" name="current_email" size="30" />
+    </div>
+    <div>
+      <label for="email">[%|loc%]New email address:[%END%]</label>
+      <input id="email" type="text" name="email" size="30" />
+    </div>
+    <input type="hidden" name="action" value="move_user" />
+    <input type="hidden" name="previous_action" value="serveradmin" />
+    <input class="MainMenuLinks" type="submit" name="action_move_user"
+     value="[%|loc%]Update user's email[%END%]" />
   </fieldset>
-  </form>
+</form>
 
 <hr>
 <h2>[%|loc%]Impersonate another User[%END%]</h2>
 <p>[%|loc%]Listmasters can switch context (impersonate) other users; this may be useful when providing assistance or when testing privileges.  Enter the email address of the user you'd like to switch context to:[%END%]</p>
 <form class="bold_label" action="[% path_cgi %]" method="post">
-<fieldset>
-<input id="session_email" type="text" name="email" size="50"/> 
-<div style="padding-top:1.0em; clear:both;"><input class="MainMenuLinks" type="submit" name="action_set_session_email" value="[%|loc%]Switch User Context[%END%]" /></div>
-</fieldset>
+  <fieldset>
+    <input id="session_email" type="text" name="email" size="50"/> 
+    <div style="padding-top:1.0em; clear:both;"><input class="MainMenuLinks" type="submit" name="action_set_session_email" value="[%|loc%]Switch User Context[%END%]" /></div>
+  </fieldset>
 </form>
 [% END %] 
 
@@ -141,13 +142,13 @@
 <p>[%|loc%]Enter the name of the list that you'd like to rebuild HTML archives for:[%END%]</p>
 
 <form action="[% path_cgi %]" method="post">
-<fieldset>
-<label for="list"></label><input id="list" type="text" name="list" size="20" /><div style="padding-top:1.0em; padding-bottom:0.25em; float:clear;"><input class="MainMenuLinks" type="submit" name="action_rebuildarc" value="[%|loc%]Rebuild archive[%END%]" /></div>
+  <fieldset>
+    <label for="list"></label><input id="list" type="text" name="list" size="20" /><div style="padding-top:1.0em; padding-bottom:0.25em; float:clear;"><input class="MainMenuLinks" type="submit" name="action_rebuildarc" value="[%|loc%]Rebuild archive[%END%]" /></div>
 
-<h3>[%|loc%]Rebuild archives for all lists[%END%]</h3>
-<p><b>[%|loc%]Note:[%END%]</b> [%|loc%]As this option may take a long time to complete, it is recommended (if possible) to use it during non-busy times.[%END%]
-<div style="padding-bottom: 1.0em; float:clear;"> <input class="MainMenuLinks" type="submit" name="action_rebuildallarc" value="[%|loc%]Rebuild all[%END%]" /></div>
-</fieldset>
+    <h3>[%|loc%]Rebuild archives for all lists[%END%]</h3>
+    <p><b>[%|loc%]Note:[%END%]</b> [%|loc%]As this option may take a long time to complete, it is recommended (if possible) to use it during non-busy times.[%END%]
+    <div style="padding-bottom: 1.0em; float:clear;"> <input class="MainMenuLinks" type="submit" name="action_rebuildallarc" value="[%|loc%]Rebuild all[%END%]" /></div>
+  </fieldset>
 </form>
 [% END %] 
 
@@ -156,38 +157,38 @@
 <h3>[%|loc%]Sympa log level[%END%]</h3>
 <p>[%|loc%]Set debug level for logs written to disk.  This setting is temporary, applying only for the lifetime of the fastcgi session hosting this interface.[%END%]</p>
 <form class="bold_label" action="[% path_cgi %]" method="post">
-<fieldset>
-[%|loc%]Log level:[%END%] 
-<input id="log_level_0" type="radio" name="log_level" value="0" [%IF log_level == 0 %]checked="checked"[%END%]/> <label class="inlineLabel" for="log_level_0">0 </label> 
-<input id="log_level_1" type="radio" name="log_level" value="1" [%IF log_level == 1 %]checked="checked"[%END%]/> <label class="inlineLabel" for="log_level_1">1 </label>
-<input id="log_level_2" type="radio" name="log_level" value="2" [%IF log_level == 2 %]checked="checked"[%END%]/> <label class="inlineLabel" for="log_level_2">2 </label>
-<input id="log_level_3" type="radio" name="log_level" value="3" [%IF log_level == 3 %]checked="checked"[%END%]/> <label class="inlineLabel" for="log_level_3">3 </label>
-<input id="log_level_4" type="radio" name="log_level" value="4" [%IF log_level == 4 %]checked="checked"[%END%]/> <label class="inlineLabel" for="log_level_4">4 </label>
-<input type="submit" name="action_set_loglevel" value="[%|loc%]Set log level[%END%]" />
-</fieldset>
+  <fieldset>
+  [%|loc%]Log level:[%END%] 
+    <input id="log_level_0" type="radio" name="log_level" value="0" [%IF log_level == 0 %]checked="checked"[%END%]/> <label class="inlineLabel" for="log_level_0">0 </label> 
+    <input id="log_level_1" type="radio" name="log_level" value="1" [%IF log_level == 1 %]checked="checked"[%END%]/> <label class="inlineLabel" for="log_level_1">1 </label>
+    <input id="log_level_2" type="radio" name="log_level" value="2" [%IF log_level == 2 %]checked="checked"[%END%]/> <label class="inlineLabel" for="log_level_2">2 </label>
+    <input id="log_level_3" type="radio" name="log_level" value="3" [%IF log_level == 3 %]checked="checked"[%END%]/> <label class="inlineLabel" for="log_level_3">3 </label>
+    <input id="log_level_4" type="radio" name="log_level" value="4" [%IF log_level == 4 %]checked="checked"[%END%]/> <label class="inlineLabel" for="log_level_4">4 </label>
+    <input type="submit" name="action_set_loglevel" value="[%|loc%]Set log level[%END%]" />
+  </fieldset>
 </form>
 [% END %] 
 
 [% IF subaction == 'templates' %]
 <h2>[%|loc%]Templates[%END%]</h2>
 <form class="bold_label" action="[% path_cgi %]" method="post">
-<fieldset>
-  <h3>[%|loc%]Edit default list template[%END%]</h3>
-  <select id="file" name="file">
-    [% FOREACH f = lists_default_files %]<option value='[% f.key %]' [% f.value.selected %]>[% f.value.complete %]</option>[% END %]
-  </select>
-  <input type="submit" name="action_editfile" value="[%|loc%]Edit[%END%]" />
-</fieldset>
+  <fieldset>
+    <h3>[%|loc%]Edit default list template[%END%]</h3>
+    <select id="file" name="file">
+      [% FOREACH f = lists_default_files %]<option value='[% f.key %]' [% f.value.selected %]>[% f.value.complete %]</option>[% END %]
+    </select>
+    <input type="submit" name="action_editfile" value="[%|loc%]Edit[%END%]" />
+  </fieldset>
 </form>
 
 <form class="bold_label" action="[% path_cgi %]" method="post">
-<fieldset>
-  <h3>[%|loc%]Edit site-wide templates[%END%]</h3>
-  <select id="file" name="file">
-    [% FOREACH f = server_files %]<option value='[% f.key %]' [% f.value.selected %]>[% f.value.complete %]</option>[% END %]
-  </select>
-  <input class="MainMenuLinks" type="submit" name="action_editfile" value="[%|loc%]Edit[%END%]" />
-</fieldset>
+  <fieldset>
+    <h3>[%|loc%]Edit site-wide templates[%END%]</h3>
+    <select id="file" name="file">
+      [% FOREACH f = server_files %]<option value='[% f.key %]' [% f.value.selected %]>[% f.value.complete %]</option>[% END %]
+    </select>
+    <input class="MainMenuLinks" type="submit" name="action_editfile" value="[%|loc%]Edit[%END%]" />
+  </fieldset>
 </form>
 <br />
 <p><a class="actionMenuLinks" href="https://translate.sympa.org/">[%|loc%]view translations[%END%]</a>
@@ -200,14 +201,14 @@
 <h3>[%|loc%]Dump TT2 Variables[%END%]</h3>
 <p>[%|loc%]Toggle the dumping of available TT2 variables when rendering web interface pages. This may be useful when developing or debugging custom TT2 templates. This setting is temporary, applying only for the lifetime of the web interface fastcgi process.[%END%]</p>
 <form class="bold_label" action="[% path_cgi %]" method="post">
-<fieldset>
-[% IF dumpvars == 'true' %]
-  <input class="MainMenuLinks" type="submit" name="action_unset_dumpvars" value="[%|loc%]Disable template variables dump[%END%]" />
-[% ELSE %]
-  <input class="MainMenuLinks" type="submit" name="action_set_dumpvars" value="[%|loc%]Enable template variables dump[%END%]" />
-[% END %]
+  <fieldset>
+  [% IF dumpvars == 'true' %]
+    <input class="MainMenuLinks" type="submit" name="action_unset_dumpvars" value="[%|loc%]Disable template variables dump[%END%]" />
+  [% ELSE %]
+    <input class="MainMenuLinks" type="submit" name="action_set_dumpvars" value="[%|loc%]Enable template variables dump[%END%]" />
+  [% END %]
 
-</fieldset>
+  </fieldset>
 </form>
 </div>
 [% END %] 
@@ -215,7 +216,7 @@
 [% IF subaction == 'skins' %]
 <h2>[%|loc%]Skins, CSS and colors[%END%]</h2><br />
 <div>
-<a class="actionMenuLinks" href="[% 'skinsedit' | url_rel %]">[%|loc%]Skins administration page[%END%]</a>
+  <a class="actionMenuLinks" href="[% 'skinsedit' | url_rel %]">[%|loc%]Skins administration page[%END%]</a>
 </div>
 [% END %] 
 [% IF subaction == 'edit_config' %]
@@ -238,9 +239,9 @@
      [% IF confparam.edit == '1' %]
 <form action="[% path_cgi %]" method="post">
   <fieldset>
-  <input type="text" name="new_value"  value="[% confparam.current_value %]" style="width:75%"/> 
-  <input type="hidden" name="conf_parameter_name" value="[% confparam.name  %]" />
-  <input class="MainMenuLinks" type="submit" name="action_set_param" value="[%|loc%]Set[%END%]" style="width:20%" />
+    <input type="text" name="new_value"  value="[% confparam.current_value %]" style="width:75%"/> 
+    <input type="hidden" name="conf_parameter_name" value="[% confparam.name  %]" />
+    <input class="MainMenuLinks" type="submit" name="action_set_param" value="[%|loc%]Set[%END%]" style="width:20%" />
 </fieldset>
 </form>
 [% ELSE %]

--- a/default/web_tt2/setlang.tt2
+++ b/default/web_tt2/setlang.tt2
@@ -1,27 +1,27 @@
 <!-- setlang.tt2 -->
 <div id="setlang">
 <form action="[% path_cgi %]" method="post">
-<fieldset>
-     <input type="hidden" name="action" value="set_lang"/>
-     <input type="hidden" name="previous_action" value="[% action %]"/>
-     <input type="hidden" name="previous_list" value="[% list %]"/>
+  <fieldset>
+    <input type="hidden" name="action" value="set_lang"/>
+    <input type="hidden" name="previous_action" value="[% action %]"/>
+    <input type="hidden" name="previous_list" value="[% list %]"/>
 [% IF languages.size > 1 %]
-     <label for="language_selection">[%|loc%]Language Selection[% END %]</label>
+    <label for="language_selection">[%|loc%]Language Selection[% END %]</label>
     <select id="language_selection" name="lang" class="neutral submitOnChange">
 
-     [% FOREACH lang = languages %]
-       <option lang="[% lang.key %]" xml:lang="[% lang.key %]"
-        value="[% lang.key %]"
-        [%~ IF lang.value.selected %] selected="selected"[% END %]>
-       [%~ lang.key | optdesc('lang') ~%]
-       </option>
-     [% END %]
-     </select>
-     <noscript>
-         <input title="[%|loc%]Validate your language selection[% END %]" class="MainMenuLinks" name="action_set_lang" id="submitlang" type="submit" value="[%|loc%]Set language[% END %]"/>
-     </noscript>
+      [% FOREACH lang = languages %]
+        <option lang="[% lang.key %]" xml:lang="[% lang.key %]"
+         value="[% lang.key %]"
+         [%~ IF lang.value.selected %] selected="selected"[% END %]>
+          [%~ lang.key | optdesc('lang') ~%]
+        </option>
+      [% END %]
+    </select>
+    <noscript>
+      <input title="[%|loc%]Validate your language selection[% END %]" class="MainMenuLinks" name="action_set_lang" id="submitlang" type="submit" value="[%|loc%]Set language[% END %]"/>
+    </noscript>
 [% END %]
-</fieldset>
+  </fieldset>
 </form>
 </div>
 <!-- end setlang.tt2 -->

--- a/default/web_tt2/show_cert.tt2
+++ b/default/web_tt2/show_cert.tt2
@@ -2,12 +2,12 @@
 
 <br />
 <div id="show_cert">
-<ul>
-  <strong>[%|loc%]HTTPS authentication information[%END%]</strong><br />
-  <li>[%|loc%]User certificate belong to[%END%][% ssl_client_s_dn %]</li><br />
-  <li>[%|loc%]Certificate expiration date[%END%][% ssl_client_v_end %]</li><br />
-  <li>[%|loc%]Certificate issuer[%END%][% ssl_client_i_dn %]</li><br />
-  <li>[%|loc%]Cipher key size used[%END%][% ssl_cipher_usekeysize %]</li><br />
-</ul>
+  <ul>
+    <strong>[%|loc%]HTTPS authentication information[%END%]</strong><br />
+    <li>[%|loc%]User certificate belong to[%END%][% ssl_client_s_dn %]</li><br />
+    <li>[%|loc%]Certificate expiration date[%END%][% ssl_client_v_end %]</li><br />
+    <li>[%|loc%]Certificate issuer[%END%][% ssl_client_i_dn %]</li><br />
+    <li>[%|loc%]Cipher key size used[%END%][% ssl_cipher_usekeysize %]</li><br />
+  </ul>
 </div>
 <!-- end show_cert.tt2 -->

--- a/default/web_tt2/sigindex.tt2
+++ b/default/web_tt2/sigindex.tt2
@@ -4,10 +4,10 @@
 [% IF mod_signoff %]
 <form class="noborder toggleContainer" data-toggle-selector="input[name='id']"
   action="[% path_cgi %]" method="POST" name="myform"> 
-<fieldset>
-<input type="hidden" name="list" value="[% list %]" />
+  <fieldset>
+    <input type="hidden" name="list" value="[% list %]" />
     <table  class="responsive listOfItems">
-    <caption>[%|loc%]Listing unsubscription to moderate[%END%]</caption>
+      <caption>[%|loc%]Listing unsubscription to moderate[%END%]</caption>
       <tr>
         <th><a href="#"
           data-tooltip aria-haspopup="true"
@@ -16,56 +16,56 @@
         <th colspan="2">[%|loc%]Email[%END%]</th>
         <th>[%|loc%]Date[%END%]</th>
       </tr>
-      
+
       [% IF signoffs %]
 
-      [% FOREACH sig = signoffs %]
+        [% FOREACH sig = signoffs %]
 
-	[% IF dark == '1' %]
-	  <tr>
-	[% ELSE %]
-          <tr class="color0">
-	[% END %]
-	    <td>
-           <input type="checkbox" name="id" value="[% sig.key %]" />
-	    </td>
-	  <td colspan="2">
-	        [% sig.value.email %]
-	  </td>
-	  <td>
-	      [% sig.value.date %]
-	  </td>
-        </tr>
+          [% IF dark == '1' %]
+            <tr>
+          [% ELSE %]
+            <tr class="color0">
+          [% END %]
+              <td>
+                <input type="checkbox" name="id" value="[% sig.key %]" />
+              </td>
+              <td colspan="2">
+                [% sig.value.email %]
+              </td>
+              <td>
+                [% sig.value.date %]
+              </td>
+          </tr>
 
-        [% IF dark == '1' %]
-	  [% SET dark = 0 %]
-	[% ELSE %]
-	  [% SET dark = 1 %]
-	[% END %]
+          [% IF dark == '1' %]
+            [% SET dark = 0 %]
+          [% ELSE %]
+            [% SET dark = 1 %]
+          [% END %]
 
         [% END %]
 
-        [% ELSE %]
-         <tr colspan="4"><th>[%|loc%]No unsubscription requests[%END%]</th></TR>
-        [% END %]
-      </table>
-<input type="hidden" name="previous_action" value="sigindex" />
-<input type="hidden" name="previous_list" value="[% list %]" />
-  <div>
-    <input class="MainMenuLinks toggleButton" type="button"
-      value="[%|loc%]Toggle Selection[%END%]" />
-  </div>
-  <div>
+      [% ELSE %]
+         <tr colspan="4"><th>[%|loc%]No unsubscription requests[%END%]</th></tr>
+      [% END %]
+    </table>
+    <input type="hidden" name="previous_action" value="sigindex" />
+    <input type="hidden" name="previous_list" value="[% list %]" />
+    <div>
+      <input class="MainMenuLinks toggleButton" type="button"
+       value="[%|loc%]Toggle Selection[%END%]" />
+    </div>
+    <div>
     [%# If a list is not 'open' and allow_subscribe_if_pending has been set to
         'off', del cannot be performed. ~%]
     [% IF list_status == 'open' || conf.allow_subscribe_if_pending == 'on' ~%]
       <input class="MainMenuLinks" type="submit" name="action_auth_del"
        value="[%|loc%]Delete selected addresses[%END%]" />
     [%~ END %]
-    <input class="MainMenuLinks" type="submit" name="action_decl_del"
-     value="[%|loc%]Reject selected addresses[%END%]" />
-  </div>
-</fieldset>
+      <input class="MainMenuLinks" type="submit" name="action_decl_del"
+       value="[%|loc%]Reject selected addresses[%END%]" />
+    </div>
+  </fieldset>
 </form>
 [% ELSE %]
 <p class="small-8 small-centered columns alert-box info text-center">[%|loc%]No unsubscription requests[%END%]</p>

--- a/default/web_tt2/skinsedit.tt2
+++ b/default/web_tt2/skinsedit.tt2
@@ -87,11 +87,11 @@
      <td>color_4</td>
      <td>[% color_4 %]</td>
      <td style="background-color: [% color_4 %]; cursor: pointer;" onclick="chooseColorNumber('color_4','[% color_4 %]')" align="center" >&nbsp;</td>
-     <td>[%|loc%]font color of:[%END%]<UL>
-		<LI>[%|loc%]form labels;[%END%]</LI>
-		<LI>[%|loc%]side menu titles;[%END%]</LI>
-		<LI>[%|loc%]text areas in forms.[%END%]</LI>
-	 </UL></td>
+     <td>[%|loc%]font color of:[%END%]<ul>
+       <li>[%|loc%]form labels;[%END%]</li>
+       <li>[%|loc%]side menu titles;[%END%]</li>
+       <li>[%|loc%]text areas in forms.[%END%]</li>
+     </ul></td>
 </tr>
 <tr>
      <td>color_5</td>

--- a/default/web_tt2/sso_login.tt2
+++ b/default/web_tt2/sso_login.tt2
@@ -5,25 +5,25 @@
       [%|loc%]A confirmation password will be sent to the address you supply, after pressing the button. This will take you to the next screen to confirm that your address is operational.[%END%]
 
       <form action="[% path_cgi %]" method="post">
-	<fieldset>
+        <fieldset>
           <input type="hidden" name="previous_action" value="[% previous_action %]" />
           <input type="hidden" name="previous_list" value="[% previous_list %]" />
-	  <input type="hidden" name="referer" value="[% referer %]" />
-	  <input type="hidden" name="subaction" value="validateemail" />
-	  <input type="hidden" name="action" value="sso_login" />
-  	  <input type="hidden" name="nomenu" value="[% nomenu %]" />
+          <input type="hidden" name="referer" value="[% referer %]" />
+          <input type="hidden" name="subaction" value="validateemail" />
+          <input type="hidden" name="action" value="sso_login" />
+          <input type="hidden" name="nomenu" value="[% nomenu %]" />
           <input type="hidden" name="auth_service_name" value="[% server.key %]" />
 
           <label for="email"><strong>[%|loc%]Your e-mail address:[%END%]</strong><br />
-        [% IF init_email %]
-	  [% email %]
+          [% IF init_email %]
+            [% email %]
             <input id="email" type="text" name="email" value="[% init_email %]" />
-	[% ELSE %]
-	    <input id="email" type="text" name="email" value="" />
-	[% END %]
+          [% ELSE %]
+            <input id="email" type="text" name="email" value="" />
+          [% END %]
           </label>&nbsp; &nbsp; &nbsp;
-	  <input type="submit" name="action_sso_login" value="[%|loc%]Send me a confirmation password[%END%]"/>
-	</fieldset>
+          <input type="submit" name="action_sso_login" value="[%|loc%]Send me a confirmation password[%END%]"/>
+        </fieldset>
       </form>
 
 [% ELSIF subaction == 'validateemail' %]

--- a/default/web_tt2/subindex.tt2
+++ b/default/web_tt2/subindex.tt2
@@ -18,58 +18,58 @@
           <th>[%|loc%]Date[%END%]</th>
           <th>[%|loc%]Additional information[%END%]</th>
       </tr>
-      
-      [% IF subscriptions %]
 
-      [% FOREACH sub = subscriptions %]
+  [% IF subscriptions %]
 
-	[% IF dark == '1' %]
-	  <tr>
-	[% ELSE %]
-          <tr class="color0">
-	[% END %]
-	    <td>
+    [% FOREACH sub = subscriptions %]
+
+      [% IF dark == '1' %]
+      <tr>
+      [% ELSE %]
+      <tr class="color0">
+      [% END %]
+        <td>
            <input type="checkbox" name="id" value="[% sub.key %]" />
-	    </td>
-	  <td colspan="2">
-	        [% sub.value.email %]
-	  </td>
-	  <td>
-	        [% sub.value.gecos %]&nbsp;
-          </td>
-	  <td>
-	      [% sub.value.date %]
-	  </td>
-          <td class="text-left">
-              [% FOREACH ca_k IN list_conf.custom_attribute %]<b>[% ca_k.name %][%|loc%]:[%END%] </b>[% IF sub.value.custom_attribute.item(ca_k.id).value %][% sub.value.custom_attribute.item(ca_k.id).value %][% ELSE %]-[% END %]<br>[% END %]
-          </td>
-        </tr>
+        </td>
+        <td colspan="2">
+          [% sub.value.email %]
+        </td>
+        <td>
+          [% sub.value.gecos %]&nbsp;
+        </td>
+        <td>
+          [% sub.value.date %]
+        </td>
+        <td class="text-left">
+          [% FOREACH ca_k IN list_conf.custom_attribute %]<b>[% ca_k.name %][%|loc%]:[%END%] </b>[% IF sub.value.custom_attribute.item(ca_k.id).value %][% sub.value.custom_attribute.item(ca_k.id).value %][% ELSE %]-[% END %]<br>[% END %]
+        </td>
+      </tr>
 
-        [% IF dark == '1' %]
-	  [% SET dark = 0 %]
-	[% ELSE %]
-	  [% SET dark = 1 %]
-	[% END %]
+      [% IF dark == '1' %]
+        [% SET dark = 0 %]
+      [% ELSE %]
+        [% SET dark = 1 %]
+      [% END %]
 
-        [% END %]
+    [% END %]
 
-        [% ELSE %]
-         <tr colspan="4"><th>[%|loc%]No subscription requests[%END%]</th></TR>
-        [% END %]
-      </table>
-<input type="hidden" name="previous_action" value="subindex" />
-<input type="hidden" name="previous_list" value="[% list %]" />
-<input class="MainMenuLinks toggleButton" type="button"
-  value="[%|loc%]Toggle Selection[%END%]" />
-  [%# If a list is not 'open' and allow_subscribe_if_pending has been set to
-      'off', add cannot be performed. ~%]
-  [% IF list_status == 'open' || conf.allow_subscribe_if_pending == 'on' ~%]
-    <input class="MainMenuLinks" type="submit" name="action_auth_add"
-     value="[%|loc%]Add selected addresses[%END%]" />
-  [%~ END %]
-  <input class="MainMenuLinks" type="submit" name="action_decl_add"
-   value="[%|loc%]Reject selected addresses[%END%]" />
-</fieldset>
+    [% ELSE %]
+      <tr colspan="4"><th>[%|loc%]No subscription requests[%END%]</th></TR>
+    [% END %]
+    </table>
+    <input type="hidden" name="previous_action" value="subindex" />
+    <input type="hidden" name="previous_list" value="[% list %]" />
+    <input class="MainMenuLinks toggleButton" type="button"
+      value="[%|loc%]Toggle Selection[%END%]" />
+      [%# If a list is not 'open' and allow_subscribe_if_pending has been set to
+          'off', add cannot be performed. ~%]
+      [% IF list_status == 'open' || conf.allow_subscribe_if_pending == 'on' ~%]
+        <input class="MainMenuLinks" type="submit" name="action_auth_add"
+         value="[%|loc%]Add selected addresses[%END%]" />
+      [%~ END %]
+      <input class="MainMenuLinks" type="submit" name="action_decl_add"
+       value="[%|loc%]Reject selected addresses[%END%]" />
+  </fieldset>
 </form>
 [% ELSE %]
 <p class="small-8 small-centered columns alert-box info text-center">[%|loc%]No subscription requests[%END%]</p>

--- a/default/web_tt2/suboptions.tt2
+++ b/default/web_tt2/suboptions.tt2
@@ -25,37 +25,37 @@
 
 <br /><br />
 
-  [%IF available_topics %]	
-    [%|loc%]Topic subscription:[%END%]		
+  [%IF available_topics %]
+    [%|loc%]Topic subscription:[%END%]
     [%IF possible_topic %]
-      <BLOCKQUOTE>	
+      <BLOCKQUOTE>
       [% FOREACH t = available_topics %]
-        [%IF topic_checked.${t.name} %]	
+        [%IF topic_checked.${t.name} %]
           <input type="checkbox" name="topic_[%t.name%]" value="1" checked="1"> [% t.title %] </input>
         [%ELSE%]
           <input type="checkbox" name="topic_[%t.name%]" value="1"> [% t.title %] </input>
-        [%END%] 	
+        [%END%]
         <br />
       [% END %]
       [%IF topic_checked.other %]
         <input type="checkbox" name="topic_other" value="1"  checked="1"/> [%|loc%]Other (messages not tagged) [%END%]
-      [%ELSE%]	
+      [%ELSE%]
         <input type="checkbox" name="topic_other" value="1" /> [%|loc%]Other (messages not tagged) [%END%]
       [%END%] 
       <br />
       </BLOCKQUOTE>
   
       [%IF sub_user_topic %]
-        <br />	
+        <br />
         <input type="checkbox" name="no_topic" value="1"> [%|loc%]Disable topics subscription[%END%]</input>
         <br />
       [%END%]
-       	
+
     [%ELSE%]
       <BLOCKQUOTE><i>[%|loc%]Only possible for direct reception modes.[%END%]</i></BLOCKQUOTE>
     [%END%]
-  [%END%]	
- 	 
+  [%END%]
+
   <label for="visibility"> [%|loc%]Visibility:[%END%] </label>
   <div>
   <select id="visibility" name="visibility">

--- a/default/web_tt2/subscriber_table.tt2
+++ b/default/web_tt2/subscriber_table.tt2
@@ -13,161 +13,161 @@
             class="toggleButton"><i class="fa fa-check-square-o"></i> </a></th>
         [% END %]
 
-	[% SET colspan = colspan + 3 %]
+        [% SET colspan = colspan + 3 %]
         [% IF sortby == 'email' %]
-  	    <th colspan="2" class="sortby">
-	    [%|loc%]Email[%END%]
-	[% ELSE %]
-	    <th colspan="2">	    
-	    <a href="[% 'review' | url_rel([list,1,size,'email']) %]">[%|loc%]Email[%END%]</a>
-	[% END %]
-	</th>
-        [% IF sortby == 'domain' %]
-  	    <th class="sortby">
-	    [%|loc%]Domain[%END%]
-	[% ELSE %]
-	    <th>
-               <a href="[% 'review' | url_rel([list,1,size,'domain']) %]">[%|loc%]Domain[%END%]</a>
-	[% END %]
-	</th>
-	[% IF pictures_display %]
-	    [% SET colspan = colspan + 1 %]
-  	    <th>	    
-  	    [%|loc%]Picture[%END%]
-	    </th>
-  	[% END %]
-
-	[% SET colspan = colspan + 1 %]
-	[% IF sortby == 'name' %]
-	<th class="sortby">
-	  [%|loc%]Name[%END%]
-	[% ELSE %]
-	<th>
-          <a href="[% 'review' | url_rel([list,1,size,'name']) %]">[%|loc%]Name[%END%]</a>
-	[% END %] 
-	</th>
-        [% IF is_owner %]
-	  [% SET colspan = colspan + 4 %]
-          <th>
-	  [%|loc%]Reception[%END%]
-	  </th>
-            [% IF sortby == 'sources' %]
-  	      <th class="sortby">
-	      [%|loc%]Sources[%END%]
-	    [% ELSE %]
-	      <th>
-	      <a href="[% 'review' | url_rel([list,1,size,'sources']) %]" >[%|loc%]Sources[%END%]</a>
-	    [% END %]
-	    </th>
-	  [% IF sortby == 'date' %]
-  	    <th class="sortby">
-	    [%|loc%]Sub date[%END%]
-	  [% ELSE %]
-	    <th>
-            <a href="[% 'review' | url_rel([list,1,size,'date']) %]" >[%|loc%]Sub date[%END%]</a>
-	  [% END %]
-          </th>
-	  <th>[%|loc%]Last update[%END%]</th>
-	  [% IF additional_fields %]
-	    [% SET colspan = colspan + 1 %]
-	    <th>[% additional_fields %]</th>
-	  [% END %]
-          [% FOREACH ca_k IN list_conf.custom_attribute %]
-	    [% SET colspan = colspan + 1 %]
-	    <th>[% ca_k.name %]</th>
-	  [% END %]
+          <th colspan="2" class="sortby">
+            [%|loc%]Email[%END%]
+        [% ELSE %]
+          <th colspan="2">
+            <a href="[% 'review' | url_rel([list,1,size,'email']) %]">[%|loc%]Email[%END%]</a>
         [% END %]
-      </tr>
-      [% FOREACH u = thosesubscribers %]
-	[% IF dark == '1' %]
-	  <tr>
-	[% ELSE %]
-          <tr class="color0">
-	[% END %]
+          </th>
+        [% IF sortby == 'domain' %]
+          <th class="sortby">
+            [%|loc%]Domain[%END%]
+        [% ELSE %]
+          <th>
+             <a href="[% 'review' | url_rel([list,1,size,'domain']) %]">[%|loc%]Domain[%END%]</a>
+        [% END %]
+          </th>
+        [% IF pictures_display %]
+          [% SET colspan = colspan + 1 %]
+          <th>
+            [%|loc%]Picture[%END%]
+          </th>
+        [% END %]
 
-	 [% IF is_owner %]
-	    <td>
-	        <input type="checkbox" name="email" value="[% u.email %]" />
-	    </td>
- 	 [% END %]
-	 [% IF u.bounce %]
-	   <td colspan="2" class="text-left">
-	 
-	     [% IF is_owner %]
-	       <a href="[% 'editsubscriber' | url_rel([list],{email=>u.email,previous_action=>action}) %]">[% u.email %]</a>
-	     [% ELSE %]
- 	       [% u.email %]
- 	     [% END %]
-	   </td>
-	 [% IF is_owner %]
-           <td class="color7"><strong>[%|loc%]bouncing[%END%]</strong>
-	   </td>
-	 [% END %]
+        [% SET colspan = colspan + 1 %]
+        [% IF sortby == 'name' %]
+          <th class="sortby">
+            [%|loc%]Name[%END%]
+        [% ELSE %]
+          <th>
+            <a href="[% 'review' | url_rel([list,1,size,'name']) %]">[%|loc%]Name[%END%]</a>
+        [% END %] 
+          </th>
+        [% IF is_owner %]
+          [% SET colspan = colspan + 4 %]
+          <th>
+            [%|loc%]Reception[%END%]
+          </th>
+          [% IF sortby == 'sources' %]
+            <th class="sortby">
+              [%|loc%]Sources[%END%]
+          [% ELSE %]
+            <th>
+              <a href="[% 'review' | url_rel([list,1,size,'sources']) %]" >[%|loc%]Sources[%END%]</a>
+          [% END %]
+            </th>
+          [% IF sortby == 'date' %]
+            <th class="sortby">
+              [%|loc%]Sub date[%END%]
+          [% ELSE %]
+            <th>
+              <a href="[% 'review' | url_rel([list,1,size,'date']) %]" >[%|loc%]Sub date[%END%]</a>
+          [% END %]
+            </th>
+            <th>[%|loc%]Last update[%END%]</th>
+          [% IF additional_fields %]
+            [% SET colspan = colspan + 1 %]
+            <th>[% additional_fields %]</th>
+          [% END %]
+          [% FOREACH ca_k IN list_conf.custom_attribute %]
+            [% SET colspan = colspan + 1 %]
+            <th>[% ca_k.name %]</th>
+          [% END %]
+        [% END %]
+        </tr>
+    [% FOREACH u = thosesubscribers %]
+      [% IF dark == '1' %]
+        <tr>
+      [% ELSE %]
+        <tr class="color0">
+      [% END %]
 
-	 [% ELSE %]
-	   <td colspan="3" class="text-left">
-	     [% IF is_owner %]
-	       <a href="[% 'editsubscriber' | url_rel([list],{email=>u.email,previous_action=>action}) %]">[% u.email %]</a>
-	     [% ELSE %]
-	       [% u.email %]
-	     [% END %]
-	   </td>
-	 [% END %]
-
-  	  [% IF pictures_display %]
-  	    [% IF u.pictures_url %]
-  	      <td>
-  	      <a href="[%u.pictures_url%]" title="[%|loc%]Open in a new window[%END%]" target="pictures"><img class="Pictures" src="[%u.pictures_url%]" alt="[%|loc(u.email)%]%1's picture[%END%]" /></a>   
-  	      </td>
-  	    [% ELSE %]
-  	      <td>
-  	      </td>
-  	    [% END %]
-  	  [% END %]
-	  <td>
-             <span>
-	        [% u.gecos %]&nbsp;
-	     </span>
+      [% IF is_owner %]
+          <td>
+            <input type="checkbox" name="email" value="[% u.email %]" />
           </td>
-	  [% IF is_owner %]
-  	    <td>
-  	      [%|optdesc('reception')%][% u.reception %][%END%]
-	    </td>
-            <td>
-            [% IF u.subscribed %]
-              [% IF u.included %]
-                 [%|loc%]subscribed[%END%]<br />[% u.sources %]
-              [% ELSE %]
-                 [%|loc%]subscribed[%END%]
-              [% END %]
-            [% ELSE %]
-              [% u.sources %]
-            [% END %]   
-            </td>
-	    <td>
-	      [% u.date %]
-	    </td>
-	    <td>
-	      [% u.update_date %]
-	    </td>
-    	  [% IF additional_fields %]
-	     <td>
-	      [% u.additional %]
-	     </td>
-	  [% END %]
-	  [% FOREACH ca_k IN list_conf.custom_attribute %]<td>[% SET id = ca_k.id %][% u.custom_attribute.$id.value %]</td>[% END %]
-       	  [% END %]
+      [% END %]
+      [% IF u.bounce %]
+          <td colspan="2" class="text-left">
+
+          [% IF is_owner %]
+            <a href="[% 'editsubscriber' | url_rel([list],{email=>u.email,previous_action=>action}) %]">[% u.email %]</a>
+          [% ELSE %]
+            [% u.email %]
+          [% END %]
+          </td>
+        [% IF is_owner %]
+          <td class="color7"><strong>[%|loc%]bouncing[%END%]</strong>
+          </td>
+        [% END %]
+
+      [% ELSE %]
+          <td colspan="3" class="text-left">
+          [% IF is_owner %]
+            <a href="[% 'editsubscriber' | url_rel([list],{email=>u.email,previous_action=>action}) %]">[% u.email %]</a>
+          [% ELSE %]
+            [% u.email %]
+          [% END %]
+          </td>
+      [% END %]
+
+      [% IF pictures_display %]
+        [% IF u.pictures_url %]
+          <td>
+            <a href="[%u.pictures_url%]" title="[%|loc%]Open in a new window[%END%]" target="pictures"><img class="Pictures" src="[%u.pictures_url%]" alt="[%|loc(u.email)%]%1's picture[%END%]" /></a>
+          </td>
+        [% ELSE %]
+          <td>
+          </td>
+        [% END %]
+      [% END %]
+          <td>
+            <span>
+              [% u.gecos %]&nbsp;
+            </span>
+          </td>
+      [% IF is_owner %]
+          <td>
+            [%|optdesc('reception')%][% u.reception %][%END%]
+          </td>
+          <td>
+        [% IF u.subscribed %]
+          [% IF u.included %]
+               [%|loc%]subscribed[%END%]<br />[% u.sources %]
+          [% ELSE %]
+               [%|loc%]subscribed[%END%]
+          [% END %]
+        [% ELSE %]
+            [% u.sources %]
+        [% END %]
+          </td>
+          <td>
+            [% u.date %]
+          </td>
+          <td>
+            [% u.update_date %]
+          </td>
+        [% IF additional_fields %]
+          <td>
+            [% u.additional %]
+          </td>
+        [% END %]
+        [% FOREACH ca_k IN list_conf.custom_attribute %]<td>[% SET id = ca_k.id %][% u.custom_attribute.$id.value %]</td>[% END %]
+      [% END %]
         </tr>
 
-        [% IF dark == '1' %]
-	  [% SET dark = 0 %]
-	[% ELSE %]
-	  [% SET dark = 1 %]
-	[% END %]
-      [% END %]
-        </tbody>
-      </table>
+      [% IF dark == '1' %]
+        [% SET dark = 0 %]
       [% ELSE %]
-      <p class="small-12 medium-8 medium-centered columns alert-box info text-center">[%|loc%]List has no subscribers[%END%]</p>
+        [% SET dark = 1 %]
+      [% END %]
     [% END %]
+      </tbody>
+    </table>
+[% ELSE %]
+    <p class="small-12 medium-8 medium-centered columns alert-box info text-center">[%|loc%]List has no subscribers[%END%]</p>
+[% END %]
 <!-- End subscribers_table.tt2 -->

--- a/default/web_tt2/sympa_menu.tt2
+++ b/default/web_tt2/sympa_menu.tt2
@@ -1,86 +1,86 @@
 <!-- sympa_menu.tt2 -->
-        [% IF not top_menu %]
-        <li class="menu_title"><label><i class="fa fa-bars"></i> [%|loc%]Sympa menu[%END%]</label></li>
-        [% END %]
-	[% IF action == 'home' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-		<li class="[% class %]"><a  href="[% 'home' | url_rel %]"><i class="fi-home"></i>  [%|loc%]Home[%END%]</a></li>
-		
-	[% IF may_create_list %]
-		[% IF action == 'create_list_request' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-		<li class="[% class %]"><a class="heavyWork" href="[% 'create_list_request' | url_rel %]"><i class="fa fa-plus"></i> [%|loc%]Request a List[%END%]</a></li>
-	[% END %]
-		
-	[% IF is_listmaster %]
-		[% IF action == 'serveradmin' or action == 'skinsedit' or action == 'get_pending_lists'  or action == 'get_closed_lists'  or action == 'get_latest_lists'   or action == 'get_inactive_lists' or action == 'edit_config' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-		<li class="[% class %]"><a  href="[% 'serveradmin' | url_rel %]" ><i class="fa fa-wrench"></i> [%|loc%]Listmaster Admin[%END%]</a></li>
-	[% END %]
-		[% IF top_menu %]		
-		[% IF action == 'search_list_request' or action == 'lists' or action == 'lists_categories' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-		<li class="[% class %]">
-			<a href="#"><i class="fa fa-search-plus"></i> [%|loc%]Search for List(s)[%END%]</a>
-			<ul class="vertical menu">
-		[% END %]
-				[% IF action == 'search_list_request' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-				<li class="[% class %]"><a href="[% 'search_list_request' | url_rel %]"><i class="fa fa-search"></i> [%|loc%]Search form[%END%]</a></li>
-				[% IF action == 'lists' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-				<li class="[% class %]"><a class="heavyWork" href="[% 'lists' | url_rel %]"><i class="fa fa-list"></i> [%|loc%]Index of Lists[%END%]</a></li>
-				[% IF action == 'lists_categories' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-				<li class="[% class %]"><a href="[% 'lists_categories' | url_rel %]" target=""><i class="fa fa-sitemap"></i> [%|loc%]Browse lists by categories[%END%]</a>		
-		[% IF top_menu %]
-			</ul>
-		</li>
-		[% END %]
-		[% IF action == 'help' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-		[% IF top_menu %]
-		<li class="[% class %]">
-			<a href="#"><i class="fa fa-life-ring"></i> [%|loc%]Support[%END%]</a>
-			<ul class="vertical menu">
-		[% END %]
-				[% IF action == 'help' && help_topic != 'faq' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-				<li class="[% class %]"><a href="[% 'help' | url_rel %]" title="[%|loc%]Documentation[%END%]"><i class="fa fa-book"></i> [%|loc%]Documentation[%END%]</a></li>
-				[% IF help_topic == 'faq' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-				<li class="[% class %]"><a href="[% 'help/faq' | url_rel %]" title="[%|loc%]Frequently asked questions[%END%]"><i class="fa fa-question"></i> [%|loc%]FAQ[%END%]</a></li>
-				[% SET class = '' %]
-				[% IF is_listmaster %]<li class="[% class %]"><a href="mailto:sympa-developpers@listes.renater.fr" data-tooltip aria-haspopup="true" title="[%|loc%]Give us feedback about this new Sympa version[%END%]"><i class="fa fa-comments"></i> [%|loc%]Feedback[%END%]</a></li>[% END %]
-		[% IF top_menu %]
-			</ul>
-		</li>
-		[% END %]
-	[% IF conf.main_menu_custom_button_1_title %]
-		<li><a class="MainMenuLinks" [% IF conf.main_menu_custom_button_1_target %] target ="[% conf.main_menu_custom_button_1_target %]"[% END %] href="[% conf.main_menu_custom_button_1_url %]">[% conf.main_menu_custom_button_1_title %]</a></li>
-	[%END%]
-		
-	[% IF conf.main_menu_custom_button_2_title %]
-		<li><a class="MainMenuLinks" [% IF conf.main_menu_custom_button_2_target %] target ="[% conf.main_menu_custom_button_2_target %]"[% END %] href="[% conf.main_menu_custom_button_2_url %]">[% conf.main_menu_custom_button_2_title %]</a></li>
-	[%END%]
-	
-	[% IF conf.main_menu_custom_button_3_title %]
-		<li><a class="MainMenuLinks" [% IF conf.main_menu_custom_button_3_target %] target ="[% conf.main_menu_custom_button_3_target %]"[% END %] href="[% conf.main_menu_custom_button_3_url %]">[% conf.main_menu_custom_button_3_title %]</a></li>
-	[%END%]
+[% IF not top_menu %]
+  <li class="menu_title"><label><i class="fa fa-bars"></i> [%|loc%]Sympa menu[%END%]</label></li>
+[% END %]
+[% IF action == 'home' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
+  <li class="[% class %]"><a  href="[% 'home' | url_rel %]"><i class="fi-home"></i>  [%|loc%]Home[%END%]</a></li>
 
-	[% IF conf.automatic_list_families.keys && user.email %]
-		[% SET family_li = '' %]
-		[% SET owns_family = 0 %]
-		[% FOREACH alf IN conf.automatic_list_families.keys %]
-			[% IF action == 'create_automatic_list_request' && family.name == conf.automatic_list_families.$alf.name %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]  
-			[% IF may_create_automatic_list.$alf %]
-			[% display = conf.automatic_list_families.$alf.display %]
-			[% name = conf.automatic_list_families.$alf.name %]
-			[% family_li = BLOCK ~%]
-			  [% family_li ~%]
-			  <li class="[% class %]"><a href="[% 'create_automatic_list_request' | url_rel([name]) %]" ><i class="fa fa-list-alt"></i> [% display %]</a></li>
-			[%~ END %]
-			[% owns_family = 1 %]
-			[% END %]
-		[% END %]
-			[% IF top_menu %][% IF action == 'create_automatic_list_request' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %][% END %]
-			[% IF owns_family %]
-			<li class="[% class %]">
-				<a href="#"><i class="fa fa-list-alt"></i> [%|loc%]Lists Families[%END%]</a>
-				<ul class="vertical menu">
-					[% family_li %]
-				 </ul>
-			</li>
-			[% END %]
-	[% END %]
-<!-- end sympa_menu.tt2 -->	
+[% IF may_create_list %]
+  [% IF action == 'create_list_request' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
+  <li class="[% class %]"><a class="heavyWork" href="[% 'create_list_request' | url_rel %]"><i class="fa fa-plus"></i> [%|loc%]Request a List[%END%]</a></li>
+[% END %]
+
+[% IF is_listmaster %]
+  [% IF action == 'serveradmin' or action == 'skinsedit' or action == 'get_pending_lists'  or action == 'get_closed_lists'  or action == 'get_latest_lists'   or action == 'get_inactive_lists' or action == 'edit_config' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
+  <li class="[% class %]"><a  href="[% 'serveradmin' | url_rel %]" ><i class="fa fa-wrench"></i> [%|loc%]Listmaster Admin[%END%]</a></li>
+[% END %]
+[% IF top_menu %]
+  [% IF action == 'search_list_request' or action == 'lists' or action == 'lists_categories' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
+  <li class="[% class %]">
+    <a href="#"><i class="fa fa-search-plus"></i> [%|loc%]Search for List(s)[%END%]</a>
+    <ul class="vertical menu">
+[% END %]
+      [% IF action == 'search_list_request' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
+      <li class="[% class %]"><a href="[% 'search_list_request' | url_rel %]"><i class="fa fa-search"></i> [%|loc%]Search form[%END%]</a></li>
+      [% IF action == 'lists' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
+      <li class="[% class %]"><a class="heavyWork" href="[% 'lists' | url_rel %]"><i class="fa fa-list"></i> [%|loc%]Index of Lists[%END%]</a></li>
+      [% IF action == 'lists_categories' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
+      <li class="[% class %]"><a href="[% 'lists_categories' | url_rel %]" target=""><i class="fa fa-sitemap"></i> [%|loc%]Browse lists by categories[%END%]</a>
+[% IF top_menu %]
+    </ul>
+  </li>
+[% END %]
+[% IF action == 'help' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
+[% IF top_menu %]
+  <li class="[% class %]">
+    <a href="#"><i class="fa fa-life-ring"></i> [%|loc%]Support[%END%]</a>
+    <ul class="vertical menu">
+[% END %]
+      [% IF action == 'help' && help_topic != 'faq' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
+      <li class="[% class %]"><a href="[% 'help' | url_rel %]" title="[%|loc%]Documentation[%END%]"><i class="fa fa-book"></i> [%|loc%]Documentation[%END%]</a></li>
+      [% IF help_topic == 'faq' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
+      <li class="[% class %]"><a href="[% 'help/faq' | url_rel %]" title="[%|loc%]Frequently asked questions[%END%]"><i class="fa fa-question"></i> [%|loc%]FAQ[%END%]</a></li>
+      [% SET class = '' %]
+      [% IF is_listmaster %]<li class="[% class %]"><a href="mailto:sympa-developpers@listes.renater.fr" data-tooltip aria-haspopup="true" title="[%|loc%]Give us feedback about this new Sympa version[%END%]"><i class="fa fa-comments"></i> [%|loc%]Feedback[%END%]</a></li>[% END %]
+[% IF top_menu %]
+    </ul>
+  </li>
+[% END %]
+[% IF conf.main_menu_custom_button_1_title %]
+  <li><a class="MainMenuLinks" [% IF conf.main_menu_custom_button_1_target %] target ="[% conf.main_menu_custom_button_1_target %]"[% END %] href="[% conf.main_menu_custom_button_1_url %]">[% conf.main_menu_custom_button_1_title %]</a></li>
+[%END%]
+
+[% IF conf.main_menu_custom_button_2_title %]
+  <li><a class="MainMenuLinks" [% IF conf.main_menu_custom_button_2_target %] target ="[% conf.main_menu_custom_button_2_target %]"[% END %] href="[% conf.main_menu_custom_button_2_url %]">[% conf.main_menu_custom_button_2_title %]</a></li>
+[%END%]
+
+[% IF conf.main_menu_custom_button_3_title %]
+  <li><a class="MainMenuLinks" [% IF conf.main_menu_custom_button_3_target %] target ="[% conf.main_menu_custom_button_3_target %]"[% END %] href="[% conf.main_menu_custom_button_3_url %]">[% conf.main_menu_custom_button_3_title %]</a></li>
+[%END%]
+
+[% IF conf.automatic_list_families.keys && user.email %]
+  [% SET family_li = '' %]
+  [% SET owns_family = 0 %]
+  [% FOREACH alf IN conf.automatic_list_families.keys %]
+    [% IF action == 'create_automatic_list_request' && family.name == conf.automatic_list_families.$alf.name %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
+    [% IF may_create_automatic_list.$alf %]
+      [% display = conf.automatic_list_families.$alf.display %]
+      [% name = conf.automatic_list_families.$alf.name %]
+      [% family_li = BLOCK ~%]
+      [% family_li ~%]
+  <li class="[% class %]"><a href="[% 'create_automatic_list_request' | url_rel([name]) %]" ><i class="fa fa-list-alt"></i> [% display %]</a></li>
+    [%~ END %]
+  [% owns_family = 1 %]
+  [% END %]
+[% END %]
+[% IF top_menu %][% IF action == 'create_automatic_list_request' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %][% END %]
+  [% IF owns_family %]
+  <li class="[% class %]">
+    <a href="#"><i class="fa fa-list-alt"></i> [%|loc%]Lists Families[%END%]</a>
+    <ul class="vertical menu">
+      [% family_li %]
+    </ul>
+  </li>
+  [% END %]
+[% END %]
+<!-- end sympa_menu.tt2 -->

--- a/default/web_tt2/view_template.tt2
+++ b/default/web_tt2/view_template.tt2
@@ -3,37 +3,37 @@
 <h2>[%|loc%]Template edition system[%END%]</h2><br />
 <p>
 
-<ul>
-<li>[%|loc%]Template name: [%END%] <strong> [% template_name %] </strong></li>
-<li>[%|loc%]Type: [%END%]<strong> [% SWITCH webormail -%]
-[% CASE 'web' %][%|loc%]web[%END -%]
-[% CASE 'mail' %][%|loc%]mail[%END -%]
-[% CASE %][% webormail -%]
-[%END%] </strong></li>
-<li>[%|loc%]Path: [%END%]<strong> [% template_path %] </strong></li>
-<li>[%|loc%]Scope: [%END%]
-[%- SWITCH scope -%]
-[% CASE 'distrib' %]<strong> [%|loc%]default[%END%] </strong>
-[%|loc%](this template is the default included in the distribution)[%END%]
-[% CASE 'site' %]<strong> [%|loc%]site[%END%] </strong>
-[%|loc%](this template is the default used by all robots unless redefined for a specific robot)[%END%]
-[% CASE 'robot' %]<strong> [%|loc%]robot[%END%] </strong>
-[%|loc(robot)%](this template is the default for all lists of robot %1 unless it is redefined for a specific list)[%END%]
-[% CASE 'list' %]<strong> [%|loc%]list[%END -%] </strong>
-[%|loc(list,robot)%](this template is defined for list %1@%2)[%END%]
-[% CASE %]<strong> [% scope %] </strong>
-[% END %]</li>
-<li>[%|loc%]Language: [%END%]
-[%- IF tpl_lang == 'default' -%]
-<strong> [%|loc%]default[%END%] </strong>
-[%|loc%](This template is the default for all languages unless it is redefined for a specific language)[%END%]
-[%- ELSE -%]
-<strong class="neutral"
- lang="[%tpl_lang_lang%]" xml:lang="[%tpl_lang_lang%]">
-[%~ tpl_lang | optdesc('lang',1) ~%]
-</strong>
-[%- END %]</li>
-</ul>
+  <ul>
+    <li>[%|loc%]Template name: [%END%] <strong> [% template_name %] </strong></li>
+    <li>[%|loc%]Type: [%END%]<strong> [% SWITCH webormail -%]
+    [% CASE 'web' %][%|loc%]web[%END -%]
+    [% CASE 'mail' %][%|loc%]mail[%END -%]
+    [% CASE %][% webormail -%]
+    [%END%] </strong></li>
+    <li>[%|loc%]Path: [%END%]<strong> [% template_path %] </strong></li>
+    <li>[%|loc%]Scope: [%END%]
+    [%- SWITCH scope -%]
+    [% CASE 'distrib' %]<strong> [%|loc%]default[%END%] </strong>
+    [%|loc%](this template is the default included in the distribution)[%END%]
+    [% CASE 'site' %]<strong> [%|loc%]site[%END%] </strong>
+    [%|loc%](this template is the default used by all robots unless redefined for a specific robot)[%END%]
+    [% CASE 'robot' %]<strong> [%|loc%]robot[%END%] </strong>
+    [%|loc(robot)%](this template is the default for all lists of robot %1 unless it is redefined for a specific list)[%END%]
+    [% CASE 'list' %]<strong> [%|loc%]list[%END -%] </strong>
+    [%|loc(list,robot)%](this template is defined for list %1@%2)[%END%]
+    [% CASE %]<strong> [% scope %] </strong>
+    [% END %]</li>
+    <li>[%|loc%]Language: [%END%]
+    [%- IF tpl_lang == 'default' -%]
+    <strong> [%|loc%]default[%END%] </strong>
+    [%|loc%](This template is the default for all languages unless it is redefined for a specific language)[%END%]
+    [%- ELSE -%]
+    <strong class="neutral"
+     lang="[%tpl_lang_lang%]" xml:lang="[%tpl_lang_lang%]">
+    [%~ tpl_lang | optdesc('lang',1) ~%]
+    </strong>
+    [%- END %]</li>
+  </ul>
 </p><br />
 <div class="block">
 <pre>

--- a/default/web_tt2/viewlogs.tt2
+++ b/default/web_tt2/viewlogs.tt2
@@ -86,188 +86,188 @@
 <br />
 <em>[%|loc(total_results)%]%1 results[%END%].</em>
 <div id="table_container">
-<table class="responsive listOfItems" >
-<caption>[%|loc%]Logs table[%END%]</caption>
-      <tr>
-	[% IF sortby == 'date' %]
-  	    <th class="sortby">
-	    [%|loc%]Date[%END%]
-	[% ELSE %]
-	    <th>
-            <a href="[% 'viewlogs' | url_rel([list,1,size,'date']) %]" >[%|loc%]Date[%END%]</a>
-	[% END %]
-        </th>
+  <table class="responsive listOfItems" >
+    <caption>[%|loc%]Logs table[%END%]</caption>
+    <tr>
+    [% IF sortby == 'date' %]
+      <th class="sortby">
+        [%|loc%]Date[%END%]
+    [% ELSE %]
+      <th>
+        <a href="[% 'viewlogs' | url_rel([list,1,size,'date']) %]" >[%|loc%]Date[%END%]</a>
+    [% END %]
+      </th>
 
-	    <th>
-               <a href="[% 'viewlogs' | url_rel([list,1,size,'list']) %]">[%|loc%]List[%END%]</a>
-	</th>
+      <th>
+        <a href="[% 'viewlogs' | url_rel([list,1,size,'list']) %]">[%|loc%]List[%END%]</a>
+      </th>
 
-	[% IF sortby == 'action' %]
-  	    <th class="sortby">
-	    [%|loc%]Action[%END%]
-	[% ELSE %]
-	    <th>
-               <a href="[% 'viewlogs' | url_rel([list,1,size,'action']) %]">[%|loc%]Action[%END%]</a>
-	[% END %]
-	</th>
+    [% IF sortby == 'action' %]
+      <th class="sortby">
+        [%|loc%]Action[%END%]
+    [% ELSE %]
+      <th>
+        <a href="[% 'viewlogs' | url_rel([list,1,size,'action']) %]">[%|loc%]Action[%END%]</a>
+    [% END %]
+      </th>
 
-	<th>
-	  [%|loc%]Parameters[%END%]
-	</th>
+      <th>
+        [%|loc%]Parameters[%END%]
+      </th>
 
-	<th>
-	  [%|loc%]Target Email[%END%]
-	</th>
+      <th>
+        [%|loc%]Target Email[%END%]
+      </th>
 
-	<th>
-	  [%|loc%]Message ID[%END%]
-	</th>
+      <th>
+        [%|loc%]Message ID[%END%]
+      </th>
 
-	<th>
-	  [%|loc%]Status[%END%]
-	</th>
+      <th>
+        [%|loc%]Status[%END%]
+      </th>
 
-	<th>
-	  [%|loc%]Error type[%END%]
-	</th>
+      <th>
+        [%|loc%]Error type[%END%]
+      </th>
 
-	[% IF sortby == 'user_email' %]
-  	    <th class="sortby">
-	    [%|loc%]User Email[%END%]
-	[% ELSE %]
-	    <th>	    
-	    <a href="[% 'viewlogs' | url_rel([list,1,size,'user_email']) %]">[%|loc%]User Email[%END%]</a>
-	[% END %]
-	</th>
+    [% IF sortby == 'user_email' %]
+      <th class="sortby">
+        [%|loc%]User Email[%END%]
+    [% ELSE %]
+      <th>
+        <a href="[% 'viewlogs' | url_rel([list,1,size,'user_email']) %]">[%|loc%]User Email[%END%]</a>
+    [% END %]
+      </th>
 
-	[% IF is_listmaster || is_owner %]
-	<th>
-	  [%|loc%]User IP[%END%]
-	</th>
-	[% END %]
+    [% IF is_listmaster || is_owner %]
+      <th>
+        [%|loc%]User IP[%END%]
+      </th>
+    [% END %]
 
-	<th>
-	  [%|loc%]Service[%END%]
-	</th>
-        
-      </tr>
- 
-      [% FOREACH l = log_entries %]
-	[% IF dark == '1' %]
-	    <tr>
-	[% ELSE %]
-            <tr class="color0">
-	[% END %]
-	
-	[% IF l.status == 'error' %]
-	  <tr class="bg_color_error">
-	[% END %]
-	  <td>
-	    [% l.date %]
-	  </td>
-	 [% IF is_listmaster || is_owner %]
-	  <td>
-  	      [% l.list %]
-	  </td>
-	  [% END %]
-	  <td>
-  	      [% l.action %]
-	  </td>
-	  <td>
-  	      [% l.parameters %]
-	  </td>
-	  <td>
-  	      [% l.target_email %]
-	  </td>
-          <td>
-          [% IF l.msg_id %]
-            <a href="[% 'viewlogs' | url_rel([list,page,size,sortby],{type=>'all_actions',target_type=>'msg_id',target=>l.msg_id}) %]"
-              data-tooltip aria-haspopup="true"
-              title="[%|loc%]view other events related to this message id.[%END%]">[%|loc%]Other events[%END%]</a>
-          [% END %]
-          </td>
-	  <td>
-	     [% l.status %]
-	  </td>
-	  <td>
-  	      [% l.error_type %]
-	  </td>
-	  <td>
-  	    [% l.user_email %]</span>
-	  </td>
-	  [% IF is_listmaster || is_owner %]
-	  <td>
-  	      [% l.client %]
-	  </td>
-	  [% END %]
-	  <td>
-  	      [% l.daemon %]
-	  </td>
-	</tr>
-      	[% IF dark == '1' %]
-	  [% SET dark = 0 %]
-	[% ELSE %]
-	  [% SET dark = 1 %]
-	[% END %]
+      <th>
+        [%|loc%]Service[%END%]
+      </th>
 
+    </tr>
+
+  [% FOREACH l = log_entries %]
+    [% IF dark == '1' %]
+    <tr>
+    [% ELSE %]
+    <tr class="color0">
+    [% END %]
+
+    [% IF l.status == 'error' %]
+    <tr class="bg_color_error">
+    [% END %]
+      <td>
+        [% l.date %]
+      </td>
+    [% IF is_listmaster || is_owner %]
+      <td>
+        [% l.list %]
+      </td>
+    [% END %]
+      <td>
+        [% l.action %]
+      </td>
+      <td>
+        [% l.parameters %]
+      </td>
+      <td>
+        [% l.target_email %]
+      </td>
+      <td>
+      [% IF l.msg_id %]
+        <a href="[% 'viewlogs' | url_rel([list,page,size,sortby],{type=>'all_actions',target_type=>'msg_id',target=>l.msg_id}) %]"
+          data-tooltip aria-haspopup="true"
+          title="[%|loc%]view other events related to this message id.[%END%]">[%|loc%]Other events[%END%]</a>
       [% END %]
-</table>
+      </td>
+      <td>
+        [% l.status %]
+      </td>
+      <td>
+        [% l.error_type %]
+      </td>
+      <td>
+        [% l.user_email %]</span>
+      </td>
+    [% IF is_listmaster || is_owner %]
+      <td>
+        [% l.client %]
+      </td>
+    [% END %]
+      <td>
+        [% l.daemon %]
+      </td>
+    </tr>
+    [% IF dark == '1' %]
+      [% SET dark = 0 %]
+    [% ELSE %]
+      [% SET dark = 1 %]
+    [% END %]
+
+  [% END %]
+  </table>
 </div>
 [% END %]
 
 [% IF action != 'search' %]
-  <div id="page_size">
+<div id="page_size">
   <form action="[% path_cgi %]" method="POST">
-  <fieldset>
-  <input type="hidden" name="sortby" value="[% sortby %]" />
-  <input type="hidden" name="action" value="viewlogs" />
-  <input type="hidden" name="list" value="[% list %]" />
-  <input type="hidden" name="target_type" value="[% target_type %]" />
-  <input type="hidden" name="target" value="[% target %]" />
-  <input type="hidden" name="date_from" value="[% date_from %]" />
-  <input type="hidden" name="date_to" value="[% date_to %]" />
-  <input type="hidden" name="type" value="[% type %]" />
-  <input type="hidden" name="ip" value="[% ip %]" />
-  <label for="size">[%|loc%]Page size[%END%]</label>
-  [% SET mysize = (size || 0) ~%]
-  <select id="size" name="size" class="submitOnChange">
-  [% FOREACH s = [25, 50, 100, 500] ~%]
-    [% IF 0 < mysize && mysize < s ~%]
-      <option value="[% size %]" selected>[% size %]</option>
-      <option value="[% s %]">[% s %]</option>
-      [%~ mysize = 0 ~%]
-    [%~ ELSIF mysize == s ~%]
-      <option value="[% size %]" selected>[% size %]</option>
-      [%~ mysize = 0 ~%]
-    [%~ ELSIF s < mysize && loop.last() ~%]
-      <option value="[% s %]">[% s %]</option>
-      <option value="[% size %]" selected>[% size %]</option>
-    [%~ ELSE ~%]
-      <option value="[% s %]">[% s %]</option>
-    [%~ END %]
-  [%~ END %]
-  </select>
-  <noscript>
-    <input type="submit" class="MainMenuLinks" name="action_viewlogs"
-      value="[%|loc%]Change[%END%]" />
-  </noscript>
-  </fieldset>
+    <fieldset>
+      <input type="hidden" name="sortby" value="[% sortby %]" />
+      <input type="hidden" name="action" value="viewlogs" />
+      <input type="hidden" name="list" value="[% list %]" />
+      <input type="hidden" name="target_type" value="[% target_type %]" />
+      <input type="hidden" name="target" value="[% target %]" />
+      <input type="hidden" name="date_from" value="[% date_from %]" />
+      <input type="hidden" name="date_to" value="[% date_to %]" />
+      <input type="hidden" name="type" value="[% type %]" />
+      <input type="hidden" name="ip" value="[% ip %]" />
+      <label for="size">[%|loc%]Page size[%END%]</label>
+      [% SET mysize = (size || 0) ~%]
+      <select id="size" name="size" class="submitOnChange">
+      [% FOREACH s = [25, 50, 100, 500] ~%]
+        [% IF 0 < mysize && mysize < s ~%]
+          <option value="[% size %]" selected>[% size %]</option>
+          <option value="[% s %]">[% s %]</option>
+          [%~ mysize = 0 ~%]
+        [%~ ELSIF mysize == s ~%]
+          <option value="[% size %]" selected>[% size %]</option>
+          [%~ mysize = 0 ~%]
+        [%~ ELSIF s < mysize && loop.last() ~%]
+          <option value="[% s %]">[% s %]</option>
+          <option value="[% size %]" selected>[% size %]</option>
+        [%~ ELSE ~%]
+          <option value="[% s %]">[% s %]</option>
+        [%~ END %]
+      [%~ END %]
+      </select>
+      <noscript>
+        <input type="submit" class="MainMenuLinks" name="action_viewlogs"
+          value="[%|loc%]Change[%END%]" />
+      </noscript>
+    </fieldset>
   </form>
-<br />
+  <br />
   [% IF prev_page ~%]
-    <a href="[% 'viewlogs' | url_rel([list,prev_page,size,sortby]) %]">
+  <a href="[% 'viewlogs' | url_rel([list,prev_page,size,sortby]) %]">
     <i class="fa fa-caret-left fa-lg" title="[%|loc%]Previous page[%END%]"></i>
-    </a>
+  </a>
   [%~ END %]
   [% IF page ~%]
     [%|loc(page,total_page)%]page %1 / %2[%END%]
   [%~ END %]
   [% IF next_page ~%]
-    <a href="[% 'viewlogs' | url_rel([list,next_page,size,sortby]) %]">
+  <a href="[% 'viewlogs' | url_rel([list,next_page,size,sortby]) %]">
     <i class="fa fa-caret-right fa-lg" title="[%|loc%]Next page[%END%]"></i>
-    </a>
+  </a>
   [%~ END %]
-  </div>
+</div>
 [% END %]
 
 </div>


### PR DESCRIPTION
I recently updated my Sympa and thus dived in the templates to update my changes. I saw a lot of tab indentation mixed with spaces indentation, which make templates hard to read if your tab width setting is not the one used by the writer of the template (and the tab width is not always the same accross the different templates).

So I removed all tabs and replaced them by spaces. I also made indentation improvments in some templates (not all: it would be a huge work, I may do it in a second time).

If you do a `git diff --ignore-all-space` on my commit, you'll see that I didn't touch much real code (I replaced some tags that were in caps, small things like that).