### PR TITLE
Tidy up all files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ Makefile
 
 /.includepath
 /.project
+
+# Vim tmp file
+*.swp

--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -257,7 +257,7 @@ sub load {
                 'force_reload' => $force_reload
             }
         )
-        ) {
+    ) {
         return undef;
     }
     ##_create_robot_like_config_for_main_robot();
@@ -290,7 +290,7 @@ sub load_robots {
                     'force_reload' => $param->{'force_reload'}
                 }
             )
-            ) {
+        ) {
             $log->syslog(
                 'err',
                 'The config for robot %s contain errors: it could not be correctly loaded',
@@ -438,7 +438,7 @@ sub get_db_conf {
               WHERE robot_conf = ? AND label_conf = ?},
             $robot, $label
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable retrieve value of parameter %s for robot %s from the database',
@@ -480,7 +480,7 @@ sub set_robot_conf {
               WHERE robot_conf = ? AND label_conf = ?},
             $robot, $label
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to check presence of parameter %s for robot %s in database',
@@ -501,7 +501,7 @@ sub set_robot_conf {
                   VALUES (?, ?, ?)},
                 $robot, $label, $value
             )
-            ) {
+        ) {
             $log->syslog(
                 'err',
                 'Unable add value %s for parameter %s in the robot %s DB conf',
@@ -520,7 +520,7 @@ sub set_robot_conf {
                 $robot, $label, $value,
                 $robot, $label
             )
-            ) {
+        ) {
             $log->syslog(
                 'err',
                 'Unable set parameter %s value to %s in the robot %s DB conf',
@@ -562,7 +562,7 @@ sub conf_2_db {
                         . '/robot.conf'
                 }
             )
-            ) {
+        ) {
             $config = $result_of_config_loading->{'config'};
         }
         _remove_unvalid_robot_entry($config);
@@ -573,7 +573,7 @@ sub conf_2_db {
                 if (($conf_parameters[$i]->{'vhost'} eq '1')
                     && #skip parameters that can't be define by robot so not to be loaded in db at that stage
                     ($config->{$conf_parameters[$i]->{'name'}})
-                    ) {
+                ) {
                     Conf::set_robot_conf(
                         $robot,
                         $conf_parameters[$i]->{'name'},
@@ -642,7 +642,7 @@ sub checkfiles_as_root {
                 group => Sympa::Constants::GROUP,
                 mode  => 0644,
             )
-            ) {
+        ) {
             $log->syslog('err', 'Unable to set rights on %s',
                 $Conf{'db_name'});
             return undef;
@@ -666,7 +666,7 @@ sub checkfiles_as_root {
                     user  => Sympa::Constants::USER,
                     group => Sympa::Constants::GROUP,
                 )
-                ) {
+            ) {
                 $log->syslog('err', 'Unable to set rights on %s',
                     $Conf{'db_name'});
                 return undef;
@@ -781,7 +781,7 @@ sub checkfiles {
                     user  => Sympa::Constants::USER,
                     group => Sympa::Constants::GROUP,
                 )
-                ) {
+            ) {
                 $log->syslog('err', 'Unable to set rights on %s',
                     $Conf{$qdir});
                 $config_err++;
@@ -1060,7 +1060,7 @@ sub _load_auth {
             }
             unless ($value =~
                 /^$valid_keywords{$current_paragraph->{'auth_type'}}{$keyword}$/
-                ) {
+            ) {
                 $log->syslog('err',
                     'Unknown format "%s" for keyword "%s" in %s line %d',
                     $value, $keyword, $config_file, $line_num);
@@ -1263,7 +1263,7 @@ sub lang2charset {
     my $locale2charset;
     if ($lang and %Conf::Conf    # configuration loaded
         and $locale2charset = $Conf::Conf{'locale2charset'}
-        ) {
+    ) {
         foreach my $l (Sympa::Language::implicated_langs($lang)) {
             if (exists $locale2charset->{$l}) {
                 return $locale2charset->{$l};
@@ -1323,7 +1323,7 @@ sub load_sql_filter {
                 'db_user'   => {'format' => '.*', 'occurrence' => '0-1',},
                 'db_passwd' => {'format' => '.*', 'occurrence' => '0-1',},
                 'db_options' => {'format' => '.*', 'occurrence' => '0-1',},
-                'db_env'     => {'format' => '.*',  'occurrence' => '0-1',},
+                'db_env'     => {'format' => '.*', 'occurrence' => '0-1',},
                 'db_port'    => {'format' => '\d+', 'occurrence' => '0-1',},
                 'db_timeout' => {'format' => '\d+', 'occurrence' => '0-1',},
             }
@@ -1591,7 +1591,7 @@ sub load_generic_conf_file {
 
                 unless ($paragraph[$i] =~
                     /^\s*$key\s+($structure{$pname}{'format'}{$key}{'format'})\s*$/i
-                    ) {
+                ) {
                     $log->syslog('notice',
                         'Bad entry "%s" in paragraph "%s" in %s',
                         $paragraph[$i], $key, $pname, $config_file);
@@ -1843,7 +1843,7 @@ sub _infer_server_specific_parameter_values {
         Sympa::Tools::Data::smart_eq(
             $param->{'config_hash'}{'dkim_feature'}, 'on'
         )
-        ) {
+    ) {
         # dkim_signature_apply_ on nothing if dkim_feature is off
         # Sets empty array.
         $param->{'config_hash'}{'dkim_signature_apply_on'} = [''];
@@ -1884,7 +1884,7 @@ sub _infer_server_specific_parameter_values {
     foreach my $parameter (
         'rfc2369_header_fields', 'anonymous_header_fields',
         'remove_headers',        'remove_outgoing_headers'
-        ) {
+    ) {
         if ($param->{'config_hash'}{$parameter} eq 'none') {
             delete $param->{'config_hash'}{$parameter};
         } else {

--- a/src/lib/Sympa/Aliases/CheckSMTP.pm
+++ b/src/lib/Sympa/Aliases/CheckSMTP.pm
@@ -71,7 +71,7 @@ sub check {
             Hello   => $smtp_helo,
             Timeout => 30
         )
-        ) {
+    ) {
         $smtp->mail('');
         my $conf = 0;
         foreach my $address (@addresses) {

--- a/src/lib/Sympa/Aliases/Template.pm
+++ b/src/lib/Sympa/Aliases/Template.pm
@@ -62,8 +62,8 @@ sub _aliases {
             Conf::get_robot_conf($domain, 'return_path_suffix'),
 
         # No longer used by default.
-        'robot'             => $domain,
-        'default_domain'    => $Conf::Conf{'domain'},
+        'robot'          => $domain,
+        'default_domain' => $Conf::Conf{'domain'},
     };
 
     my $aliases_dump;
@@ -91,7 +91,7 @@ sub add {
 
     return 0
         if lc Conf::get_robot_conf($list->{'domain'}, 'sendmail_aliases') eq
-            'none';
+        'none';
 
     # Create a lock
     my $lock_fh;
@@ -160,7 +160,7 @@ sub del {
 
     return 0
         if lc Conf::get_robot_conf($list->{'domain'}, 'sendmail_aliases') eq
-            'none';
+        'none';
 
     # Create a lock
     my $lock_fh;

--- a/src/lib/Sympa/Archive.pm
+++ b/src/lib/Sympa/Archive.pm
@@ -87,7 +87,7 @@ sub _create_spool {
                     user  => Sympa::Constants::USER(),
                     group => Sympa::Constants::GROUP()
                 )
-                ) {
+            ) {
                 die sprintf 'Cannot create %s: %s', $directory, $ERRNO;
             }
         }
@@ -767,7 +767,7 @@ sub _clean_archive_directory {
             $answer->{'dir_to_rebuild'},
             $answer->{'cleaned_dir'}
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to create a temporary directory where to store files for HTML escaping (%s). Cancelling',

--- a/src/lib/Sympa/Bulk.pm
+++ b/src/lib/Sympa/Bulk.pm
@@ -69,7 +69,7 @@ sub _create_spool {
         $Conf::Conf{queuebulk},     $self->{msg_directory},
         $self->{pct_directory},     $self->{bad_directory},
         $self->{bad_msg_directory}, $self->{bad_pct_directory}
-        ) {
+    ) {
         unless (-d $directory) {
             $log->syslog('info', 'Creating spool %s', $directory);
             unless (
@@ -79,7 +79,7 @@ sub _create_spool {
                     user  => Sympa::Constants::USER(),
                     group => Sympa::Constants::GROUP()
                 )
-                ) {
+            ) {
                 die sprintf 'Cannot create %s: %s', $directory, $ERRNO;
             }
         }
@@ -361,7 +361,7 @@ sub _get_recipient_tabs_by_domain {
             or
             # number of recipients in general
             (@sendto and $nrcpt >= Conf::get_robot_conf($robot_id, 'nrcpt'))
-            ) {
+        ) {
             undef %rcpt_by_dom;
             # do not replace this line by "push @sendtobypacket, \@sendto" !!!
             my @tab = @sendto;

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -569,16 +569,17 @@ our @params = (
         'edit'       => '1',
         'gettext_comment' =>
             'Restrict list ownership to addresses in the specified domains. This can be used to reserve list ownership to a group of trusted users from a set of domains associated with an organization, while allowing editors and subscribers from the Internet at large.',
-        'default'    => undef,
+        'default' => undef,
     },
-    {   'name'       => 'owner_domain_min',
-        'sample'     => '1',
-        'gettext_id' => 'Minimum number of owners for each list that must match owner_domain restriction',
-        'file'       => 'sympa.conf',
-        'default'    => '0',
-        'optional'   => '1',
-        'vhost'      => '1',
-        'edit'       => '1',
+    {   'name'   => 'owner_domain_min',
+        'sample' => '1',
+        'gettext_id' =>
+            'Minimum number of owners for each list that must match owner_domain restriction',
+        'file'     => 'sympa.conf',
+        'default'  => '0',
+        'optional' => '1',
+        'vhost'    => '1',
+        'edit'     => '1',
         'gettext_comment' =>
             'Minimum number of owners for each list must satisfy the owner_domain restriction. The default of zero (0) means *all* list owners must match. Setting to 1 requires only one list owner to match owner_domain; all other owners can be from any domain. This setting can be used to ensure that there is always at least one known contact point for any mailing list.',
     },
@@ -2061,7 +2062,7 @@ our @params = (
         'file'    => 'sympa.conf',
         'default' => '300',
     },
-    {   'name'    => 'voot_feature', # Not implemented yet.
+    {   'name'    => 'voot_feature',             # Not implemented yet.
         'default' => 'off',
         'file'    => 'sympa.conf',
     },

--- a/src/lib/Sympa/Config.pm
+++ b/src/lib/Sympa/Config.pm
@@ -91,7 +91,7 @@ sub _init_schema_item {
     my %options = @_;
 
     return undef
-	unless ref $pitem->{format} ne 'HASH' and exists $pitem->{default};
+        unless ref $pitem->{format} ne 'HASH' and exists $pitem->{default};
 
     my $default = $pitem->{default};
 
@@ -670,13 +670,11 @@ sub _validate_changes {
     # review the entire new configuration as a whole
     foreach my $validation (CORE::keys %global_validations) {
         next unless ref $global_validations{$validation} eq 'CODE';
-        my ($error, $err_info) = $global_validations{$validation}->($self, $new);
+        my ($error, $err_info) =
+            $global_validations{$validation}->($self, $new);
         next unless $error;
 
-        push @$errors,
-                [
-                 'user', $error, $err_info
-                ];
+        push @$errors, ['user', $error, $err_info];
         $ret = 'invalid';
     }
     return '' unless %$new;
@@ -965,7 +963,9 @@ sub _merge_changes_paragraph {
 
 sub get_id {
     my $that = shift->{context};
-    (ref $that eq 'Sympa::List') ? $that->get_id : (defined $that) ? $that : '';
+          (ref $that eq 'Sympa::List') ? $that->get_id
+        : (defined $that)              ? $that
+        :                                '';
 }
 
 1;

--- a/src/lib/Sympa/Database.pm
+++ b/src/lib/Sympa/Database.pm
@@ -73,9 +73,8 @@ sub new {
                   (exists $params{$_} and defined $params{$_})
                 ? ($_ => $params{$_})
                 : ()
-            } (
-            @{$driver->required_parameters}, @{$driver->optional_parameters}
-            )
+        } ( @{$driver->required_parameters}, @{$driver->optional_parameters}
+        )
     );
 }
 
@@ -155,7 +154,8 @@ sub connect {
 
     unless ($self->ping) {
         unless ($persistent_connection_of{$self->{_id}}) {
-            $log->syslog('err', 'Can\'t connect to Database %s: %s', $self, $DBI::errstr);
+            $log->syslog('err', 'Can\'t connect to Database %s: %s',
+                $self, $DBI::errstr);
             $self->{_status} = 'failed';
             return undef;
         }

--- a/src/lib/Sympa/DatabaseDriver/MySQL.pm
+++ b/src/lib/Sympa/DatabaseDriver/MySQL.pm
@@ -102,7 +102,7 @@ sub is_autoinc {
             $param->{'table'},
             $param->{'field'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to gather autoincrement field named %s for table %s',
             $param->{'field'}, $param->{'table'});
@@ -127,7 +127,7 @@ sub set_autoinc {
             $param->{'table'}, $param->{'field'},
             $param->{'field'}, $field_type
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to set field %s in table %s as autoincrement',
             $param->{'field'}, $param->{'table'});
@@ -171,7 +171,7 @@ sub add_table {
             "CREATE TABLE %s (temporary INT) DEFAULT CHARACTER SET utf8",
             $param->{'table'}
         )
-        ) {
+    ) {
         $log->syslog('err', 'Could not create table %s in database %s',
             $param->{'table'}, $self->{'db_name'});
         return undef;
@@ -224,7 +224,7 @@ sub update_field {
             $param->{'table'}, $param->{'field'}, $param->{'field'},
             $param->{'type'},  $options
         )
-        ) {
+    ) {
         $log->syslog('err', 'Could not change field "%s" in table "%s"',
             $param->{'field'}, $param->{'table'});
         return undef;
@@ -262,7 +262,7 @@ sub add_field {
             $param->{'field'},             $param->{'type'},
             $options
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not add field %s to table %s in database %s',
             $param->{'field'}, $param->{'table'}, $self->{'db_name'});
@@ -288,7 +288,7 @@ sub delete_field {
             "ALTER TABLE %s DROP COLUMN `%s`", $param->{'table'},
             $param->{'field'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not delete field %s from table %s in database %s',
             $param->{'field'}, $param->{'table'}, $self->{'db_name'});
@@ -362,7 +362,7 @@ sub set_primary_key {
             "ALTER TABLE %s ADD PRIMARY KEY (%s)", $param->{'table'},
             $fields
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Could not set fields %s as primary key for table %s in database %s',
@@ -417,7 +417,7 @@ sub unset_index {
             "ALTER TABLE %s DROP INDEX %s", $param->{'table'},
             $param->{'index'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not drop index %s from table %s in database %s',
             $param->{'index'}, $param->{'table'}, $self->{'db_name'});
@@ -447,7 +447,7 @@ sub set_index {
             "ALTER TABLE %s ADD INDEX %s (%s)", $param->{'table'},
             $param->{'index_name'},             $fields
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Could not add index %s using field %s for table %s in database %s',

--- a/src/lib/Sympa/DatabaseDriver/Oracle.pm
+++ b/src/lib/Sympa/DatabaseDriver/Oracle.pm
@@ -108,7 +108,7 @@ sub is_autoinc {
             uc($param->{'table'}),
             uc('trg_' . $param->{'field'})
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to gather autoincrement field named %s for table %s',
             $param->{'field'}, $param->{'table'});
@@ -151,7 +151,7 @@ sub set_autoinc {
                 FROM dual;
               END;}, $field, $table, $field, $field
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to set field %s in table %s as autoincrement',
             $field, $table);
@@ -207,7 +207,7 @@ sub get_fields {
               FROM all_tab_columns
               WHERE table_name = ?}, uc($param->{'table'})
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not get the list of fields from table %s in database %s',
             $param->{'table'}, $self->{'db_name'});
@@ -263,7 +263,7 @@ sub update_field {
               MODIFY (%s %s %s)},
             $param->{'table'}, $param->{'field'}, $param->{'type'}, $options
         )
-        ) {
+    ) {
         $log->syslog('err', 'Could not change field "%s" in table "%s"',
             $param->{'field'}, $param->{'table'});
         return undef;
@@ -296,7 +296,7 @@ sub add_field {
               ADD (%s %s %s)},
             $param->{'table'}, $param->{'field'}, $param->{'type'}, $options
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not add field %s to table %s in database %s',
             $param->{'field'}, $param->{'table'}, $self->{'db_name'});
@@ -324,7 +324,7 @@ sub delete_field {
             $param->{'table'},
             $param->{'field'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not delete field %s from table %s in database %s',
             $param->{'field'}, $param->{'table'}, $self->{'db_name'});
@@ -358,7 +358,7 @@ sub get_primary_key {
                     cons.table_name = ?},
             uc($param->{'table'})
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not get field list from table %s in database %s',
             $param->{'table'}, $self->{'db_name'});
@@ -384,7 +384,7 @@ sub unset_primary_key {
             q{ALTER TABLE %s
               DROP PRIMARY KEY}, $param->{'table'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not drop primary key from table %s in database %s',
             $param->{'table'}, $self->{'db_name'});
@@ -414,7 +414,7 @@ sub set_primary_key {
               ADD CONSTRAINT %s PRIMARY KEY (%s)},
             $param->{'table'}, $pkname, $fields
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Could not set fields %s as primary key for table %s in database %s',
@@ -446,7 +446,7 @@ sub get_indexes {
               WHERE generated = 'N' AND table_name = ?},
             uc $param->{'table'}
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Could not get the list of indexes from table %s in database %s',
@@ -504,7 +504,7 @@ sub set_index {
               ON %s (%s)},
             $param->{'index_name'}, $param->{'table'}, $fields
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Could not add index %s using field %s for table %s in database %s',

--- a/src/lib/Sympa/DatabaseDriver/PostgreSQL.pm
+++ b/src/lib/Sympa/DatabaseDriver/PostgreSQL.pm
@@ -142,7 +142,7 @@ sub is_autoinc {
                                     )},
             $seqname
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to gather autoincrement field named %s for table %s',
             $param->{'field'}, $param->{'table'});
@@ -167,7 +167,7 @@ sub set_autoinc {
             "ALTER TABLE %s ALTER COLUMN %s TYPE BIGINT", $param->{'table'},
             $param->{'field'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to set type of field %s in table %s as bigint',
             $param->{'field'}, $param->{'table'});
@@ -178,7 +178,7 @@ sub set_autoinc {
             "ALTER TABLE %s ALTER COLUMN %s SET DEFAULT NEXTVAL('%s')",
             $param->{'table'}, $param->{'field'}, $seqname
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to set default value of field %s in table %s as next value of sequence table %s',
@@ -193,7 +193,7 @@ sub set_autoinc {
             "UPDATE %s SET %s = NEXTVAL('%s')", $param->{'table'},
             $param->{'field'},                  $seqname
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to set sequence %s as value for field %s, table %s',
             $seqname, $param->{'field'}, $param->{'table'});
@@ -270,7 +270,7 @@ sub get_fields {
             "SELECT a.attname AS field, t.typname AS type, a.atttypmod AS length FROM pg_class c, pg_attribute a, pg_type t WHERE a.attnum > 0 and a.attrelid = c.oid and c.relname = '%s' and a.atttypid = t.oid order by a.attnum",
             $param->{'table'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not get the list of fields from table %s in database %s',
             $param->{'table'}, $self->{'db_name'});
@@ -361,7 +361,7 @@ sub add_field {
             $param->{'field'},             $param->{'type'},
             $options
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not add field %s to table %s in database %s',
             $param->{'field'}, $param->{'table'}, $self->{'db_name'});
@@ -387,7 +387,7 @@ sub delete_field {
             "ALTER TABLE %s DROP COLUMN %s", $param->{'table'},
             $param->{'field'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not delete field %s from table %s in database %s',
             $param->{'field'}, $param->{'table'}, $self->{'db_name'});
@@ -415,7 +415,7 @@ sub get_primary_key {
             "SELECT pg_attribute.attname AS field FROM pg_index, pg_class, pg_attribute WHERE pg_class.oid ='%s'::regclass AND indrelid = pg_class.oid AND pg_attribute.attrelid = pg_class.oid AND pg_attribute.attnum = any(pg_index.indkey) AND indisprimary",
             $param->{'table'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not get the primary key from table %s in database %s',
             $param->{'table'}, $self->{'db_name'});
@@ -448,7 +448,7 @@ sub unset_primary_key {
                     tc.constraint_type = 'PRIMARY KEY'},
             $self->quote($self->{'db_name'}), $self->quote($param->{'table'})
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not search primary key from table %s in database %s',
             $param->{'table'}, $self->{'db_name'});
@@ -469,7 +469,7 @@ sub unset_primary_key {
             q{ALTER TABLE %s DROP CONSTRAINT "%s"}, $param->{'table'},
             $key_name
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not drop primary key "%s" from table %s in database %s',
             $key_name, $param->{'table'}, $self->{'db_name'});
@@ -504,7 +504,7 @@ sub set_primary_key {
             q{ALTER TABLE %s ADD %s (%s)}, $param->{'table'},
             $key,                          $fields
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Could not set fields %s as primary key for table %s in database %s',
@@ -538,7 +538,7 @@ sub get_indexes {
                     pg_catalog.pg_table_is_visible(c.oid)},
             $param->{'table'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not get the oid for table %s in database %s',
             $param->{'table'}, $self->{'db_name'});
@@ -551,7 +551,7 @@ sub get_indexes {
             "SELECT c2.relname, pg_catalog.pg_get_indexdef(i.indexrelid, 0, true) AS description FROM pg_catalog.pg_class c, pg_catalog.pg_class c2, pg_catalog.pg_index i WHERE c.oid = \'%s\' AND c.oid = i.indrelid AND i.indexrelid = c2.oid AND NOT i.indisprimary ORDER BY i.indisprimary DESC, i.indisunique DESC, c2.relname",
             $ref->{'oid'}
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Could not get the list of indexes from table %s in database %s',
@@ -610,7 +610,7 @@ sub set_index {
             "CREATE INDEX %s ON %s (%s)", $param->{'index_name'},
             $param->{'table'},            $fields
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Could not add index %s using field %s for table %s in database %s',

--- a/src/lib/Sympa/DatabaseDriver/SQLite.pm
+++ b/src/lib/Sympa/DatabaseDriver/SQLite.pm
@@ -288,7 +288,7 @@ sub add_field {
                 q{ALTER TABLE %s ADD %s %s%s},
                 $table, $field, $param->{'type'}, $options
             )
-            ) {
+        ) {
             $log->syslog('err',
                 'Could not add field %s to table %s in database %s',
                 $field, $table, $self->{'db_name'});
@@ -449,7 +449,8 @@ sub unset_index {
         $param->{'index'}, $param->{'table'});
 
     my $sth;
-    unless ($sth = $self->do_query(q{DROP INDEX IF EXISTS "%s"}, $param->{'index'})) {
+    unless ($sth =
+        $self->do_query(q{DROP INDEX IF EXISTS "%s"}, $param->{'index'})) {
         $log->syslog('err',
             'Could not drop index %s from table %s in database %s',
             $param->{'index'}, $param->{'table'}, $self->{'db_name'});
@@ -479,7 +480,7 @@ sub set_index {
             q{CREATE INDEX %s ON %s (%s)}, $param->{'index_name'},
             $param->{'table'},             $fields
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Could not add index %s using field %s for table %s in database %s',
@@ -706,7 +707,7 @@ sub _update_table {
                     'fields'     => [sort keys %{$indexes->{$name}}]
                 }
             )
-            ) {
+        ) {
             return undef;
         }
     }
@@ -728,7 +729,7 @@ sub _get_create_table {
               WHERE type = 'table' AND name = '%s'},
             $table
         )
-        ) {
+    ) {
         $log->syslog('Could not get table \'%s\' on database \'%s\'',
             $table, $self->{'db_name'});
         return undef;
@@ -757,7 +758,7 @@ sub _copy_table {
             q{INSERT INTO "%s" (%s) SELECT %s FROM "%s"},
             $table_new, $fields, $fields, $table
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not copy talbe "%s" to temporary table "%s_new"',
             $table, $table_new);

--- a/src/lib/Sympa/DatabaseDriver/Sybase.pm
+++ b/src/lib/Sympa/DatabaseDriver/Sybase.pm
@@ -99,7 +99,7 @@ sub is_autoinc {
             $param->{'table'},
             $param->{'field'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to gather autoincrement field named %s for table %s',
             $param->{'field'}, $param->{'table'});
@@ -119,7 +119,7 @@ sub set_autoinc {
             "ALTER TABLE `%s` CHANGE `%s` `%s` BIGINT( 20 ) NOT NULL AUTO_INCREMENT",
             $param->{'table'}, $param->{'field'}, $param->{'field'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to set field %s in table %s as autoincrement',
             $param->{'field'}, $param->{'table'});
@@ -137,7 +137,7 @@ sub get_tables {
             "SELECT name FROM %s..sysobjects WHERE type='U'",
             $self->{'db_name'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to retrieve the list of tables from database %s',
             $self->{'db_name'});
@@ -209,7 +209,7 @@ sub update_field {
             $param->{'table'}, $param->{'field'}, $param->{'field'},
             $param->{'type'},  $options
         )
-        ) {
+    ) {
         $log->syslog('err', 'Could not change field "%s" in table "%s"',
             $param->{'field'}, $param->{'table'});
         return undef;
@@ -247,7 +247,7 @@ sub add_field {
             $param->{'field'},             $param->{'type'},
             $options
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not add field %s to table %s in database %s',
             $param->{'field'}, $param->{'table'}, $self->{'db_name'});
@@ -273,7 +273,7 @@ sub delete_field {
             "ALTER TABLE %s DROP COLUMN `%s`", $param->{'table'},
             $param->{'field'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not delete field %s from table %s in database %s',
             $param->{'field'}, $param->{'table'}, $self->{'db_name'});
@@ -347,7 +347,7 @@ sub set_primary_key {
             "ALTER TABLE %s ADD PRIMARY KEY (%s)", $param->{'table'},
             $fields
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Could not set fields %s as primary key for table %s in database %s',
@@ -402,7 +402,7 @@ sub unset_index {
             "ALTER TABLE %s DROP INDEX %s", $param->{'table'},
             $param->{'index'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Could not drop index %s from table %s in database %s',
             $param->{'index'}, $param->{'table'}, $self->{'db_name'});
@@ -432,7 +432,7 @@ sub set_index {
             "ALTER TABLE %s ADD INDEX %s (%s)", $param->{'table'},
             $param->{'index_name'},             $fields
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Could not add index %s using field %s for table %s in database %s',

--- a/src/lib/Sympa/DatabaseManager.pm
+++ b/src/lib/Sympa/DatabaseManager.pm
@@ -123,7 +123,7 @@ sub probe_db {
         foreach my $method (
             qw(set_autoinc add_table update_field add_field delete_field
             unset_primary_key set_primary_key unset_index set_index)
-            ) {
+        ) {
             unless ($sdm->can($method)) {
                 $may_update = 0;
                 last;
@@ -192,7 +192,7 @@ sub probe_db {
                         'may_update'  => $may_update,
                     }
                 )
-                ) {
+            ) {
                 $log->syslog(
                     'err',
                     'Unable to check the validity of fields definition for table %s. Aborting',
@@ -219,7 +219,7 @@ sub probe_db {
                         'may_update' => $may_update
                     }
                 )
-                ) {
+            ) {
                 $log->syslog(
                     'err',
                     'Unable to check the validity of primary key for table %s. Aborting',
@@ -236,7 +236,7 @@ sub probe_db {
                         'may_update' => $may_update
                     }
                 )
-                ) {
+            ) {
                 $log->syslog(
                     'err',
                     'Unable to check the valifity of indexes for table %s. Aborting',
@@ -251,7 +251,7 @@ sub probe_db {
                 $sdm->is_autoinc(
                     {'table' => $table, 'field' => $autoincrement{$table}}
                 )
-                ) {
+            ) {
                 if ($may_update
                     and $sdm->set_autoinc(
                         {   'table'      => $table,
@@ -260,7 +260,7 @@ sub probe_db {
                                 ->{$autoincrement{$table}},
                         }
                     )
-                    ) {
+                ) {
                     $log->syslog('notice',
                         "Setting table $table field $autoincrement{$table} as autoincrement"
                     );
@@ -348,7 +348,7 @@ sub _check_fields {
                         ),
                     }
                 )
-                ) {
+            ) {
                 push @{$report_ref}, $rep;
             } else {
                 $log->syslog('err',
@@ -365,7 +365,7 @@ sub _check_fields {
                     effective_format => $real_struct{$t}{$f},
                     required_format  => $db_struct->{$t}->{$f}
                 )
-                ) {
+            ) {
                 push @{$report_ref},
                     sprintf(
                     "Field '%s'  (table '%s' ; database '%s') does NOT have awaited type (%s). Attempting to change it...",
@@ -393,7 +393,7 @@ sub _check_fields {
                             'notnull' => $not_null{$f},
                         }
                     )
-                    ) {
+                ) {
                     push @{$report_ref}, $rep;
                 } else {
                     $log->syslog('err',
@@ -454,7 +454,7 @@ sub _check_primary_key {
                     and $rep = $sdm->set_primary_key(
                         {'table' => $t, 'fields' => $primary{$t}}
                     )
-                    ) {
+                ) {
                     push @{$report_ref}, $rep;
                 } else {
                     return undef;
@@ -480,7 +480,7 @@ sub _check_primary_key {
                     and $rep = $sdm->set_primary_key(
                         {'table' => $t, 'fields' => $primary{$t}}
                     )
-                    ) {
+                ) {
                     push @{$report_ref}, $rep;
                 } else {
                     return undef;
@@ -537,7 +537,7 @@ sub _check_indexes {
                         'fields'     => $indexes{$t}{$idx}
                     }
                 )
-                ) {
+            ) {
                 push @{$report_ref}, $rep;
             }
         }
@@ -563,7 +563,7 @@ sub _check_indexes {
                             'fields'     => $indexes{$t}{$idx}
                         }
                     )
-                    ) {
+                ) {
                     push @{$report_ref}, $rep;
                 } else {
                     return undef;
@@ -592,7 +592,7 @@ sub _check_indexes {
                             'fields'     => $indexes{$t}{$idx}
                         }
                     )
-                    ) {
+                ) {
                     push @{$report_ref}, $rep;
                 } else {
                     return undef;

--- a/src/lib/Sympa/Family.pm
+++ b/src/lib/Sympa/Family.pm
@@ -356,7 +356,7 @@ sub modify_list {
         $list = Sympa::List->new(
             $hash_list->{'config'}{'listname'}, $self->{'robot'}
         )
-        ) {
+    ) {
         push @{$return->{'string_error'}},
             "The list $hash_list->{'config'}{'listname'} does not exist.";
         return $return;
@@ -390,11 +390,11 @@ sub modify_list {
 
     ## list config family updating
     my $spindle = Sympa::Spindle::ProcessRequest->new(
-        context      => $self,
-        action       => 'update_automatic_list',
-        current_list => $list,
-        parameters   => $hash_list->{config},
-        sender       => Sympa::get_address($self, 'listmaster'),
+        context          => $self,
+        action           => 'update_automatic_list',
+        current_list     => $list,
+        parameters       => $hash_list->{config},
+        sender           => Sympa::get_address($self, 'listmaster'),
         scenario_context => {skip => 1},
     );
     unless ($spindle and $spindle->spin and $spindle->success) {
@@ -455,7 +455,7 @@ sub modify_list {
     ## notify owner for forbidden customizing
     if (    #(scalar $custom->{'forbidden'}{'file'}) ||
         (scalar @{$custom->{'forbidden'}{'param'}})
-        ) {
+    ) {
         #my $forbidden_files = join(',',@{$custom->{'forbidden'}{'file'}});
         my $forbidden_param = join(',', @{$custom->{'forbidden'}{'param'}});
         $log->syslog('notice',
@@ -839,8 +839,8 @@ sub instantiate {
                     $list->{'name'}
                 );
             } else {
-                $self->{'created_lists'}{'without_aliases'}{$list->{'name'}} =
-                    $list->{'name'};
+                $self->{'created_lists'}{'without_aliases'}{$list->{'name'}}
+                    = $list->{'name'};
             }
 
             # config_changes
@@ -959,7 +959,9 @@ sub instantiate {
             # In old documentation "moderator" was single or multiple editors.
             my $mod = $hash_list->{config}{moderator};
             $hash_list->{config}{editor} ||=
-            (ref $mod eq 'ARRAY') ? $mod : (ref $mod eq 'HASH') ? [$mod] : [];
+                  (ref $mod eq 'ARRAY') ? $mod
+                : (ref $mod eq 'HASH')  ? [$mod]
+                :                         [];
 
             my $result = $self->_update_existing_list($list, $hash_list);
             unless (defined $result) {
@@ -1945,11 +1947,11 @@ sub _update_existing_list {
 
     ## list config family updating
     my $spindle = Sympa::Spindle::ProcessRequest->new(
-        context      => $self,
-        action       => 'update_automatic_list',
-        current_list => $list,
-        parameters   => $hash_list->{config},
-        sender       => Sympa::get_address($self, 'listmaster'),
+        context          => $self,
+        action           => 'update_automatic_list',
+        current_list     => $list,
+        parameters       => $hash_list->{config},
+        sender           => Sympa::get_address($self, 'listmaster'),
         scenario_context => {skip => 1},
     );
     unless ($spindle and $spindle->spin and $spindle->success) {
@@ -2006,7 +2008,7 @@ sub _update_existing_list {
     ## notify owner for forbidden customizing
     if (    #(scalar $custom->{'forbidden'}{'file'}) ||
         (scalar @{$custom->{'forbidden'}{'param'}})
-        ) {
+    ) {
         #my $forbidden_files = join(',',@{$custom->{'forbidden'}{'file'}});
         my $forbidden_param = join(',', @{$custom->{'forbidden'}{'param'}});
         $log->syslog('notice',
@@ -2588,7 +2590,7 @@ sub insert_delete_exclusion {
                   VALUES (?, ?, ?, ?, ?)},
                 sprintf('family:%s', $name), $name, $robot_id, $email, $date
             )
-            ) {
+        ) {
             $log->syslog('err', 'Unable to exclude user %s from family %s',
                 $email, $self);
             return undef;

--- a/src/lib/Sympa/HTMLSanitizer.pm
+++ b/src/lib/Sympa/HTMLSanitizer.pm
@@ -45,11 +45,11 @@ sub new {
     my $robot_id = shift || '*';
 
     my $self = $class->SUPER::new(
-        {   Context  => 'Document',
-            AllowSrc => 1,
-            AllowHref       => 1,
-            AllowRelURL     => 1,
-            EscapeFiltered  => 0,
+        {   Context        => 'Document',
+            AllowSrc       => 1,
+            AllowHref      => 1,
+            AllowRelURL    => 1,
+            EscapeFiltered => 0,
         }
     );
 
@@ -83,7 +83,7 @@ sub new {
             } else {
                 ();
             }
-            } @allowed_origins
+        } @allowed_origins
     ) . ')\z';
 
     return $self;

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -317,7 +317,7 @@ foreach my $t (qw(subscriber_table admin_table)) {
 }
 
 # This is the generic hash which keeps all lists in memory.
-my %list_of_lists  = ();
+my %list_of_lists = ();
 
 ## Creates an object.
 sub new {
@@ -400,8 +400,8 @@ sub new {
     ## Config file was loaded or reloaded
     my $pertinent_ttl = $list->{'admin'}{'distribution_ttl'}
         || $list->{'admin'}{'ttl'};
-    if ($status
-        and grep {$list->{'admin'}{'status'} eq $_} qw(open pending)
+    if (    $status
+        and grep { $list->{'admin'}{'status'} eq $_ } qw(open pending)
         and (
             (   not $options->{'skip_sync_admin'}
                 and $list->_cache_read_expiry('last_sync_admin_user') <
@@ -409,7 +409,7 @@ sub new {
             )
             or $options->{'force_sync_admin'}
         )
-        ) {
+    ) {
         ## Update admin_table
         unless (defined $list->sync_include_admin()) {
             $log->syslog('err', '')
@@ -577,7 +577,7 @@ sub get_latest_distribution_date {
 #sub get_next_sequence;
 
 sub get_stats {
-    my $self  = shift;
+    my $self = shift;
 
     my @stats;
     my $lock_fh = Sympa::LockedFile->new($self->{'dir'} . '/stats', 2, '<');
@@ -677,8 +677,8 @@ sub _cache_read_expiry {
 }
 
 sub _cache_get {
-    my $self   = shift;
-    my $type   = shift;
+    my $self = shift;
+    my $type = shift;
 
     my $lasttime = $self->{_mtime}{$type};
     my $mtime;
@@ -714,7 +714,7 @@ sub dump_users {
     my $role = shift;
 
     die 'bug in logic. Ask developer'
-        unless grep {$role eq $_} qw(member owner editor);
+        unless grep { $role eq $_ } qw(member owner editor);
 
     my $file = $self->{'dir'} . '/' . $role . '.dump';
 
@@ -722,8 +722,10 @@ sub dump_users {
     rename $file, $file . '.old' if -e $file;
     my $lock_fh = Sympa::LockedFile->new($file, 5, '>');
     unless ($lock_fh) {
-        $log->syslog('err', 'Failed to save file %s.new: %s', $file,
-            Sympa::LockedFile->last_error);
+        $log->syslog(
+            'err', 'Failed to save file %s.new: %s',
+            $file, Sympa::LockedFile->last_error
+        );
         return undef;
     }
 
@@ -735,7 +737,7 @@ sub dump_users {
             $user = $self->get_first_list_member();
             $user;
             $user = $self->get_next_list_member()
-            ) {
+        ) {
             foreach my $k (sort keys %map_field) {
                 printf $lock_fh "%s %s\n", $k, $user->{$k}
                     if defined $user->{$k} and length $user->{$k};
@@ -750,7 +752,6 @@ sub dump_users {
             foreach my $k (sort keys %map_field) {
                 printf $lock_fh "%s %s\n", $k, $user->{$k}
                     if defined $user->{$k} and length $user->{$k};
-    
             }
             print $lock_fh "\n";
         }
@@ -797,7 +798,7 @@ sub save_config {
         $self->_save_list_config_file(
             $config_file_name, $old_config_file_name
         )
-        ) {
+    ) {
         $log->syslog('info', 'Unable to save config file %s',
             $config_file_name);
         $lock_fh->close();
@@ -1375,11 +1376,11 @@ sub get_digest_recipients_per_mode {
         my $user = $self->get_first_list_member();
         $user;
         $user = $self->get_next_list_member()
-        ) {
+    ) {
         # Test to know if the rcpt suspended her subscription for this list.
         # If yes, don't send the message.
         if ($user and $user->{'suspend'}) {
-            if ((not $user->{'startdate'} or $user->{'startdate'} <= time)
+            if (    (not $user->{'startdate'} or $user->{'startdate'} <= time)
                 and (not $user->{'enddate'} or time <= $user->{'enddate'})) {
                 next;
             } elsif ($user->{'enddate'} and $user->{'enddate'} < time) {
@@ -1448,7 +1449,7 @@ sub get_recipients_per_mode {
         my $user = $self->get_first_list_member();
         $user;
         $user = $self->get_next_list_member()
-        ) {
+    ) {
         unless ($user->{'email'}) {
             $log->syslog('err',
                 'Skipping user with no email address in list %s', $self);
@@ -1457,7 +1458,7 @@ sub get_recipients_per_mode {
         # Test to know if the rcpt suspended her subscription for this list.
         # if yes, don't send the message.
         if ($user and $user->{'suspend'}) {
-            if ((not $user->{'startdate'} or $user->{'startdate'} <= time)
+            if (    (not $user->{'startdate'} or $user->{'startdate'} <= time)
                 and (not $user->{'enddate'} or time <= $user->{'enddate'})) {
                 push @tabrcpt_nomail_verp, $user->{'email'};
                 next;
@@ -1740,7 +1741,7 @@ sub send_notify_to_owner {
                     Sympa::send_file(
                         $self, 'listowner_notification', [$owner], $param
                     )
-                    ) {
+                ) {
                     $log->syslog(
                         'notice',
                         'Unable to send template "listowner_notification" to %s list owner %s',
@@ -1757,7 +1758,7 @@ sub send_notify_to_owner {
                     Sympa::send_file(
                         $self, 'listowner_notification', $owner, $param
                     )
-                    ) {
+                ) {
                     $log->syslog(
                         'notice',
                         'Unable to send template "listowner_notification" to %s list owner %s',
@@ -1774,7 +1775,7 @@ sub send_notify_to_owner {
                 Sympa::send_file(
                     $self, 'listowner_notification', \@rcpt, $param
                 )
-                ) {
+            ) {
                 $log->syslog(
                     'notice',
                     'Unable to send template "listowner_notification" to %s list owner',
@@ -1883,8 +1884,8 @@ sub find_picture_url {
     my ($filename) = $self->find_picture_filenames($email);
     return undef unless $filename;
 
-    return Sympa::Tools::Text::weburl(
-        $Conf::Conf{'pictures_url'}, [$self->get_id, $filename]);
+    return Sympa::Tools::Text::weburl($Conf::Conf{'pictures_url'},
+        [$self->get_id, $filename]);
 }
 
 =over
@@ -1957,7 +1958,7 @@ sub send_notify_to_editor {
             Sympa::send_file(
                 $self, 'listeditor_notification', \@rcpt, $param
             )
-            ) {
+        ) {
             $log->syslog(
                 'notice',
                 'Unable to send template "listeditor_notification" to %s list editor',
@@ -2098,7 +2099,7 @@ sub delete_list_member {
                         list_subscriber = ? AND robot_subscriber = ?},
                 $who, $name, $self->{'domain'}
             )
-            ) {
+        ) {
             $log->syslog('err', 'Unable to remove list member %s', $who);
             next;
         }
@@ -2160,7 +2161,7 @@ sub delete_list_admin {
                 $who,              $self->{'name'},
                 $self->{'domain'}, $role
             )
-            ) {
+        ) {
             $log->syslog('err', 'Unable to remove admin %s of list %s',
                 $who, $self);
             next;
@@ -2235,10 +2236,10 @@ sub get_total {
               WHERE list_subscriber = ? AND robot_subscriber = ?},
             $self->{'name'}, $self->{'domain'}
         )
-        ) {
+    ) {
         $log->syslog('err', 'Unable to get subscriber count for list %s',
             $self);
-        return $total;      # Return cache probably outdated.
+        return $total;    # Return cache probably outdated.
     }
     $total = $self->_cache_put('total', $sth->fetchrow);
     $sth->finish;
@@ -2289,7 +2290,7 @@ sub suspend_subscription {
             $data->{'startdate'}, $data->{'enddate'},
             $email, $list, $robot
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to suspend subscription of user %s to list %s@%s',
             $email, $list, $robot);
@@ -2326,7 +2327,7 @@ sub restore_suspended_subscription {
                     robot_subscriber = ?},
             $email, $self->{'name'}, $self->{'domain'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to restore subscription of user %s to list %s',
             $email, $self);
@@ -2377,7 +2378,7 @@ sub insert_delete_exclusion {
                       VALUES (?, ?, ?, ?, ?)},
                     $name, '', $robot_id, $email, $date
                 )
-                ) {
+            ) {
                 $log->syslog('err', 'Unable to exclude user %s from list %s',
                     $email, $self);
                 return undef;
@@ -2407,7 +2408,7 @@ sub insert_delete_exclusion {
                                 user_exclusion = ?},
                         $name, $robot_id, $email
                     )
-                    ) {
+                ) {
                     $log->syslog(
                         'err',
                         'Unable to remove entry %s for list %s from table exclusion_table',
@@ -2458,7 +2459,7 @@ sub get_exclusion {
                          robot_exclusion = ?},
                 $name, $self->{'admin'}{'family_name'}, $robot_id
             )
-            ) {
+        ) {
             $log->syslog('err',
                 'Unable to retrieve excluded users for list %s', $self);
             $sth = pop @sth_stack;
@@ -2473,7 +2474,7 @@ sub get_exclusion {
                   WHERE list_exclusion = ? AND robot_exclusion = ?},
                 $name, $robot_id
             )
-            ) {
+        ) {
             $log->syslog('err',
                 'Unable to retrieve excluded users for list %s', $self);
             $sth = pop @sth_stack;
@@ -2524,7 +2525,7 @@ sub _map_list_member_cols {
             {Sympa::DatabaseDescription::full_db_struct()}
             ->{'subscriber_table'}->{fields}
         }
-        ) {
+    ) {
         next if $f eq 'list_subscriber' or $f eq 'robot_subscriber';
 
         my $k = {reverse %map_field}->{$f};
@@ -2577,7 +2578,7 @@ sub get_list_member {
             $self->{'name'},
             $self->{'domain'}
         )
-        ) {
+    ) {
         $log->syslog('err', 'Unable to gather information for user: %s',
             $email, $self);
         return undef;
@@ -2608,7 +2609,8 @@ sub get_list_member {
         $sth->finish;
 
         if ($error) {
-            $log->syslog('err',
+            $log->syslog(
+                'err',
                 'An error occurred while fetching the data from the database: %s',
                 $sth->errstr
             );
@@ -2807,14 +2809,14 @@ sub _map_list_admin_cols {
 
     foreach my $f (
         keys %{
-            {Sympa::DatabaseDescription::full_db_struct()}
-            ->{'admin_table'}->{fields}
+            {Sympa::DatabaseDescription::full_db_struct()}->{'admin_table'}
+                ->{fields}
         }
-        ) {
+    ) {
         next
             if $f eq 'list_admin'
-                or $f eq 'robot_admin'
-                or $f eq 'role_admin';
+            or $f eq 'robot_admin'
+            or $f eq 'role_admin';
 
         my $k = {reverse %map_field}->{$f};
         unless ($k) {
@@ -2951,7 +2953,7 @@ sub get_admins {
                     $_
                 and $_->{role} eq 'owner'
                 and ($_->{reception} || 'mail') ne 'nomail'
-            } @{$admin_user || []}
+        } @{$admin_user || []}
             unless @users;
     } elsif ($role eq 'receptive_owner') {
         @users = grep {
@@ -2990,7 +2992,7 @@ sub get_current_admins {
             $self->{'name'},
             $self->{'domain'}
         )
-        ) {
+    ) {
         $log->syslog('err', 'Unable to get admins for list %s', $self);
         return undef;
     }
@@ -3056,7 +3058,7 @@ sub get_first_bouncing_list_member {
             $self->{'name'},
             $self->{'domain'}
         )
-        ) {
+    ) {
         $log->syslog('err', 'Unable to get bouncing users %s@%s',
             $name, $self->{'domain'});
         return undef;
@@ -3236,7 +3238,7 @@ sub get_members {
             $self->{'name'},
             $self->{'domain'}
         )
-        ) {
+    ) {
         $log->syslog('err', 'Unable to get members of list %s', $self);
         return;    # Returns void.
     }
@@ -3394,7 +3396,7 @@ sub get_total_bouncing {
                     bounce_subscriber IS NOT NULL},
             $name, $self->{'domain'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to gather bouncing subscribers count for list %s@%s',
             $name, $self->{'domain'});
@@ -3469,13 +3471,10 @@ sub is_list_member {
                     user_subscriber = ?},
             $self->{'name'}, $self->{'domain'}, $who
         )
-        ) {
-        $log->syslog(
-            'err',
+    ) {
+        $log->syslog('err',
             'Unable to check chether user %s is subscribed to list %s',
-            $who,
-            $self
-        );
+            $who, $self);
         return undef;
     }
     $is_list_member->{$who} = $sth->fetchrow;
@@ -3535,7 +3534,7 @@ sub update_list_member {
                 $self->{'name'},
                 $self->{'domain'}
             )
-            ) {
+        ) {
             $log->syslog(
                 'err',
                 'Could not update information for subscriber %s in database for list %s',
@@ -3559,7 +3558,7 @@ sub update_list_member {
                 $self->{'name'},
                 $self->{'domain'}
             )
-            ) {
+        ) {
             $log->syslog(
                 'err',
                 'Could not update information for subscriber %s in database for list %s',
@@ -3714,7 +3713,7 @@ sub update_list_admin {
                     $table, join(',', @set_list),
                     $sdm->quote($who)
                 )
-                ) {
+            ) {
                 $log->syslog('err',
                     'Could not update information for admin %s in table %s',
                     $who, $table);
@@ -3735,7 +3734,7 @@ sub update_list_admin {
                         $sdm->quote($self->{'domain'}),
                         $sdm->quote($role)
                     )
-                    ) {
+                ) {
                     $log->syslog(
                         'err',
                         'Could not update information for admin %s in table %s for list %s@%s',
@@ -3761,7 +3760,7 @@ sub update_list_admin {
                         $sdm->quote($self->{'domain'}),
                         $sdm->quote($role)
                     )
-                    ) {
+                ) {
                     $log->syslog(
                         'err',
                         'Could not update information for admin %s in table %s for list %s@%s',
@@ -3793,7 +3792,7 @@ sub update_list_admin {
 ## Adds a list member ; no overwrite.
 sub add_list_member {
     $log->syslog('debug2', '%s, ...', @_);
-    my $self = shift;
+    my $self      = shift;
     my @new_users = @_;
 
     my $name = $self->{'name'};
@@ -3804,7 +3803,7 @@ sub add_list_member {
     $self->{'add_outcome'}{'remaining_members_to_add'} =
         $self->{'add_outcome'}{'expected_number_of_added_users'};
 
-    my $current_list_members_count = $self->get_total; #FIXME: high db load
+    my $current_list_members_count = $self->get_total;   # FIXME: high db load
 
     my $sdm = Sympa::DatabaseManager->instance;
 
@@ -3877,7 +3876,7 @@ sub add_list_member {
                     'lang'     => $new_user->{'lang'},
                     'password' => $new_user->{'password'}
                 )
-                ) {
+            ) {
                 $log->syslog('err', 'Unable to add user %s to user_table',
                     $who);
                 $self->{'add_outcome'}{'errors'}{'unable_to_add_to_database'}
@@ -3932,7 +3931,7 @@ sub add_list_member {
                 $new_user->{'startdate'},
                 $new_user->{'enddate'}
             )
-            ) {
+        ) {
             $log->syslog(
                 'err',
                 'Unable to add subscriber %s to table subscriber_table for list %s@%s %s',
@@ -3993,8 +3992,8 @@ sub _create_add_error_string {
 ## Adds a new list admin user, no overwrite.
 sub add_list_admin {
     $log->syslog('debug2', '(%s, %s, ...)', @_);
-    my $self = shift;
-    my $role = shift;
+    my $self  = shift;
+    my $role  = shift;
     my @users = @_;
 
     my $total = 0;
@@ -4025,7 +4024,7 @@ sub _add_list_admin {
                 'lang'     => $user->{'lang'},
                 'password' => $user->{'password'},
             )
-            ) {
+        ) {
             $log->syslog('err', 'Unable to add admin %s to user_table', $who);
             return undef;
         }
@@ -4054,7 +4053,7 @@ sub _add_list_admin {
     @set_list =
         @map_field{grep { $_ ne 'date' and exists $user->{$_} } @key_list};
     @val_list =
-        @{$user}{grep   { $_ ne 'date' and exists $user->{$_} } @key_list};
+        @{$user}{grep { $_ ne 'date' and exists $user->{$_} } @key_list};
     if (    $options{replace}
         and @set_list
         and $sdm
@@ -4073,7 +4072,7 @@ sub _add_list_admin {
             $self->{'domain'}
         )
         and $sth->rows    # If no affected rows, then insert a new row
-        ) {
+    ) {
         return 1;
     }
     @set_list = @map_field{@key_list};
@@ -4094,7 +4093,7 @@ sub _add_list_admin {
             $self->{'name'},
             $self->{'domain'}
         )
-        ) {
+    ) {
         return 1;
     }
 
@@ -4251,7 +4250,7 @@ sub is_included {
               WHERE source_inclusion = ?},
             $self->get_id
         )
-        ) {
+    ) {
         $log->syslog('err', 'Failed to get inclusion information on list %s',
             $self);
         return 1;    # Fake positive result.
@@ -4426,7 +4425,7 @@ sub restore_users {
     my $role = shift;
 
     die 'bug in logic. Ask developer'
-        unless grep {$role eq $_} qw(member owner editor);
+        unless grep { $role eq $_ } qw(member owner editor);
 
     # Open the file and switch to paragraph mode.
     my $file = $self->{'dir'} . '/' . $role . '.dump';
@@ -4442,15 +4441,18 @@ sub restore_users {
                     #FIMXE: Define appropriate schema.
                     if (/^\s*(suspend|subscribed|included)\s+(\S+)\s*$/) {
                         ($1 => !!$2);
-                    } elsif (/^\s*(date|update_date|startdate|enddate|bounce_score|number_messages)\s+(\d+)\s*$/
-                        or /^\s*(reception)\s+(mail|digest|nomail|summary|notice|txt|html|urlize|not_me)\s*$/
+                    } elsif (
+                        /^\s*(date|update_date|startdate|enddate|bounce_score|number_messages)\s+(\d+)\s*$/
+                        or
+                        /^\s*(reception)\s+(mail|digest|nomail|summary|notice|txt|html|urlize|not_me)\s*$/
                         or /^\s*(visibility)\s+(conceal|noconceal)\s*$/
                         or (/^\s*(\w+)\s+(.+)\s*$/ and $map_field{$1})) {
                         ($1 => $2);
                     } else {
                         ();
                     }
-                    } split /\n/, $para
+                } split /\n/,
+                $para
             };
             next unless $user->{email};
 
@@ -4475,7 +4477,8 @@ sub restore_users {
                     } else {
                         ();
                     }
-                    } split /\n/, $para
+                } split /\n/,
+                $para
             };
             $user->{update_date} = $time;
             $self->_add_list_admin($role, $user, replace => 1)
@@ -4498,8 +4501,9 @@ sub restore_users {
                 $role, $self->{'name'}, $self->{'domain'},
                 $time
             )
-            ) {
-            $log->syslog('err', '(%s) Failed to delete %s %s(s)', $self, $role);
+        ) {
+            $log->syslog('err', '(%s) Failed to delete %s %s(s)',
+                $self, $role);
         }
         $changed++ if $sth and $sth->rows;
         unless (
@@ -4515,7 +4519,7 @@ sub restore_users {
                 $role, $self->{'name'}, $self->{'domain'},
                 $time
             )
-            ) {
+        ) {
             $log->syslog('err', '(%s) Failed to delete %s', $self, $role);
         }
         $changed++ if $sth and $sth->rows;
@@ -4585,7 +4589,7 @@ sub _include_users_remote_sympa_list {
                 'capath'     => $Conf::Conf{'capath'}
             }
         )
-        ) {
+    ) {
         chomp $line;
 
         if ($getting_headers) {    # ignore http headers
@@ -4764,7 +4768,7 @@ sub _include_users_list {
         my $user = $includelist->get_first_list_member();
         $user;
         $user = $includelist->get_next_list_member()
-        ) {
+    ) {
         # Do we need filtering ?
         if (defined $filter and length $filter) {
             # Prepare available variables
@@ -5917,7 +5921,7 @@ sub _load_list_members_from_include {
                         $incl->{'nosync_time_ranges'}
                     )
                     or $source_is_new
-                    ) {
+                ) {
                     $log->syslog('debug', 'Is_new %d, syncing',
                         $source_is_new);
                     $included = _include_users_sql(
@@ -5952,7 +5956,7 @@ sub _load_list_members_from_include {
                         $incl->{'nosync_time_ranges'}
                     )
                     or $source_is_new
-                    ) {
+                ) {
                     $included =
                         _include_users_ldap(\%users, $source_id, $incl, $db,
                         $self->{'admin'}{'default_user_options'});
@@ -5980,7 +5984,7 @@ sub _load_list_members_from_include {
                         $incl->{'nosync_time_ranges'}
                     )
                     or $source_is_new
-                    ) {
+                ) {
                     my $result =
                         _include_users_ldap_2level(\%users, $source_id, $incl,
                         $db, $self->{'admin'}{'default_user_options'});
@@ -6466,7 +6470,7 @@ sub _load_include_admin_user_file {
 
                 unless ($paragraph[$i] =~
                     /^\s*$key\s+($pinfo->{$pname}{'file_format'}{$key}{'file_format'})\s*$/i
-                    ) {
+                ) {
                     chomp($paragraph[$i]);
                     $log->syslog('info',
                         'Bad entry "%s" for key "%s", paragraph "%s" in %s',
@@ -6486,7 +6490,7 @@ sub _load_include_admin_user_file {
                 ## Default value
                 unless (defined $hash{$k}) {
                     if (defined $pinfo->{$pname}{'file_format'}{$k}{'default'}
-                        ) {
+                    ) {
                         $hash{$k} =
                             $self->_load_list_param($k, 'default',
                             $pinfo->{$pname}{'file_format'}{$k});
@@ -6578,7 +6582,7 @@ sub sync_include_ca {
         my $user = $self->get_first_list_member();
         $user;
         $user = $self->get_next_list_member()
-        ) {
+    ) {
         $users{$user->{'email'}} = $user->{'custom_attribute'};
     }
 
@@ -6626,7 +6630,7 @@ sub sync_include_ca {
             if (Sympa::Datasource::is_allowed_to_sync(
                     $incl->{'nosync_time_ranges'}
                 )
-                ) {
+            ) {
                 my $getter = '_' . $type;
                 {    # Magic inside
                     no strict "refs";
@@ -6656,7 +6660,7 @@ sub sync_include_ca {
         if ($self->update_list_member(
                 $email, custom_attribute => $users{$email}
             )
-            ) {
+        ) {
             $log->syslog('debug', 'Updated user %s', $email);
         } else {
             $log->syslog('err', 'Could not update user %s', $email);
@@ -6684,7 +6688,7 @@ sub purge_ca {
         my $user = $self->get_first_list_member();
         $user;
         $user = $self->get_next_list_member()
-        ) {
+    ) {
         next unless (keys %{$user->{'custom_attribute'}});
         my $attributes;
         foreach my $id (keys %{$user->{'custom_attribute'}}) {
@@ -6698,7 +6702,7 @@ sub purge_ca {
         if ($self->update_list_member(
                 $email, custom_attribute => $users{$email}
             )
-            ) {
+        ) {
             $log->syslog('debug', 'Updated user %s', $email);
         } else {
             $log->syslog('err', 'Could not update user %s', $email);
@@ -6722,7 +6726,7 @@ sub sync_include {
         my $user = $self->get_first_list_member();
         $user;
         $user = $self->get_next_list_member()
-        ) {
+    ) {
         $old_subscribers{lc($user->{'email'})} = $user;
 
         ## User neither included nor subscribed = > set subscribed to 1
@@ -6737,7 +6741,7 @@ sub sync_include {
                     update_date => time,
                     subscribed  => 1
                 )
-                ) {
+            ) {
                 $log->syslog(
                     'err', '(%s) Failed to update %s',
                     $self, lc($user->{'email'})
@@ -6868,7 +6872,7 @@ sub sync_include {
                         included    => 0,
                         id          => ''
                     )
-                    ) {
+                ) {
                     $log->syslog('err', '(%s) Failed to update %s',
                         $self, $email);
                     next;
@@ -6935,7 +6939,7 @@ sub sync_include {
                             $old_subscribers{$email}{$attribute},
                             $new_subscribers->{$email}{$attribute}
                         )
-                        ) {
+                    ) {
                         $log->syslog('debug', 'Updating %s to list %s',
                             $email, $self);
                         my $update_time =
@@ -6947,7 +6951,7 @@ sub sync_include {
                                 $attribute =>
                                     $new_subscribers->{$email}{$attribute}
                             )
-                            ) {
+                        ) {
                             $log->syslog('err', '(%s) Failed to update %s',
                                 $self, $email);
                             next;
@@ -6969,7 +6973,7 @@ sub sync_include {
                         included    => 1,
                         id          => $new_subscribers->{$email}{id}
                     )
-                    ) {
+                ) {
                     $log->syslog('err', '(%s) Failed to update %s',
                         $self, $email);
                     next;
@@ -7069,7 +7073,7 @@ sub _update_inclusion_table {
                 $self->get_id, $role, $list_id, $now
             )
             and $sth->rows
-            ) {
+        ) {
             $log->syslog('err', 'Unable to update list %s in database',
                 $self);
             return undef;
@@ -7184,7 +7188,7 @@ sub _sync_include_user {
                 $self->{'name'}, $self->{'domain'}
             )
             and $sth->rows
-            ) {
+        ) {
             unless (
                 $sdm
                 and $sth = $sdm->do_prepared_query(
@@ -7205,7 +7209,7 @@ sub _sync_include_user {
                     $role, $user->{info}, $user->{profile}
                 )
                 and $sth->rows
-                ) {
+            ) {
                 $log->syslog('err', '(%s) Failed to update %s %s',
                     $self, $role, $user->{email});
             } else {
@@ -7235,7 +7239,7 @@ sub _sync_include_user {
             $role, $self->{'name'}, $self->{'domain'},
             $time
         )
-        ) {
+    ) {
         $log->syslog('err', '(%s) Failed to delete %s', $self, $role);
     } else {
         $users_deleted += $sth->rows;
@@ -7253,7 +7257,7 @@ sub _sync_include_user {
             $role, $self->{'name'}, $self->{'domain'},
             $time
         )
-        ) {
+    ) {
         $log->syslog('err', '(%s) Failed to delete %s', $self, $role);
     } else {
         $users_deleted += $sth->rows;
@@ -7290,7 +7294,7 @@ sub is_update_param {
     foreach my $p (
         'reception', 'visibility', 'gecos',    'info',
         'profile',   'id',         'included', 'subscribed'
-        ) {
+    ) {
         if (defined $new_param->{$p}) {
             if (!defined($old_param->{$p})
                 or $new_param->{$p} ne $old_param->{$p}) {
@@ -7343,7 +7347,7 @@ sub _inclusion_loop {
             grep {
                 # Ignore loop by other nodes to prevent infinite processing.
                 not exists $visited{$_}
-                } map {
+            } map {
                 my @parents;
                 if ($sdm
                     and $sth = $sdm->do_prepared_query(
@@ -7352,13 +7356,13 @@ sub _inclusion_loop {
                           WHERE target_inclusion = ? AND role_inclusion = ?},
                         $_, $role
                     )
-                    ) {
+                ) {
                     @parents =
                         map { $_->[0] } @{$sth->fetchall_arrayref([0]) || []};
                     $sth->finish;
                 }
                 @parents
-                } @ancestors
+            } @ancestors
         );
     }
 
@@ -7419,7 +7423,7 @@ sub get_including_lists {
               WHERE source_inclusion = ? AND role_inclusion = ?},
             $self->get_id, $role
         )
-        ) {
+    ) {
         $log->syslog('err', 'Cannot get lists including %s', $self);
         return undef;
     }
@@ -8472,7 +8476,7 @@ sub _load_list_config_file {
 
                 unless ($paragraph[$i] =~
                     /^\s*$key\s+($pinfo->{$pname}{'file_format'}{$key}{'file_format'})\s*$/i
-                    ) {
+                ) {
                     chomp($paragraph[$i]);
                     $log->syslog(
                         'err',
@@ -8497,7 +8501,7 @@ sub _load_list_config_file {
                 ## Default value
                 unless (defined $hash{$k}) {
                     if (defined $pinfo->{$pname}{'file_format'}{$k}{'default'}
-                        ) {
+                    ) {
                         $hash{$k} =
                             $self->_load_list_param($k, 'default',
                             $pinfo->{$pname}{'file_format'}{$k});
@@ -8655,7 +8659,7 @@ sub _load_list_config_postprocess {
         )
         || ($config_hash->{'reply_to'}
             && !$config_hash->{'defaults'}{'reply_to'})
-        ) {
+    ) {
         my ($value, $apply, $other_email);
         $value = $config_hash->{'forced_reply_to'}
             || $config_hash->{'reply_to'};
@@ -8704,7 +8708,7 @@ sub _load_list_config_postprocess {
     ## default_user_options in reception of available_user_options
     if (!grep (/^$config_hash->{'default_user_options'}{'reception'}$/,
             @{$config_hash->{'available_user_options'}{'reception'}})
-        ) {
+    ) {
         push @{$config_hash->{'available_user_options'}{'reception'}},
             $config_hash->{'default_user_options'}{'reception'};
         $log->syslog(
@@ -9189,7 +9193,7 @@ sub remove_bouncers {
             'exclude'   => '1',
             'operation' => 'auto_del'
         )
-        ) {
+    ) {
         $log->syslog('info', 'Error while calling sub delete_users');
         return undef;
     }
@@ -9547,7 +9551,7 @@ sub _update_list_db {
             $searchkey, $web_archive, $topics
         )
         and $sth->rows
-        ) {
+    ) {
         $log->syslog('err', 'Unable to update list %s in database', $self);
         $sth = pop @sth_stack;
         return undef;

--- a/src/lib/Sympa/List/Config.pm
+++ b/src/lib/Sympa/List/Config.pm
@@ -125,7 +125,7 @@ sub _init_schema_item {
                 # See also _get_schema_apply_privilege().
                 $pitem->{privilege} = 'read'
                     if not $pitem->{privilege}
-                        or 'read' lt $pitem->{privilege};
+                    or 'read' lt $pitem->{privilege};
             } elsif (exists $pitem->{default} and defined $pitem->{default}) {
                 delete $pitem->{default}
                     unless grep { $pitem->{default} eq $_ } @constr;
@@ -168,13 +168,13 @@ sub _get_schema_apply_privilege {
     my $priv = $list->may_edit(join('.', @{$pnames || []}), $user);
     $priv = 'read'
         if $pitem->{internal}
-            and (not $priv or 'read' lt $priv);
+        and (not $priv or 'read' lt $priv);
     $priv = $priv_p
         if not $priv
-            or ($priv_p and $priv_p lt $priv);
+        or ($priv_p and $priv_p lt $priv);
     $pitem->{privilege} = $priv
         if not $pitem->{privilege}
-            or ($priv and $priv lt $pitem->{privilege});
+        or ($priv and $priv lt $pitem->{privilege});
     $pitem->{privilege} ||= 'hidden';    # Implicit default
 
     if (ref $pitem->{format} eq 'HASH') {
@@ -210,9 +210,11 @@ sub commit {
     # Updating config_changes for changed parameters.
     # FIXME:Check subitems also.
     if (ref($list->get_family) eq 'Sympa::Family') {
-        unless ($list->update_config_changes(
-            'param', [CORE::keys %{$changes || {}}]
-        )) {
+        unless (
+            $list->update_config_changes(
+                'param', [CORE::keys %{$changes || {}}]
+            )
+        ) {
             push @$errors, ['intern', 'update_config_changes'];
             return undef;
         }

--- a/src/lib/Sympa/List/Users.pm
+++ b/src/lib/Sympa/List/Users.pm
@@ -48,8 +48,8 @@ use constant _global_validations => {
         my $self = shift;
         my $new  = shift;
 
-        my $pinfo = $self->{_pinfo};
-        my $loglevel = 'debug'; # was set to 'info' during development
+        my $pinfo    = $self->{_pinfo};
+        my $loglevel = 'debug';         # was set to 'info' during development
 
         # gather parameters
         my $owner_domain = $self->get('owner_domain');
@@ -75,10 +75,10 @@ use constant _global_validations => {
         @owner = grep defined, @owner;
 
         # count matches and non-matches
-        my @non_matching_owners = grep {!/$domainrex/} @owner;
-        my @matching_owners = grep {/$domainrex/} @owner;
+        my @non_matching_owners = grep { !/$domainrex/ } @owner;
+        my @matching_owners     = grep {/$domainrex/} @owner;
 
-        my $non_matching_count = 1 + $#non_matching_owners;
+        my $non_matching_count   = 1 + $#non_matching_owners;
         my $matching_owner_count = 1 + $#matching_owners;
 
         # logging
@@ -87,27 +87,34 @@ use constant _global_validations => {
         $log->syslog($loglevel, "owners: " . join(",", @owner));
         $log->syslog($loglevel, "total owners: " . ($#owner + 1));
         $log->syslog($loglevel, "domainrex: $domainrex");
-        $log->syslog($loglevel, "matching_owners: " . join(",", @matching_owners));
-        $log->syslog($loglevel, "matching_owner_count: $matching_owner_count");
-        $log->syslog($loglevel, "non_matching_owners: " . join(",", @non_matching_owners));
+        $log->syslog($loglevel,
+            "matching_owners: " . join(",", @matching_owners));
+        $log->syslog($loglevel,
+            "matching_owner_count: $matching_owner_count");
+        $log->syslog($loglevel,
+            "non_matching_owners: " . join(",", @non_matching_owners));
         $log->syslog($loglevel, "non_matching_count: $non_matching_count");
 
         # apply different rules based on min domain requirement
         if ($owner_domain_min == 0) {
-            return ('owner_domain',
-                    {p_info => $pinfo->{'owner'},
-                     p_paths => ['owner'],
-                     owner_domain => $owner_domain,
-                     value => join(' ', @non_matching_owners)})
-                unless ($non_matching_count == 0);
+            return (
+                'owner_domain',
+                {   p_info       => $pinfo->{'owner'},
+                    p_paths      => ['owner'],
+                    owner_domain => $owner_domain,
+                    value        => join(' ', @non_matching_owners)
+                }
+            ) unless ($non_matching_count == 0);
         } else {
-            return ('owner_domain_min',
-                    {p_info => $pinfo->{'owner'},
-                     p_paths => ['owner'],
-                     owner_domain => $owner_domain,
-                     owner_domain_min => $owner_domain_min,
-                     value => $matching_owner_count})
-                unless ($matching_owner_count >= $owner_domain_min);
+            return (
+                'owner_domain_min',
+                {   p_info           => $pinfo->{'owner'},
+                    p_paths          => ['owner'],
+                    owner_domain     => $owner_domain,
+                    owner_domain_min => $owner_domain_min,
+                    value            => $matching_owner_count
+                }
+            ) unless ($matching_owner_count >= $owner_domain_min);
         }
         return '';
     },
@@ -155,7 +162,7 @@ use constant _local_validations => {
 
         return 'incorrect_email'
             if grep { $email eq $_ } @special
-                or $email =~ /^$bounce_email_re$/;
+            or $email =~ /^$bounce_email_re$/;
     },
     # Avoid duplicate parameter values in the array.
     unique_paragraph_key => sub {

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -66,8 +66,8 @@ our %pinfo = (
         'gettext_id' => "Visibility of the list",
         'gettext_comment' =>
             'This parameter indicates whether the list should feature in the output generated in response to a LISTS command or should be shown in the list overview of the web-interface.',
-        'scenario'   => 'visibility',
-        'synonym'    => {
+        'scenario' => 'visibility',
+        'synonym'  => {
             'public'  => 'noconceal',
             'private' => 'conceal'
         }
@@ -214,7 +214,7 @@ our %pinfo = (
         'gettext_id' => "Topics for the list",
         'gettext_comment' =>
             "This parameter allows the classification of lists. You may define multiple topics as well as hierarchical ones. WWSympa's list of public lists uses this parameter.",
-        'format'     => [],     # Sympa::Robot::topic_keys() called later
+        'format'     => [],          # Sympa::Robot::topic_keys() called later
         'field_type' => 'listtopic',
         'split_char' => ',',
         'occurrence' => '0-n',
@@ -227,11 +227,11 @@ our %pinfo = (
         'gettext_id' => "Internet domain",
         'gettext_comment' =>
             'Domain name of the list, default is the robot domain name set in the related robot.conf file or in file sympa.conf.',
-        format_s  => '$host',
-        filters      => ['canonic_domain'],
-        'default'    => {'conf' => 'host'},
-        'length'     => 20,
-        'obsolete'   => 1
+        format_s   => '$host',
+        filters    => ['canonic_domain'],
+        'default'  => {'conf' => 'host'},
+        'length'   => 20,
+        'obsolete' => 1
     },
 
     'lang' => {
@@ -258,9 +258,9 @@ our %pinfo = (
     },
 
     'max_list_members' => {
-        order          => 10.11,
-        'group'        => 'description',
-        'gettext_id'   => "Maximum number of list members",
+        order        => 10.11,
+        'group'      => 'description',
+        'gettext_id' => "Maximum number of list members",
         'gettext_comment' =>
             'limit for the number of subscribers. 0 means no limit.',
         'gettext_unit' => 'list members',
@@ -289,7 +289,7 @@ our %pinfo = (
         'gettext_id' => "Who can send messages",
         'gettext_comment' =>
             'This parameter specifies who can send messages to the list.',
-        'scenario'   => 'send'
+        'scenario' => 'send'
     },
 
     'delivery_time' => {
@@ -304,9 +304,9 @@ our %pinfo = (
     },
 
     'digest' => {
-        order         => 20.03,
-        'group'       => 'sending',
-        'gettext_id'  => "Digest frequency",
+        order        => 20.03,
+        'group'      => 'sending',
+        'gettext_id' => "Digest frequency",
         'gettext_comment' =>
             'Definition of digest mode. If this parameter is present, subscribers can select the option of receiving messages in multipart/digest MIME format, or as a plain text digest. Messages are then grouped together, and compiled messages are sent to subscribers according to the frequency selected with this parameter.',
         'file_format' => '\d+(\s*,\s*\d+)*\s+\d+:\d+',
@@ -355,7 +355,7 @@ our %pinfo = (
                 'gettext_id' => "reception mode",
                 'gettext_comment' =>
                     'Only these modes will be allowed for the subscribers of this list. If a subscriber has a reception mode not in the list, Sympa uses the mode specified in the default_user_options paragraph.',
-                'format'     => [
+                'format' => [
                     'mail',    'notice', 'digest', 'digestplain',
                     'summary', 'nomail', 'txt',    'urlize',
                     'not_me'
@@ -376,12 +376,12 @@ our %pinfo = (
         'gettext_id' => "Subscription profile",
         'gettext_comment' =>
             'Default profile for the subscribers of the list.',
-        'format'     => {
+        'format' => {
             'reception' => {
-                'order'      => 1,
-                'gettext_id' => "reception mode",
+                'order'           => 1,
+                'gettext_id'      => "reception mode",
                 'gettext_comment' => 'Mail reception mode.',
-                'format'     => [
+                'format'          => [
                     'mail',    'notice', 'digest', 'digestplain',
                     'summary', 'nomail', 'txt',    'urlize',
                     'not_me'
@@ -392,13 +392,13 @@ our %pinfo = (
                 'default'    => 'mail'
             },
             'visibility' => {
-                'order'      => 2,
-                'gettext_id' => "visibility",
-                    'gettext_comment' => 'Visibility of the subscriber.',
-                'format'     => ['conceal', 'noconceal'],
-                'field_type' => 'visibility',
-                'occurrence' => '1',
-                'default'    => 'noconceal'
+                'order'           => 2,
+                'gettext_id'      => "visibility",
+                'gettext_comment' => 'Visibility of the subscriber.',
+                'format'          => ['conceal', 'noconceal'],
+                'field_type'      => 'visibility',
+                'occurrence'      => '1',
+                'default'         => 'noconceal'
             }
         },
     },
@@ -409,7 +409,7 @@ our %pinfo = (
         'gettext_id' => "Topics for message categorization",
         'gettext_comment' =>
             "This paragraph defines a topic used to tag a message of a list, named by msg_topic.name (\"other\" is a reserved word), its title is msg_topic.title. The msg_topic.keywords entry is optional and allows automatic tagging. This should be a list of keywords, separated by ','.",
-        'format'     => {
+        'format' => {
             'name' => {
                 'order'      => 1,
                 'gettext_id' => "Message topic name",
@@ -483,7 +483,7 @@ our %pinfo = (
         'gettext_id' => "Reply address",
         'gettext_comment' =>
             'This defines what Sympa will place in the Reply-To: SMTP header field of the messages it distributes.',
-        'format'     => {
+        'format' => {
             'value' => {
                 'order'      => 1,
                 'gettext_id' => "value",
@@ -505,8 +505,8 @@ our %pinfo = (
                 'gettext_id' => "respect of existing header field",
                 'gettext_comment' =>
                     'The default is to respect (preserve) the existing Reply-To: SMTP header field in incoming messages. If set to forced, Reply-To: SMTP header field will be overwritten.',
-                'format'     => ['forced', 'respect'],
-                'default'    => 'respect'
+                'format'  => ['forced', 'respect'],
+                'default' => 'respect'
             }
         }
     },
@@ -516,8 +516,8 @@ our %pinfo = (
         'group'      => 'sending',
         'gettext_id' => "Anonymous sender",
         'gettext_comment' =>
-        "To hide the sender's email address before distributing the message. It is replaced by the provided email address.",
-        'format'     => '.+'
+            "To hide the sender's email address before distributing the message. It is replaced by the provided email address.",
+        'format' => '.+'
     },
 
     'custom_header' => {
@@ -538,8 +538,8 @@ our %pinfo = (
         'gettext_id' => "Subject tagging",
         'gettext_comment' =>
             'This parameter is optional. It specifies a string which is added to the subject of distributed messages (intended to help users who do not use automatic tools to sort incoming messages). This string will be surrounded by [] characters.',
-        'format'     => '.+',
-        'length'     => 15
+        'format' => '.+',
+        'length' => 15
     },
     'custom-subject' => {'obsolete' => 'custom_subject'},
 
@@ -549,19 +549,19 @@ our %pinfo = (
         'gettext_id' => "Attachment type",
         'gettext_comment' =>
             "List owners may decide to add message headers or footers to messages sent via the list. This parameter defines the way a footer/header is added to a message.\nmime: \nThe default value. Sympa will add the footer/header as a new MIME part.\nappend: \nSympa will not create new MIME parts, but will try to append the header/footer to the body of the message. Predefined message-footers will be ignored. Headers/footers may be appended to text/plain messages only.",
-        'format'     => ['mime', 'append'],
-        'default'    => 'mime'
+        'format'  => ['mime', 'append'],
+        'default' => 'mime'
     },
 
     'max_size' => {
-        order          => 20.15,
-        'group'        => 'sending',
-        'gettext_id'   => "Maximum message size",
+        order             => 20.15,
+        'group'           => 'sending',
+        'gettext_id'      => "Maximum message size",
         'gettext_comment' => 'Maximum size of a message in 8-bit bytes.',
-        'gettext_unit' => 'bytes',
-        'format'       => '\d+',
-        'length'       => 8,
-        'default'      => {'conf' => 'max_size'}
+        'gettext_unit'    => 'bytes',
+        'format'          => '\d+',
+        'length'          => 8,
+        'default'         => {'conf' => 'max_size'}
     },
     'max-size' => {'obsolete' => 'max_size'},
 
@@ -575,9 +575,10 @@ our %pinfo = (
     },
 
     'reject_mail_from_automates_feature' => {
-        order        => 20.18,
-        'group'      => 'sending',
-        'gettext_id' => "Reject mail from automatic processes (crontab, etc)?",
+        order   => 20.18,
+        'group' => 'sending',
+        'gettext_id' =>
+            "Reject mail from automatic processes (crontab, etc)?",
         'format'     => ['on', 'off'],
         'occurrence' => '1',
         'default'    => {'conf' => 'reject_mail_from_automates_feature'}
@@ -647,7 +648,7 @@ our %pinfo = (
         'gettext_id' => "Who can subscribe to the list",
         'gettext_comment' =>
             'The subscribe parameter defines the rules for subscribing to the list.',
-        'scenario'   => 'subscribe'
+        'scenario' => 'subscribe'
     },
     'subscription' => {'obsolete' => 'subscribe'},
 
@@ -657,7 +658,7 @@ our %pinfo = (
         'gettext_id' => "Who can add subscribers",
         'gettext_comment' =>
             'Privilege for adding (ADD command) a subscriber to the list',
-        'scenario'   => 'add'
+        'scenario' => 'add'
     },
 
     'unsubscribe' => {
@@ -666,7 +667,7 @@ our %pinfo = (
         'gettext_id' => "Who can unsubscribe",
         'gettext_comment' =>
             'This parameter specifies the unsubscription method for the list. Use open_notify or auth_notify to allow owner notification of each unsubscribe command.',
-        'scenario'   => 'unsubscribe'
+        'scenario' => 'unsubscribe'
     },
     'unsubscription' => {'obsolete' => 'unsubscribe'},
 
@@ -690,7 +691,7 @@ our %pinfo = (
         'gettext_id' => "Who can start a remind process",
         'gettext_comment' =>
             'This parameter specifies who is authorized to use the remind command.',
-        'scenario'   => 'remind'
+        'scenario' => 'remind'
     },
 
     'review' => {
@@ -699,8 +700,8 @@ our %pinfo = (
         'gettext_id' => "Who can review subscribers",
         'gettext_comment' =>
             'This parameter specifies who can access the list of members. Since subscriber addresses can be abused by spammers, it is strongly recommended that you only authorize owners or subscribers to access the subscriber list. ',
-        'scenario'   => 'review',
-        'synonym'    => {'open' => 'public'}
+        'scenario' => 'review',
+        'synonym'  => {'open' => 'public'}
     },
 
     'owner_domain' => {
@@ -734,7 +735,7 @@ our %pinfo = (
         'gettext_id' => "Shared documents",
         'gettext_comment' =>
             'This paragraph defines read and edit access to the shared document repository.',
-        'format'     => {
+        'format' => {
             'd_read' => {
                 'order'      => 1,
                 'gettext_id' => "Who can view",
@@ -801,20 +802,20 @@ our %pinfo = (
         'gettext_id' => "Archives",
         'gettext_comment' =>
             "Privilege for reading mail archives and frequency of archiving.\nDefines who can access the list's web archive.",
-        'format'     => {
+        'format' => {
             'period' => {
                 'order'      => 1,
                 'gettext_id' => "frequency",
                 'format'     => ['day', 'week', 'month', 'quarter', 'year'],
-                'synonym'  => {'weekly' => 'week'},
-                'obsolete' => 1,        # Not yet implemented.
+                'synonym'    => {'weekly' => 'week'},
+                'obsolete' => 1,    # Not yet implemented.
             },
             'access' => {
                 'order'      => 2,
                 'gettext_id' => "access right",
-                'format' => ['open', 'private', 'public', 'owner', 'closed'],
-                'synonym'  => {'open' => 'public'},
-                'obsolete' => 1,      # Use archive.mail_access
+                'format'  => ['open', 'private', 'public', 'owner', 'closed'],
+                'synonym' => {'open' => 'public'},
+                'obsolete' => 1,    # Use archive.mail_access
             },
             'web_access' => {
                 'order'      => 3,
@@ -862,7 +863,7 @@ our %pinfo = (
             'Idem spam_protection is provided but it can be used only for web archives. Access requires a cookie, and users must submit a small form in order to receive a cookie before browsing the archives. This blocks all robot, even google and co.',
         'format'     => ['cookie', 'javascript', 'at', 'none'],
         'occurrence' => '1',
-        'default' => {'conf' => 'web_archive_spam_protection'}
+        'default'    => {'conf' => 'web_archive_spam_protection'}
     },
 
     ### Bounces page ###
@@ -873,8 +874,8 @@ our %pinfo = (
         'gettext_id' => "Bounces management",
         'format'     => {
             'warn_rate' => {
-                'order'        => 1,
-                'gettext_id'   => "warn rate",
+                'order'      => 1,
+                'gettext_id' => "warn rate",
                 'gettext_comment' =>
                     'The list owner receives a warning whenever a message is distributed and the number (percentage) of bounces exceeds this value.',
                 'gettext_unit' => '%',
@@ -883,8 +884,8 @@ our %pinfo = (
                 'default'      => {'conf' => 'bounce_warn_rate'}
             },
             'halt_rate' => {
-                'order'        => 2,
-                'gettext_id'   => "halt rate",
+                'order'      => 2,
+                'gettext_id' => "halt rate",
                 'gettext_comment' =>
                     'NOT USED YET. If bounce rate reaches the halt_rate, messages for the list will be halted, i.e. they are retained for subsequent moderation.',
                 'gettext_unit' => '%',
@@ -897,14 +898,14 @@ our %pinfo = (
     },
 
     'bouncers_level1' => {
-        order        => 50.02,
-        'group'      => 'bounces',
-        'gettext_id' => "Management of bouncers, 1st level",
+        order             => 50.02,
+        'group'           => 'bounces',
+        'gettext_id'      => "Management of bouncers, 1st level",
         'gettext_comment' => 'Level 1 is the lower level of bouncing users',
-        'format'     => {
+        'format'          => {
             'rate' => {
-                'order'        => 1,
-                'gettext_id'   => "threshold",
+                'order'      => 1,
+                'gettext_id' => "threshold",
                 'gettext_comment' =>
                     "Each bouncing user have a score (from 0 to 100).\nThis parameter defines a lower limit for each category of bouncing users.For example, level 1 begins from 45 to level_2_treshold.",
                 'gettext_unit' => 'points',
@@ -916,7 +917,7 @@ our %pinfo = (
                 'order'      => 2,
                 'gettext_id' => "action for this population",
                 'gettext_comment' =>
-                   'This parameter defines which task is automaticaly applied on level 1 bouncers.',
+                    'This parameter defines which task is automaticaly applied on level 1 bouncers.',
                 'format' => ['remove_bouncers', 'notify_bouncers', 'none'],
                 'occurrence' => '1',
                 'default'    => 'notify_bouncers'
@@ -934,14 +935,14 @@ our %pinfo = (
     },
 
     'bouncers_level2' => {
-        order        => 50.03,
-        'group'      => 'bounces',
-        'gettext_id' => "Management of bouncers, 2nd level",
+        order             => 50.03,
+        'group'           => 'bounces',
+        'gettext_id'      => "Management of bouncers, 2nd level",
         'gettext_comment' => 'Level 2 is the highest level of bouncing users',
-        'format'     => {
+        'format'          => {
             'rate' => {
-                'order'        => 1,
-                'gettext_id'   => "threshold",
+                'order'      => 1,
+                'gettext_id' => "threshold",
                 'gettext_comment' =>
                     "Each bouncing user have a score (from 0 to 100).\nThis parameter defines the score range defining each category of bouncing users.For example, level 2 is for users with a score between 80 and 100.",
                 'gettext_unit' => 'points',
@@ -954,7 +955,7 @@ our %pinfo = (
                 'gettext_id' => "action for this population",
                 'gettext_comment' =>
                     'This parameter defines which task is automaticaly applied on level 2 bouncers.',
-                'format'  => ['remove_bouncers', 'notify_bouncers', 'none'],
+                'format' => ['remove_bouncers', 'notify_bouncers', 'none'],
                 'occurrence' => '1',
                 'default'    => 'remove_bouncers'
             },
@@ -989,7 +990,7 @@ our %pinfo = (
                 'order' => 1,
                 'gettext_id' =>
                     "tracking message by delivery status notification",
-                'format' => ['on', 'off'],
+                'format'     => ['on', 'off'],
                 'occurrence' => '1',
                 'default' =>
                     {'conf' => 'tracking_delivery_status_notification'}
@@ -998,7 +999,7 @@ our %pinfo = (
                 'order' => 2,
                 'gettext_id' =>
                     "tracking message by message disposition notification",
-                'format' => ['on', 'on_demand', 'off'],
+                'format'     => ['on', 'on_demand', 'off'],
                 'occurrence' => '1',
                 'default' =>
                     {'conf' => 'tracking_message_disposition_notification'}
@@ -1026,8 +1027,8 @@ our %pinfo = (
         'gettext_id' => "Welcome return-path",
         'gettext_comment' =>
             'If set to unique, the welcome message is sent using a unique return path in order to remove the subscriber immediately in the case of a bounce.',
-        'format'     => ['unique', 'owner'],
-        'default'    => {'conf' => 'welcome_return_path'}
+        'format'  => ['unique', 'owner'],
+        'default' => {'conf' => 'welcome_return_path'}
     },
 
     'remind_return_path' => {
@@ -1036,8 +1037,8 @@ our %pinfo = (
         'gettext_id' => "Return-path of the REMIND command",
         'gettext_comment' =>
             'Same as welcome_return_path, but applied to remind messages.',
-        'format'     => ['unique', 'owner'],
-        'default'    => {'conf' => 'remind_return_path'}
+        'format'  => ['unique', 'owner'],
+        'default' => {'conf' => 'remind_return_path'}
     },
 
     ### Datasources page ###
@@ -1122,7 +1123,7 @@ our %pinfo = (
         'gettext_id' => "List inclusion",
         format_s     => '$listname(\@$host)?(\s+filter\s+.+)?',
         'occurrence' => '0-n',
-        'obsolete'   => 1,       # 2.2.6 - 6.2.15.
+        'obsolete' => 1,    # 2.2.6 - 6.2.15.
     },
 
     'include_sympa_list' => {
@@ -1131,7 +1132,7 @@ our %pinfo = (
         'gettext_id' => "List inclusion",
         'gettext_comment' =>
             'Include subscribers from other list. All subscribers of list listname become subscribers of the current list. You may include as many lists as required, using one include_sympa_list paragraph for each included list. Any list at all may be included; you may therefore include lists which are also defined by the inclusion of other lists. Be careful, however, not to include list A in list B and then list B in list A, since this will give rise to an infinite loop.',
-        'format'     => {
+        'format' => {
             'name' => {
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
@@ -1159,7 +1160,7 @@ our %pinfo = (
         'gettext_id' => "remote list inclusion",
         'gettext_comment' =>
             "Sympa can contact another Sympa service using HTTPS to fetch a remote list in order to include each member of a remote list as subscriber. You may include as many lists as required, using one include_remote_sympa_list paragraph for each included list. Be careful, however, not to give rise to an infinite loop resulting from cross includes.\nFor this operation, one Sympa site acts as a server while the other one acs as client. On the server side, the only setting needed is to give permission to the remote Sympa to review the list. This is controlled by the review scenario.",
-        'format'     => {
+        'format' => {
             'name' => {
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
@@ -1224,7 +1225,7 @@ our %pinfo = (
         'gettext_id' => "LDAP query inclusion",
         'gettext_comment' =>
             'This paragraph defines parameters for a query returning a list of subscribers. This feature requires the Net::LDAP (perlldap) PERL module.',
-        'format'     => {
+        'format' => {
             'name' => {
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
@@ -1263,9 +1264,9 @@ our %pinfo = (
                 'order'      => 2.6,
                 'gettext_id' => 'SSL version',
                 'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
-                'synonym' => {'tls' => 'tlsv1'},
+                'synonym'    => {'tls' => 'tlsv1'},
                 'occurrence' => '1',
-                'default' => 'tlsv1'
+                'default'    => 'tlsv1'
             },
             'ssl_ciphers' => {
                 'order'      => 2.7,
@@ -1350,7 +1351,7 @@ our %pinfo = (
         'gettext_id' => "LDAP 2-level query inclusion",
         'gettext_comment' =>
             'This paragraph defines parameters for a two-level query returning a list of subscribers. Usually the first-level query returns a list of DNs and the second-level queries convert the DNs into e-mail addresses. This feature requires the Net::LDAP (perlldap) PERL module.',
-        'format'     => {
+        'format' => {
             'name' => {
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
@@ -1389,9 +1390,9 @@ our %pinfo = (
                 'order'      => 2.6,
                 'gettext_id' => 'SSL version',
                 'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
-                'synonym' => {'tls' => 'tlsv1'},
+                'synonym'    => {'tls' => 'tlsv1'},
                 'occurrence' => '1',
-                'default' => 'tlsv1'
+                'default'    => 'tlsv1'
             },
             'ssl_ciphers' => {
                 'order'      => 2.7,
@@ -1529,7 +1530,7 @@ our %pinfo = (
         'gettext_id' => "SQL query inclusion",
         'gettext_comment' =>
             'This parameter is used to define the SQL query parameters. ',
-        'format'     => {
+        'format' => {
             'name' => {
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
@@ -1640,9 +1641,9 @@ our %pinfo = (
     },
 
     'ttl' => {
-        order          => 60.12,
-        'group'        => 'data_source',
-        'gettext_id'   => "Inclusions timeout",
+        order        => 60.12,
+        'group'      => 'data_source',
+        'gettext_id' => "Inclusions timeout",
         'gettext_comment' =>
             'Sympa caches user data extracted using the include parameter. Their TTL (time-to-live) within Sympa can be controlled using this parameter. The default value is 3600',
         'gettext_unit' => 'seconds',
@@ -1652,9 +1653,9 @@ our %pinfo = (
     },
 
     'distribution_ttl' => {
-        order          => 60.13,
-        'group'        => 'data_source',
-        'gettext_id'   => "Inclusions timeout for message distribution",
+        order        => 60.13,
+        'group'      => 'data_source',
+        'gettext_id' => "Inclusions timeout for message distribution",
         'gettext_comment' =>
             "This parameter defines the delay since the last synchronization after which the user's list will be updated before performing either of following actions:\n* Reviewing list members\n* Message distribution",
         'gettext_unit' => 'seconds',
@@ -1705,9 +1706,9 @@ our %pinfo = (
                 'order'      => 2.6,
                 'gettext_id' => 'SSL version',
                 'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
-                'synonym' => {'tls' => 'tlsv1'},
+                'synonym'    => {'tls' => 'tlsv1'},
                 'occurrence' => '1',
-                'default' => 'tlsv1'
+                'default'    => 'tlsv1'
             },
             'ssl_ciphers' => {
                 'order'      => 2.7,
@@ -1835,9 +1836,9 @@ our %pinfo = (
                 'order'      => 2.6,
                 'gettext_id' => 'SSL version',
                 'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
-                'synonym' => {'tls' => 'tlsv1'},
+                'synonym'    => {'tls' => 'tlsv1'},
                 'occurrence' => '1',
-                'default' => 'tlsv1'
+                'default'    => 'tlsv1'
             },
             'ssl_ciphers' => {
                 'order'      => 2.7,
@@ -2072,7 +2073,7 @@ our %pinfo = (
             "Enable/Disable DKIM. This feature requires Mail::DKIM to be installed, and maybe some custom scenario to be updated",
         'format'     => ['on', 'off'],
         'occurrence' => '1',
-        'default' => {'conf' => 'dkim_feature'}
+        'default'    => {'conf' => 'dkim_feature'}
     },
 
     'dkim_parameters' => {
@@ -2101,7 +2102,7 @@ our %pinfo = (
                 'default'    => {'conf' => 'dkim_selector'}
             },
             'header_list' => {
-                'obsolete' => 1,        # Not yet implemented
+                'obsolete' => 1,    # Not yet implemented
                 'order'    => 4,
                 'gettext_id' =>
                     'List of headers to be included into the message for signature',
@@ -2109,7 +2110,7 @@ our %pinfo = (
                     'You should probably use the default value which is the value recommended by RFC4871',
                 'format'     => '\S+',
                 'occurrence' => '1-n',
-                'split_char' => ':',    #FIXME
+                'split_char' => ':',     #FIXME
                 #'default'    => {'conf' => 'dkim_header_list'},
             },
             'signer_domain' => {
@@ -2178,11 +2179,12 @@ our %pinfo = (
                 'order' => 1
             },
             'domain_regex' => {
-                'format'          => '.+',
-                'gettext_id'      => "Match domain regular expression",
-                'occurrence'      => '0-1',
-                'gettext_comment' => 'Regular expression match pattern for From domain',
-                'order'           => 2,
+                'format'     => '.+',
+                'gettext_id' => "Match domain regular expression",
+                'occurrence' => '0-1',
+                'gettext_comment' =>
+                    'Regular expression match pattern for From domain',
+                'order'   => 2,
                 'default' => {'conf' => 'dmarc_protection_domain_regex'},
             },
             'other_email' => {
@@ -2202,7 +2204,7 @@ our %pinfo = (
                 ],
                 'synonym' =>
                     {'name' => 'display_name', 'prefixed' => 'list_for_name'},
-                'default' => {'conf' => 'dmarc_protection_phrase'},
+                'default'    => {'conf' => 'dmarc_protection_phrase'},
                 'gettext_id' => "New From name format",
                 'occurrence' => '0-1',
                 'gettext_comment' =>
@@ -2276,7 +2278,7 @@ our %pinfo = (
         'gettext_id' => "Periodical subscription expiration task",
         'gettext_comment' =>
             "This parameter states which model is used to create an expire task. An expire task regularly checks the subscription or resubscription  date of subscribers and asks them to renew their subscription. If they don't they are deleted.",
-        'task'       => 'expire'
+        'task' => 'expire'
     },
 
     'latest_instantiation' => {
@@ -2325,7 +2327,7 @@ our %pinfo = (
             "Allow picture display? (must be enabled for the current robot)",
         'format'     => ['on', 'off'],
         'occurrence' => '1',
-        'default' => {'conf' => 'pictures_feature'}
+        'default'    => {'conf' => 'pictures_feature'}
     },
 
     'remind_task' => {
@@ -2334,8 +2336,8 @@ our %pinfo = (
         'gettext_id' => 'Periodical subscription reminder task',
         'gettext_comment' =>
             'This parameter states which model is used to create a remind task. A remind task regularly sends  subscribers a message which reminds them of their list subscriptions.',
-        'task'       => 'remind',
-        'default'    => {'conf' => 'default_remind_task'}
+        'task'    => 'remind',
+        'default' => {'conf' => 'default_remind_task'}
     },
 
     'spam_protection' => {
@@ -2417,8 +2419,8 @@ our %pinfo = (
         'format' =>
             ['open', 'closed', 'pending', 'error_config', 'family_closed'],
         'field_type' => 'status',
-        'default'  => 'open',
-        'internal' => 1
+        'default'    => 'open',
+        'internal'   => 1
     },
 
     'serial' => {

--- a/src/lib/Sympa/ListOpt.pm
+++ b/src/lib/Sympa/ListOpt.pm
@@ -294,7 +294,8 @@ sub get_option_description {
         if ($type eq 'listtopic') {
             $title = Sympa::Robot::topic_get_title($robot_id, $option);
         } else {
-            $title = [Sympa::Robot::topic_get_title($robot_id, $option)]->[-1];
+            $title =
+                [Sympa::Robot::topic_get_title($robot_id, $option)]->[-1];
         }
     } elsif ($type eq 'password') {
         return '*' x length($option);    # return
@@ -306,7 +307,7 @@ sub get_option_description {
             'reception'  => \%reception_mode,
             'visibility' => \%visibility_mode,
             'status'     => \%list_status,
-            }->{$type}
+        }->{$type}
             || \%list_option;
         my $t = $map->{$option} || {};
         if ($t->{gettext_id}) {

--- a/src/lib/Sympa/Log.pm
+++ b/src/lib/Sympa/Log.pm
@@ -189,7 +189,7 @@ sub syslog {
             and ($self->{log_to_stderr} eq 'all'
                 or 0 <= index($self->{log_to_stderr}, $level))
         )
-        ) {
+    ) {
         print STDERR "$message\n";
     }
     return unless defined $self->{level};
@@ -330,7 +330,7 @@ sub db_log {
             $target_email, $msg_id, $status, $error_type,
             $user_email,   $client, $daemon
         )
-        ) {
+    ) {
         $self->syslog('err',
             'Unable to insert new db_log entry in the database');
         return undef;
@@ -384,7 +384,7 @@ sub add_stat {
             $daemon, $ip,   $robot,     $parameter,
             $read
         )
-        ) {
+    ) {
         $self->syslog('err',
             'Unable to insert new stat entry in the database');
         return undef;
@@ -557,11 +557,11 @@ sub get_first_db_log {
         and grep { $sortby eq $_ }
         qw(date robot list action parameters target_email msg_id
         status error_type user_email client daemon)
-        ) {
+    ) {
         $sortby = 'date';
     }
     $statement .= sprintf 'ORDER BY %s ',
-	($sortby eq 'date' ? 'date_logs, usec_logs' : $sortby . '_logs');
+        ($sortby eq 'date' ? 'date_logs, usec_logs' : $sortby . '_logs');
 
     my $sth;
     unless ($sth = $sdm->do_query($statement)) {
@@ -630,7 +630,7 @@ sub aggregate_stat {
               WHERE read_stat = 0
               ORDER BY date_stat ASC}
         )
-        ) {
+    ) {
         $self->syslog('err', 'Unable to retrieve oldest non processed stat');
         return undef;
     }
@@ -733,7 +733,7 @@ sub _aggregate_data {
               GROUP BY robot_stat, list_stat, email_stat},
             $begin_date, $end_date
         )
-        ) {
+    ) {
         while ($row = $sth->fetchrow_hashref('NAME_lc')) {
             $sdm->do_prepared_query(
                 q{UPDATE subscriber_table
@@ -757,7 +757,7 @@ sub _aggregate_data {
               WHERE ? <= date_stat AND date_stat < ?},
             $begin_date, $end_date
         )
-        ) {
+    ) {
         $self->syslog('err',
             'Unable to set stat entries between date % and date %s as read',
             $begin_date, $end_date);
@@ -800,7 +800,7 @@ sub aggregate_daily_data {
             $operation,
             $list->{'domain'}, $list->{'name'}
         )
-        ) {
+    ) {
         $self->syslog('err', 'Unable to get stat data %s for list %s',
             $operation, $list);
         return;

--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -835,7 +835,7 @@ sub smime_decrypt {
             $self->{_head}->mime_attr('Content-Type.smime-type'),
             qr/signed-data/i
         )
-        ) {
+    ) {
         return 0;
     }
 
@@ -914,7 +914,7 @@ sub smime_decrypt {
             $head->mime_attr('Content-Type'),
             qr/multipart/i
         )
-        ) {
+    ) {
         $head->delete('Content-Transfer-Encoding')
             if $self->get_header('Content-Transfer-Encoding');
     }
@@ -1123,7 +1123,7 @@ sub check_smime_signature {
                 qr/signed-data/i
             )
         )
-        ) {
+    ) {
         return 0;
     }
 
@@ -1136,7 +1136,7 @@ sub check_smime_signature {
     my $smime = Crypt::SMIME->new;
     eval {    # Crypt::SMIME >= 0.15 is required.
         $smime->setPublicKeyStore(grep { defined $_ and length $_ }
-            ($Conf::Conf{'cafile'}, $Conf::Conf{'capath'}));
+                ($Conf::Conf{'cafile'}, $Conf::Conf{'capath'}));
     };
     unless (eval { $smime->check($self->as_string) }) {
         $log->syslog('err', '%s: Unable to verify S/MIME signature: %s',
@@ -1228,7 +1228,7 @@ sub personalize {
     my $headers = $entity->head;
     foreach my $key (
         qw/subject x-originating-ip message-id date x-original-to from to thread-topic content-type/
-        ) {
+    ) {
         next unless $headers->count($key);
         my $value = $headers->get($key, 0);
         chomp $value;
@@ -1327,7 +1327,7 @@ sub _merge_msg {
                 $message_output =
                     personalize_text($utf8_body, $list, $rcpt, $data)
             )
-            ) {
+        ) {
             $log->syslog('err', 'Error merging message');
             return undef;
         }
@@ -1424,7 +1424,7 @@ sub prepare_message_according_to_mode {
 
     my $robot_id = $list->{'domain'};
 
-    if ($mode eq 'nomail'
+    if (   $mode eq 'nomail'
         or $mode eq 'summary'
         or $mode eq 'digest'
         or $mode eq 'digestplain') {
@@ -1463,7 +1463,7 @@ sub prepare_message_according_to_mode {
         ## Add a footer
         _decorate_parts($entity, $list);
         $self->set_entity($entity);
-    } else { # 'mail'
+    } else {    # 'mail'
         # Prepare message for normal reception mode,
         # and add a footer.
         unless ($self->{'protected'}) {
@@ -1506,7 +1506,7 @@ sub _decorate_parts {
         "$listdir/message.header.mime",
         $Conf::Conf{'etc'} . '/mail_tt2/message.header',
         $Conf::Conf{'etc'} . '/mail_tt2/message.header.mime'
-        ) {
+    ) {
         if (-f $file) {
             unless (-r $file) {
                 $log->syslog('notice', 'Cannot read %s', $file);
@@ -1523,7 +1523,7 @@ sub _decorate_parts {
         "$listdir/message.footer.mime",
         $Conf::Conf{'etc'} . '/mail_tt2/message.footer',
         $Conf::Conf{'etc'} . '/mail_tt2/message.footer.mime'
-        ) {
+    ) {
         if (-f $file) {
             unless (-r $file) {
                 $log->syslog('notice', 'Cannot read %s', $file);
@@ -2213,7 +2213,7 @@ sub _as_singlepart {
                     and $part->parts
                     and lc($part->parts(0)->effective_type || 'text/plain')
                     eq $preferred_type)
-                ) {
+            ) {
                 ## Only keep the first matching part
                 $entity->parts([$part]);
                 $entity->make_singlepart();
@@ -2372,7 +2372,7 @@ sub check_virus_infection {
             open $pipein, '-|', $antivirus_path,
             '--databasedirectory' => $dbdir,
             @antivirus_args, $work_dir
-            ) {
+        ) {
             $log->syslog('err', 'Cannot open pipe: %m');
             return undef;
         }
@@ -2907,7 +2907,7 @@ sub dmarc_protect {
     if (Sympa::Tools::Data::is_in_array(
             $list->{'admin'}{'dmarc_protection'}{'mode'}, 'all'
         )
-        ) {
+    ) {
         $log->syslog('debug', 'Munging From for ALL messages');
         $mungeFrom = 1;
     }
@@ -2917,7 +2917,7 @@ sub dmarc_protect {
             $list->{'admin'}{'dmarc_protection'}{'mode'},
             'dkim_signature'
         )
-        ) {
+    ) {
         $log->syslog('debug', 'Munging From for DKIM-signed messages');
         $mungeFrom = 1;
     }
@@ -2928,7 +2928,7 @@ sub dmarc_protect {
             $list->{'admin'}{'dmarc_protection'}{'mode'},
             'domain_regex'
         )
-        ) {
+    ) {
         $log->syslog('debug',
             'Munging From for messages based on domain regexp');
         $mungeFrom = 1 if ($origFrom =~ /$dkimdomain$/);
@@ -2946,7 +2946,7 @@ sub dmarc_protect {
                 'dmarc_quarantine'
             )
         )
-        ) {
+    ) {
         $log->syslog('debug', 'Munging From for messages with strict policy');
         # Strict auto policy - is the sender domain policy to reject
         my $dom = $origFrom;
@@ -2963,7 +2963,7 @@ sub dmarc_protect {
                         $list->{'admin'}{'dmarc_protection'}{'mode'},
                         'dmarc_reject'
                     )
-                    ) {
+                ) {
                     $log->syslog('debug', 'Will block if DMARC rejects');
                     if ($rr->string =~ /p=reject/) {
                         $log->syslog('debug', 'DMARC reject policy found');
@@ -2975,7 +2975,7 @@ sub dmarc_protect {
                         $list->{'admin'}{'dmarc_protection'}{'mode'},
                         'dmarc_quarantine'
                     )
-                    ) {
+                ) {
                     $log->syslog('debug', 'Will block if DMARC quarantine');
                     if ($rr->string =~ /p=quarantine/) {
                         $log->syslog('debug',
@@ -2988,7 +2988,7 @@ sub dmarc_protect {
                         $list->{'admin'}{'dmarc_protection'}{'mode'},
                         'dmarc_any'
                     )
-                    ) {
+                ) {
                     $log->syslog('debug',
                         'Will munge whatever DMARC policy is');
                     $mungeFrom = 1;

--- a/src/lib/Sympa/Message/Template.pm
+++ b/src/lib/Sympa/Message/Template.pm
@@ -69,7 +69,7 @@ sub new {
         $domain   = $that->{'domain'};
     } elsif ($that and $that ne '*') {
         $robot_id = $that;
-        $domain   = Conf::get_robot_conf($that, 'domain');
+        $domain = Conf::get_robot_conf($that, 'domain');
     } else {
         $robot_id = '*';
         $domain   = $Conf::Conf{'domain'};
@@ -139,9 +139,9 @@ sub new {
     }
 
     foreach my $p (
-        'email',       'gecos', 'listmaster',
-        'wwsympa_url', 'title', 'listmaster_email'
-        ) {
+        'email', 'gecos', 'listmaster', 'wwsympa_url',
+        'title', 'listmaster_email'
+    ) {
         $data->{'conf'}{$p} = Conf::get_robot_conf($robot_id, $p);
     }
     $data->{'domain'} = $domain;
@@ -305,7 +305,7 @@ sub _new_from_template {
         foreach my $header (
             qw(message-id date to from subject reply-to
             mime-version content-type content-transfer-encoding)
-            ) {
+        ) {
             if ($line =~ /^$header\s*:/i) {
                 $header_ok{$header} = 1;
                 last;

--- a/src/lib/Sympa/Process.pm
+++ b/src/lib/Sympa/Process.pm
@@ -305,7 +305,7 @@ sub write_pid {
             user  => Sympa::Constants::USER,
             group => Sympa::Constants::GROUP,
         )
-        ) {
+    ) {
         die sprintf 'Unable to set rights on %s. Exiting.', $piddir;
         ## No return
     }
@@ -362,7 +362,7 @@ sub write_pid {
             user  => Sympa::Constants::USER,
             group => Sympa::Constants::GROUP,
         )
-        ) {
+    ) {
         ## Unlock pid file
         $lock_fh->close();
         die sprintf 'Unable to set rights on %s', $pidfile;
@@ -386,7 +386,7 @@ sub direct_stderr_to_file {
             user  => Sympa::Constants::USER,
             group => Sympa::Constants::GROUP,
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to set rights on %s: %m',

--- a/src/lib/Sympa/Regexps.pm
+++ b/src/lib/Sympa/Regexps.pm
@@ -52,9 +52,9 @@ use constant multiple_host_with_port =>
 #FIXME: Cannot contain IPv6 address.
 use constant multiple_host_or_url =>
     qr'([-\w]+://.+|[-.\w]+(:\d+)?)(,([-\w]+://.+|[-.\w]+(:\d+)?))*';
-use constant listname    => qr'[a-z0-9][a-z0-9\-\.\+_]*';
+use constant listname => qr'[a-z0-9][a-z0-9\-\.\+_]*';
 
-use constant ldap_attrdesc => qr'\w[-\w]*(?:;[-\w]+)*'; # RFC2251, 4.1.5
+use constant ldap_attrdesc => qr'\w[-\w]*(?:;[-\w]+)*';    # RFC2251, 4.1.5
 use constant sql_query     => qr'(SELECT|select).*';
 
 use constant scenario    => qr'[\w,\.\-]+';

--- a/src/lib/Sympa/Request.pm
+++ b/src/lib/Sympa/Request.pm
@@ -224,17 +224,17 @@ sub get_id {
         my $val = $self->{$_};
         if (Scalar::Util::blessed($val) and $val->can('get_id')) {
             sprintf '%s=%s', $_, $val->get_id;
-        } elsif (ref $val eq 'HASH' and $_ eq 'request') {  #FIXME
+        } elsif (ref $val eq 'HASH' and $_ eq 'request') {    # FIXME
             sprintf '%s=<%s>', $_, get_id($val);
         } elsif (ref $val) {
             sprintf '%s=%s', $_, ref $val;
         } else {
             sprintf '%s=%s', $_, $val;
         }
-        } grep {
+    } grep {
         defined $self->{$_}
         } qw(action context current_list listname arc mode email
-             reception visibility request error);
+        reception visibility request error);
 }
 
 1;

--- a/src/lib/Sympa/Request/Collection.pm
+++ b/src/lib/Sympa/Request/Collection.pm
@@ -63,9 +63,9 @@ sub _load {
     my %options = map {
         my $val = $self->{$_};
         ($_ => (ref $val eq 'ARRAY' ? [@$val] : $val))
-        } grep {
+    } grep {
         !/\A_/ and !/\A(?:finish|scenario_context|stash|success)\z/
-        } keys %$self;
+    } keys %$self;
 
     unless (grep { ref $_ eq 'ARRAY' } values %options) {
         return [\%options];

--- a/src/lib/Sympa/Request/Handler/add.pm
+++ b/src/lib/Sympa/Request/Handler/add.pm
@@ -82,10 +82,11 @@ sub _twist {
     unless ($request->{force}) {
         # If a list is not 'open' and allow_subscribe_if_pending has been set
         # to 'off' returns undef.
-        unless ($list->{'admin'}{'status'} eq 'open'
+        unless (
+            $list->{'admin'}{'status'} eq 'open'
             or Conf::get_robot_conf($list->{'domain'},
                 'allow_subscribe_if_pending') eq 'on'
-            ) {
+        ) {
             $self->add_stash($request, 'user', 'list_not_open',
                 {'status' => $list->{'admin'}{'status'}});
             $log->syslog('info', 'List %s not open', $list);

--- a/src/lib/Sympa/Request/Handler/auth.pm
+++ b/src/lib/Sympa/Request/Handler/auth.pm
@@ -53,7 +53,8 @@ sub _twist {
     my $req     = $request->{request};
     my $spindle = Sympa::Spindle::ProcessAuth->new(
         (   map { ($req and $req->{$_}) ? ($_ => $req->{$_}) : () }
-            qw(context action email)),
+                qw(context action email)
+        ),
         keyauth      => $key,
         confirmed_by => $sender,
 

--- a/src/lib/Sympa/Request/Handler/close_list.pm
+++ b/src/lib/Sympa/Request/Handler/close_list.pm
@@ -165,7 +165,7 @@ sub _close {
         my $user = $list->get_first_list_member();
         $user;
         $user = $list->get_next_list_member()
-        ) {
+    ) {
         push @users, $user->{'email'};
     }
     $list->delete_list_member('users' => \@users);
@@ -183,7 +183,7 @@ sub _close {
         $list->save_config(
             $sender || Sympa::get_address($list, 'listmaster')
         )
-        ) {
+    ) {
         $self->add_stash($request, 'intern', 'cannot_save_config',
             {'listname' => $list->{'name'}});
         $log->syslog('info', 'Cannot save config file');
@@ -221,7 +221,7 @@ sub _purge {
                   WHERE name_list = ? AND robot_list = ?},
             $list->{'name'}, $list->{'domain'}
         )
-        ) {
+    ) {
         $log->syslog('err', 'Cannot remove list %s from table', $list);
     }
     unless (
@@ -231,7 +231,7 @@ sub _purge {
               WHERE target_inclusion = ?},
             $list->get_id
         )
-        ) {
+    ) {
         $log->syslog('err', 'Cannot remove list %s from table', $list);
     }
 

--- a/src/lib/Sympa/Request/Handler/create_automatic_list.pm
+++ b/src/lib/Sympa/Request/Handler/create_automatic_list.pm
@@ -181,8 +181,8 @@ sub _twist {
     # Write config.
     # - Write out initial permanent owners/editors in <role>.dump files.
     # - Write reminder to config file.
-    $config =~ s/(\A|\n)[\t ]+(?=\n)/$1/g;      # normalize empty lines
-    open my $ifh, '<', \$config;                # open "in memory" file
+    $config =~ s/(\A|\n)[\t ]+(?=\n)/$1/g;    # normalize empty lines
+    open my $ifh, '<', \$config;              # open "in memory" file
     my @config = do { local $RS = ''; <$ifh> };
     close $ifh;
     foreach my $role (qw(owner editor)) {

--- a/src/lib/Sympa/Request/Handler/create_list.pm
+++ b/src/lib/Sympa/Request/Handler/create_list.pm
@@ -214,8 +214,8 @@ sub _twist {
     # Write config.
     # - Write out initial permanent owners/editors in <role>.dump files.
     # - Write reminder to config file.
-    $config =~ s/(\A|\n)[\t ]+(?=\n)/$1/g;      # normalize empty lines
-    open my $ifh, '<', \$config;                # open "in memory" file
+    $config =~ s/(\A|\n)[\t ]+(?=\n)/$1/g;    # normalize empty lines
+    open my $ifh, '<', \$config;              # open "in memory" file
     my @config = do { local $RS = ''; <$ifh> };
     close $ifh;
     foreach my $role (qw(owner editor)) {

--- a/src/lib/Sympa/Request/Handler/decl.pm
+++ b/src/lib/Sympa/Request/Handler/decl.pm
@@ -49,7 +49,8 @@ sub _twist {
     my $req     = $request->{request};
     my $spindle = Sympa::Spindle::ProcessAuth->new(
         (   map { ($req and $req->{$_}) ? ($_ => $req->{$_}) : () }
-            qw(context action email)),
+                qw(context action email)
+        ),
         keyauth     => $key,
         canceled_by => $sender,
 

--- a/src/lib/Sympa/Request/Handler/del.pm
+++ b/src/lib/Sympa/Request/Handler/del.pm
@@ -77,7 +77,7 @@ sub _twist {
             $list->{'admin'}{'status'} eq 'open'
             or Conf::get_robot_conf($list->{'domain'},
                 'allow_subscribe_if_pending') eq 'on'
-            ) {
+        ) {
             $self->add_stash($request, 'user', 'list_not_open',
                 {'status' => $list->{'admin'}{'status'}});
             $log->syslog('info', 'List %s not open', $list);
@@ -92,7 +92,7 @@ sub _twist {
             'exclude'   => ' 1',
             'operation' => 'del'
         )
-        ) {
+    ) {
         my $error =
             "Unable to delete user $who from list $which for command 'del'";
         Sympa::send_notify_to_listmaster(

--- a/src/lib/Sympa/Request/Handler/import.pm
+++ b/src/lib/Sympa/Request/Handler/import.pm
@@ -51,7 +51,7 @@ sub _twist {
             $list->{'admin'}{'status'} eq 'open'
             or Conf::get_robot_conf($list->{'domain'},
                 'allow_subscribe_if_pending') eq 'on'
-            ) {
+        ) {
             $self->add_stash($request, 'user', 'list_not_open',
                 {'status' => $list->{'admin'}{'status'}});
             $log->syslog('info', 'List %s not open', $list);
@@ -65,10 +65,9 @@ sub _twist {
         (defined $gecos and $gecos =~ /\S/)
             ? {email => $email, gecos => $gecos}
             : {email => $email}
-        } grep {
+    } grep {
         /\S/ and !/\A\s*#/
-        }
-        split /\r\n|\r|\n/, ($request->{dump} || '');
+    } split /\r\n|\r|\n/, ($request->{dump} || '');
 
     my $processed = 0;
     foreach my $user (@users) {

--- a/src/lib/Sympa/Request/Handler/index.pm
+++ b/src/lib/Sympa/Request/Handler/index.pm
@@ -86,7 +86,7 @@ sub _twist {
             $list, 'index_archive', $sender,
             {'archives' => \@arcs, 'auto_submitted' => 'auto-replied'}
         )
-        ) {
+    ) {
         $log->syslog('notice',
             'Unable to send template "index_archive" to %s', $sender);
         $self->add_stash($request, 'intern');

--- a/src/lib/Sympa/Request/Handler/invite.pm
+++ b/src/lib/Sympa/Request/Handler/invite.pm
@@ -130,7 +130,7 @@ sub _twist {
                     subject => sprintf('AUTH %s %s', $keyauth, $cmd_line),
                 }
             )
-            ) {
+        ) {
             $log->syslog('notice', 'Unable to send template "invite" to %s',
                 $email);
             my $error = sprintf 'Unable to send template "invite" to %s',

--- a/src/lib/Sympa/Request/Handler/modindex.pm
+++ b/src/lib/Sympa/Request/Handler/modindex.pm
@@ -95,7 +95,7 @@ sub _twist {
                 'boundary2' => "==digest $now[6].$now[5].$now[4].$now[3]=="
             }
         )
-        ) {
+    ) {
         $log->syslog('notice', 'Unable to send template "modindex" to %s',
             $sender);
         $self->add_stash($request, 'intern');

--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -278,7 +278,7 @@ sub _move {
             sprintf('%s@%s', $listname, $robot_id),
             $current_list->get_id
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to rename list %s to %s@%s in the database',
             $current_list, $listname, $robot_id);
@@ -304,7 +304,7 @@ sub _move {
             $listname,               $robot_id,
             $current_list->{'name'}, $current_list->{'domain'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to transfer stats from list %s to list %s@%s',
             $current_list, $listname, $robot_id);
@@ -316,7 +316,7 @@ sub _move {
         qw(Sympa::Spool::Automatic Sympa::Spool::Bounce Sympa::Spool::Incoming
         Sympa::Spool::Auth Sympa::Spool::Held Sympa::Spool::Moderation
         Sympa::Spool::Archive Sympa::Spool::Digest::Collection)
-        ) {
+    ) {
         my $spool = $spool_class->new(context => $current_list);
         next unless $spool;
 
@@ -325,8 +325,8 @@ sub _move {
             last unless $handle;
             next
                 unless $message
-                    and ref $message->{context} eq 'Sympa::List'
-                    and $message->{context}->get_id eq $current_list->get_id;
+                and ref $message->{context} eq 'Sympa::List'
+                and $message->{context}->get_id eq $current_list->get_id;
 
             # Remove old HTML view if any (For moderation spool).
             $spool->html_remove($message) if $spool->can('html_remove');
@@ -359,7 +359,7 @@ sub _move {
         foreach my $file (sort readdir $dh) {
             next
                 unless $file =~
-                    /^(\d+)\.(\w*)\.(\w+)\.([^\s\@]+)(?:\@([\w\.\-]+))?$/;
+                /^(\d+)\.(\w*)\.(\w+)\.([^\s\@]+)(?:\@([\w\.\-]+))?$/;
             my ($date, $label, $model, $listname, $domain) =
                 ($1, $2, $3, $4, $5);
             $domain ||= $Conf::Conf{'domain'};
@@ -410,8 +410,8 @@ sub _move {
         last unless $handle;
         next
             unless $message
-                and ref $message->{context} eq 'Sympa::List'
-                and $message->{context}->get_id eq $current_list->get_id;
+            and ref $message->{context} eq 'Sympa::List'
+            and $message->{context}->get_id eq $current_list->get_id;
 
         my $pct_directory =
             $spool->{pct_directory} . '/' . $handle->basename(1);
@@ -477,7 +477,7 @@ sub _move {
             $listname,               $robot_id,
             $current_list->{'name'}, $current_list->{'domain'}
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to transfer tracking information from list %s to list %s@%s',
@@ -532,7 +532,7 @@ sub _copy {
                     $current_list->{'dir'} . '/' . $subdir,
                     $new_dir . '/' . $subdir
                 )
-                ) {
+            ) {
                 $log->syslog(
                     'err',
                     'Failed to copy_directory %s: %m',
@@ -550,7 +550,7 @@ sub _copy {
                 $current_list->{'dir'} . '/' . $file,
                 $new_dir . '/' . $file
             )
-            ) {
+        ) {
             $log->syslog(
                 'err',
                 'Failed to copy %s: %m',
@@ -569,7 +569,7 @@ sub _copy {
                     $current_list->{'dir'} . '/' . $file,
                     $new_dir . '/' . $file
                 )
-                ) {
+            ) {
                 $log->syslog(
                     'err',
                     'Failed to copy %s: %m',

--- a/src/lib/Sympa/Request/Handler/move_user.pm
+++ b/src/lib/Sympa/Request/Handler/move_user.pm
@@ -80,7 +80,7 @@ sub _twist {
                     or $datasource->{'type'} ne 'include_sympa_list'
                     or (    $datasource->{'def'} =~ /\@(.+)$/
                         and $1 ne $robot_id)
-                    ) {
+                ) {
                     $use_external_data_sources = 1;
                     last;
                 }
@@ -131,7 +131,7 @@ sub _twist {
                     email       => $email,
                     update_date => time
                 )
-                ) {
+            ) {
                 $self->add_stash($request, 'user',
                     'change_member_email_failed',
                     {email => $current_email, listname => $list->{'name'}});
@@ -221,7 +221,7 @@ sub _twist {
         Sympa::Robot::update_email_netidmap_db(
             $robot_id, $current_email, $email
         )
-        ) {
+    ) {
         $self->add_stash($request, 'intern');
         $log->syslog('err', 'Update failed');
         return undef;

--- a/src/lib/Sympa/Request/Handler/review.pm
+++ b/src/lib/Sympa/Request/Handler/review.pm
@@ -91,7 +91,7 @@ sub _twist {
                 'auto_submitted' => 'auto-replied'
             }
         )
-        ) {
+    ) {
         $log->syslog('notice', 'Unable to send template "review" to %s',
             $sender);
         $self->add_stash($request, 'intern');

--- a/src/lib/Sympa/Request/Handler/set.pm
+++ b/src/lib/Sympa/Request/Handler/set.pm
@@ -83,7 +83,7 @@ sub _twist {
         $self->add_stash(
             $request, 'user',
             'not_available_reception_mode',
-            {   modes => join(' ', $list->available_reception_mode),
+            {   modes           => join(' ', $list->available_reception_mode),
                 reception_modes => [$list->available_reception_mode],
                 reception_mode  => $reception,
             }
@@ -101,7 +101,7 @@ sub _twist {
                 ($visibility ? (visibility => $visibility) : ()),
                 update_date => time
             )
-            ) {
+        ) {
             my $error =
                 sprintf
                 'Failed to change subscriber "%s" options for list %s',

--- a/src/lib/Sympa/Request/Handler/signoff.pm
+++ b/src/lib/Sympa/Request/Handler/signoff.pm
@@ -101,7 +101,7 @@ sub _twist {
             'exclude'   => '1',
             'operation' => 'signoff',
         )
-        ) {
+    ) {
         my $error = sprintf 'Unable to delete user %s from list %s',
             $email, $list->get_id;
         Sympa::send_notify_to_listmaster(

--- a/src/lib/Sympa/Request/Handler/stats.pm
+++ b/src/lib/Sympa/Request/Handler/stats.pm
@@ -70,7 +70,7 @@ sub _twist {
                 'auto_submitted' => 'auto-replied'
             }
         )
-        ) {
+    ) {
         $log->syslog('notice',
             'Unable to send template "stats_reports" to %s', $sender);
         $self->add_stash($request, 'intern');

--- a/src/lib/Sympa/Request/Handler/update_automatic_list.pm
+++ b/src/lib/Sympa/Request/Handler/update_automatic_list.pm
@@ -89,8 +89,8 @@ sub _twist {
     # Write config. NOTE: Unlike list creation, files will be overwritten.
     # - Write out permanent owners/editors in <role>.dump files.
     # - Write remainder to config file.
-    $config =~ s/(\A|\n)[\t ]+(?=\n)/$1/g;      # normalize empty lines
-    open my $ifh, '<', \$config;                # open "in memory" file
+    $config =~ s/(\A|\n)[\t ]+(?=\n)/$1/g;    # normalize empty lines
+    open my $ifh, '<', \$config;              # open "in memory" file
     my @config = do { local $RS = ''; <$ifh> };
     close $ifh;
     foreach my $role (qw(owner editor)) {

--- a/src/lib/Sympa/Request/Message.pm
+++ b/src/lib/Sympa/Request/Message.pm
@@ -175,7 +175,7 @@ sub __parse {
     foreach my $action (
         sort(grep /global_/,  keys %Sympa::CommandDef::comms),
         sort(grep !/global_/, keys %Sympa::CommandDef::comms)
-        ) {
+    ) {
         my $comm       = $Sympa::CommandDef::comms{$action};
         my $cmd_regexp = $comm->{cmd_regexp};
         my $arg_regexp = $comm->{arg_regexp};

--- a/src/lib/Sympa/Robot.pm
+++ b/src/lib/Sympa/Robot.pm
@@ -85,7 +85,7 @@ sub get_netidtoemail_db {
             $netid, $idpname,
             $robot
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to get email address from netidmap_table for id %s, service %s, robot %s',
@@ -125,7 +125,7 @@ sub set_netidtoemail_db {
               VALUES (?, ?, ?, ?)},
             $netid, $idpname, $email, $robot
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to set email address %s in netidmap_table for id %s, service %s, robot %s',
@@ -161,7 +161,7 @@ sub update_email_netidmap_db {
             $new_email,
             $old_email, $robot
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to set new email address %s in netidmap_table to replace old address %s for robot %s',
@@ -214,7 +214,8 @@ sub load_topics {
         my $index = 0;
         my (@rough_data, $topic);
         while (my $line = <$fh>) {
-            Encode::from_to($line, $Conf::Conf{'filesystem_encoding'}, 'utf8');
+            Encode::from_to($line, $Conf::Conf{'filesystem_encoding'},
+                'utf8');
             if ($line =~ /\A(others|topicsless)\s*\z/i) {
                 # "others" and "topicsless" are reserved words. Ignore.
                 next;
@@ -263,8 +264,8 @@ sub load_topics {
                 $list_of_topics{$robot}{$tree[0]}{'order'} =
                     $topic->{'order'};
             } else {
-                my $subtopic = join('/', @tree[1 .. $#tree]);
-                my $title = _load_topics_get_title($topic);
+                my $subtopic   = join('/', @tree[1 .. $#tree]);
+                my $title      = _load_topics_get_title($topic);
                 my $visibility = $topic->{'visibility'} || 'default';
                 $list_of_topics{$robot}{$tree[0]}{'sub'}{$subtopic} =
                     _add_topic($subtopic, $title, $visibility);
@@ -380,7 +381,7 @@ sub topic_keys {
 
 sub topic_get_title {
     my $robot_id = shift;
-    my $topic = shift;
+    my $topic    = shift;
 
     my $tinfo = {Sympa::Robot::load_topics($robot_id)};
     return unless %$tinfo;
@@ -414,7 +415,8 @@ sub _topic_get_title {
 
     return undef unless $titem and exists $titem->{title};
 
-    foreach my $lang (Sympa::Language::implicated_langs($language->get_lang)) {
+    foreach my $lang (Sympa::Language::implicated_langs($language->get_lang))
+    {
         return $titem->{title}->{$lang}
             if $titem->{title}->{$lang};
     }
@@ -426,7 +428,6 @@ sub _topic_get_title {
         return undef;
     }
 }
-
 
 =over 4
 

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -52,7 +52,7 @@ my $log = Sympa::Log->instance;
 my %all_scenarios;
 my %persistent_cache;
 
-my $picache = {};
+my $picache         = {};
 my $picache_refresh = 10;
 
 ## Creates a new object
@@ -73,7 +73,7 @@ sub new {
         $parameters{'robot'}
         && ($parameters{'file_path'}
             || ($parameters{'function'} && $parameters{'name'}))
-        ) {
+    ) {
         $log->syslog('err', 'Missing parameter');
         return undef;
     }
@@ -237,7 +237,7 @@ sub _parse_scenario {
             push(@scenario, $rule);
         } elsif ($current_rule =~
             /^\s*(.*?)\s+((\s*(md5|pgp|smtp|smime|dkim)\s*,?)*)\s*->\s*(.*)\s*$/gi
-            ) {
+        ) {
             $rule->{'condition'} = $1;
             $rule->{'action'}    = $5;
             my $auth_methods = $2 || 'smtp';
@@ -467,8 +467,8 @@ sub request_action {
         $scenario = Sympa::Scenario->new(
             'robot'    => $robot_id,
             'function' => 'topics_visibility',
-            'name' => $visibility,
-            'options' => $context->{'options'}
+            'name'     => $visibility,
+            'options'  => $context->{'options'}
         );
 
     } else {
@@ -479,7 +479,7 @@ sub request_action {
                 @Sympa::ConfDef::params
             )
             and $p[0]->{'scenario'}
-            ) {
+        ) {
             $scenario = Sympa::Scenario->new(
                 'robot'    => $robot_id,
                 'function' => $operation,
@@ -664,7 +664,7 @@ sub request_action {
                 ## Check syntax of returned action
                 unless ($action =~
                     /^(do_it|reject|request_auth|owner|editor|editorkey|listmaster|ham|spam|unsure)/
-                    ) {
+                ) {
                     $log->syslog('err',
                         'Matched unknown action "%s" in scenario',
                         $rule->{'action'});
@@ -708,10 +708,10 @@ sub verify {
         # per list, and each call triggers a copy of the pinfo hash.
         # Profiling shows that this scales poorly with thousands of lists.
         # Briefly cache the list params data to avoid this overhead.
-        
+
         if (time > ($picache->{$robot}{'expires'} || 0)) {
             $log->syslog('debug', 'robot %s pinfo cache refresh', $robot);
-            $picache->{$robot}{'pinfo'} = Sympa::Robot::list_params($robot);
+            $picache->{$robot}{'pinfo'}   = Sympa::Robot::list_params($robot);
             $picache->{$robot}{'expires'} = (time + $picache_refresh);
         }
         $pinfo = $picache->{$robot}{'pinfo'};
@@ -740,9 +740,9 @@ sub verify {
     }
 
     if (defined($context->{'list_object'})) {
-        $list = $context->{'list_object'};
+        $list                  = $context->{'list_object'};
         $context->{'listname'} = $list->{'name'};
-        $context->{'domain'} = $list->{'domain'};
+        $context->{'domain'}   = $list->{'domain'};
 
         # Compat.<6.2.32
         $context->{'host'} = $list->{'domain'};
@@ -761,7 +761,7 @@ sub verify {
                     $context->{'message'}->get_header('Cc')),
                 lc $listname
             ) >= 0
-            ) {
+        ) {
             $context->{'is_bcc'} = 1;
         } else {
             $context->{'is_bcc'} = 0;
@@ -770,7 +770,7 @@ sub verify {
     }
     unless ($condition =~
         /(\!)?\s*(true|is_listmaster|verify_netmask|is_editor|is_owner|is_subscriber|less_than|match|equal|message|older|newer|all|search|customcondition\:\:\w+)\s*\(\s*(.*)\s*\)\s*/i
-        ) {
+    ) {
         $log->syslog('err', 'Error rule syntaxe: unknown condition %s',
             $condition);
         return undef;
@@ -801,7 +801,7 @@ sub verify {
 				|(\w+)\.ldap
 				|(\w+)\.sql
 				)\s*,?//x
-        ) {
+    ) {
         my $value = $1;
 
         ## Custom vars
@@ -828,7 +828,7 @@ sub verify {
                         @Sympa::ConfDef::params
                 )
                 and $conf_value = Conf::get_robot_conf($robot, $conf_key)
-                ) {
+            ) {
                 $value =~ s/\[conf\-\>([\w\-]+)\]/$conf_value/;
             } else {
                 $log->syslog('debug',
@@ -946,7 +946,7 @@ sub verify {
                     $context->{'message'}->as_entity->effective_type,
                     qr/^text/)
                 and defined($context->{'message'}->as_entity->bodyhandle)
-                ) {
+            ) {
                 $log->syslog('info',
                     'No proper textual message body to evaluate rule %s',
                     $condition)
@@ -1052,7 +1052,7 @@ sub verify {
         # condition that require 2 args
     } elsif ($condition_key =~
         /^(is_owner|is_editor|is_subscriber|less_than|match|equal|message|newer|older)$/o
-        ) {
+    ) {
         unless ($#args == 1) {
             $log->syslog(
                 'err',
@@ -1831,9 +1831,9 @@ sub _load_ldap_configuration {
         return;
     }
 
-    my @valid_options    = qw(host suffix filter scope bind_dn bind_password
-                              use_tls ssl_version ssl_ciphers ssl_cert ssl_key
-                              ca_verify ca_path ca_file);
+    my @valid_options = qw(host suffix filter scope bind_dn bind_password
+        use_tls ssl_version ssl_ciphers ssl_cert ssl_key
+        ca_verify ca_path ca_file);
     my @required_options = qw(host suffix filter);
 
     my %valid_options    = map { $_ => 1 } @valid_options;

--- a/src/lib/Sympa/Spindle/AuthorizeMessage.pm
+++ b/src/lib/Sympa/Spindle/AuthorizeMessage.pm
@@ -60,7 +60,7 @@ sub _twist {
     # List msg topic.
     if (not $self->{confirmed_by}    # Not in ProcessHeld spindle.
         and $list->is_there_msg_topic
-        ) {
+    ) {
         my $topic;
         if ($topic = Sympa::Topic->load($message)) {
             # Is message already tagged?
@@ -193,7 +193,7 @@ sub _twist {
     } elsif (
         not $self->{confirmed_by}    # Not in ProcessHeld spindle.
         and $action =~ /^request_auth\b/
-        ) {
+    ) {
         ## Check syntax for merge_feature.
         unless (_test_personalize($message, $list)) {
             $log->syslog(
@@ -259,7 +259,7 @@ sub _twist {
                         $list, $result->{'tt2'},
                         $sender, {auto_submitted => 'auto-replied'}
                     )
-                    ) {
+                ) {
                     $log->syslog('notice',
                         'Unable to send template "%s" to %s',
                         $result->{'tt2'}, $sender);
@@ -340,7 +340,7 @@ sub _test_personalize {
         foreach my $rcpt (
             @{$available_recipients->{$mode}{'verp'}   || []},
             @{$available_recipients->{$mode}{'noverp'} || []}
-            ) {
+        ) {
             unless ($new_message->personalize($list, $rcpt, {})) {
                 return undef;
             }

--- a/src/lib/Sympa/Spindle/AuthorizeRequest.pm
+++ b/src/lib/Sympa/Spindle/AuthorizeRequest.pm
@@ -45,7 +45,8 @@ sub _twist {
     my $request = shift;
 
     # Skip authorization unless specific scenario is defined.
-    if ($request->{error} or not $request->handler->action_scenario
+    if (   $request->{error}
+        or not $request->handler->action_scenario
         or ($self->{scenario_context} and $self->{scenario_context}{skip})) {
         return ['Sympa::Spindle::DispatchRequest'];
     }
@@ -130,7 +131,7 @@ sub _twist {
     } elsif ($action =~ /\Alistmaster\b/i) {
         # Special case for move_list and create_list.
         $request->{pending} = 'pending';
-        $request->{notify} = ($action =~ /,\s*notify\b/i);
+        $request->{notify}  = ($action =~ /,\s*notify\b/i);
         return ['Sympa::Spindle::DispatchRequest'];
     } elsif (
         $action =~ /\Arequest_auth\b(?:\s*[(]\s*[[]\s*(\S+)\s*[]]\s*[)])?/i) {

--- a/src/lib/Sympa/Spindle/DoCommand.pm
+++ b/src/lib/Sympa/Spindle/DoCommand.pm
@@ -180,7 +180,8 @@ sub _twist {
         # Send the reply message.
         my $reports = $spindle->{stash};
         if (grep { $_ and $_->[1] eq 'user' and $_->[2] eq 'unknown_command' }
-            @{$spindle->{stash} || []}) {
+            @{$spindle->{stash} || []}
+        ) {
             $log->db_log(
                 'robot' => $robot,
                 #'list'         => 'sympa',
@@ -230,7 +231,7 @@ sub _send_report {
                 $request->{context}, $data{template},
                 $sender, {auto_submitted => 'auto-replied'}
             )
-            ) {
+        ) {
             next;
         }
 

--- a/src/lib/Sympa/Spindle/ProcessAutomatic.pm
+++ b/src/lib/Sympa/Spindle/ProcessAutomatic.pm
@@ -72,7 +72,7 @@ sub _on_success {
                 $self->{distaff}->{directory} . '/' . $handle->basename,
                 $self->{keepcopy} . '/' . $handle->basename
             )
-            ) {
+        ) {
             $log->syslog(
                 'notice',
                 'Could not rename %s/%s to %s/%s: %m',
@@ -245,14 +245,14 @@ sub _twist {
         }
 
         my $spindle_req = Sympa::Spindle::ProcessRequest->new(
-            context      => $dyn_family,
-            action       => 'create_automatic_list',
-            listname     => $listname,
-            parameters   => {},
-            sender       => $sender,
-            smime_signed => $message->{'smime_signed'},
-            md5_check    => $message->{'md5_check'},
-            dkim_pass    => $message->{'dkim_pass'},
+            context          => $dyn_family,
+            action           => 'create_automatic_list',
+            listname         => $listname,
+            parameters       => {},
+            sender           => $sender,
+            smime_signed     => $message->{'smime_signed'},
+            md5_check        => $message->{'md5_check'},
+            dkim_pass        => $message->{'dkim_pass'},
             scenario_context => {
                 sender             => $sender,
                 message            => $message,
@@ -263,8 +263,10 @@ sub _twist {
         unless ($spindle_req and $spindle_req->spin) {
             $log->syslog('err', 'Cannot create dynamic list %s', $listname);
             return undef;
-        } elsif (not($spindle_req->success
-            and $list = Sympa::List->new($listname, $dyn_family->{robot}))) {
+        } elsif (
+            not(    $spindle_req->success
+                and $list = Sympa::List->new($listname, $dyn_family->{robot}))
+        ) {
             $log->syslog('err',
                 'Unable to create list %s. Message %s ignored',
                 $listname, $message);
@@ -321,10 +323,10 @@ sub _twist {
             # purge the unwanted empty automatic list
             if ($Conf::Conf{'automatic_list_removal'} =~ /if_empty/i) {
                 Sympa::Spindle::ProcessRequest->new(
-                    context      => $robot,
-                    action       => 'close_list',
-                    current_list => $list,
-                    mode         => 'purge',
+                    context          => $robot,
+                    action           => 'close_list',
+                    current_list     => $list,
+                    mode             => 'purge',
                     scenario_context => {skip => 1},
                 )->spin;
             }
@@ -350,10 +352,10 @@ sub _twist {
             # purge the unwanted empty automatic list
             if ($Conf::Conf{'automatic_list_removal'} =~ /if_empty/i) {
                 Sympa::Spindle::ProcessRequest->new(
-                    context      => $robot,
-                    action       => 'close_list',
-                    current_list => $list,
-                    mode         => 'purge',
+                    context          => $robot,
+                    action           => 'close_list',
+                    current_list     => $list,
+                    mode             => 'purge',
                     scenario_context => {skip => 1},
                 )->spin;
             }

--- a/src/lib/Sympa/Spindle/ProcessBounce.pm
+++ b/src/lib/Sympa/Spindle/ProcessBounce.pm
@@ -216,7 +216,7 @@ sub _twist {
                     status       => $dsn_status,
                     arrival_date => $arrival_date
                 )
-                ) {
+            ) {
                 $log->syslog('notice', 'DSN %s correctly treated', $message);
                 $numreported++;
             } else {
@@ -275,7 +275,7 @@ sub _twist {
                     status       => $mdn_status,
                     arrival_date => $date
                 )
-                ) {
+            ) {
                 $log->syslog('notice', 'MDN %s correctly treated', $message);
                 $numreported++;
             } else {
@@ -322,7 +322,7 @@ sub _twist {
                         scalar reverse($list_id),
                         scalar reverse('.', $robot)
                     )
-                    ) {
+                ) {
                     my $listname = substr $list_id, 0, -length($robot) - 1;
                     $list =
                         Sympa::List->new($listname, $robot, {just_try => 1});
@@ -614,7 +614,7 @@ sub _parse_dsn {
             $message,
             qw(message/delivery-status message/global-delivery-status)
         )
-        ) {
+    ) {
         next unless $report->{status};
         my $status = $report->{status}->[0];
         if ($status and $status =~ /\b(\d+[.]\d+[.]\d+)\b/) {
@@ -887,7 +887,7 @@ sub _anabounce {
             }
         } elsif (
             /^\s*-+ The following addresses (had permanent fatal errors|had transient non-fatal errors|have delivery notifications) -+/m
-            ) {
+        ) {
 
             my $adr;
 
@@ -1009,7 +1009,7 @@ sub _anabounce {
             foreach (@paragraphe) {
 
                 if (/^Your message add?ressed to (.*) couldn\'t be delivered, for the following reason :/
-                    ) {
+                ) {
                     $adr = $1;
                     $adr =~ s/^[\"\<](.+)[\"\>]$/$1/;
                     $type = 5;
@@ -1027,7 +1027,7 @@ sub _anabounce {
             ## Rapport X400
         } elsif (
             /^Your message was not delivered to:\s+(\S+)\s+for the following reason:\s+(.+)$/m
-            ) {
+        ) {
 
             my ($adr, $error) = ($1, $2);
             $error =~ s/Your message.*$//;
@@ -1037,7 +1037,7 @@ sub _anabounce {
             ## Rapport X400
         } elsif (
             /^Your message was not delivered to\s+(\S+)\s+for the following reason:\s+(.+)$/m
-            ) {
+        ) {
 
             my ($adr, $error) = ($1, $2);
             $error =~ s/\(.*$//;
@@ -1274,7 +1274,7 @@ sub _anabounce {
             /^Your message has encountered delivery problems\s+to (\S+)\.$/m
             or
             /^Your message has encountered delivery problems\s+to the following recipient\(s\):\s+(\S+)$/m
-            ) {
+        ) {
 
             my $adr = $2 || $1;
             $info{$adr}{error} = "";
@@ -1326,7 +1326,7 @@ sub _anabounce {
             ## Rapport Mercury 1.43 par. suivant
         } elsif (
             /^The local mail transport system has reported the following problems/m
-            ) {
+        ) {
 
             $mercury_143 = 1;
 
@@ -1390,7 +1390,7 @@ sub _anabounce {
             ## Rapport Mercury 1.31 par. suivant
         } elsif (
             /^One or more addresses in your message have failed with the following/m
-            ) {
+        ) {
 
             $mercury_131 = 1;
 
@@ -1486,7 +1486,7 @@ sub _anabounce {
 
         } elsif (
             /^The following message could not be delivered because the address (\S+) does not exist/m
-            ) {
+        ) {
 
             $info{$1}{error} = "user unknown";
 
@@ -1497,7 +1497,7 @@ sub _anabounce {
             ## Rapport Exim 1.73 dans proc. paragraphe
         } elsif (
             /^The address to which the message has not yet been delivered is:/m
-            ) {
+        ) {
 
             $exim_173 = 1;
 
@@ -1591,7 +1591,7 @@ sub _anabounce {
             /^Your message cannot be delivered to the following recipients:/m
             or
             /^Your message has been enqueued and undeliverable for \d day\s*to the following recipients/m
-            ) {
+        ) {
 
             $pmdf = 1;
 

--- a/src/lib/Sympa/Spindle/ProcessDigest.pm
+++ b/src/lib/Sympa/Spindle/ProcessDigest.pm
@@ -162,8 +162,8 @@ sub _distribute_digest {
     }
 
     my $param = {
-        'replyto' => Sympa::get_address($list, 'owner'),
-        'to'      => Sympa::get_address($list),
+        'replyto'   => Sympa::get_address($list, 'owner'),
+        'to'        => Sympa::get_address($list),
         'boundary1' => '----------=_' . Sympa::unique_message_id($list),
         'boundary2' => '----------=_' . Sympa::unique_message_id($list),
     };

--- a/src/lib/Sympa/Spindle/ProcessIncoming.pm
+++ b/src/lib/Sympa/Spindle/ProcessIncoming.pm
@@ -83,7 +83,7 @@ sub _on_success {
                 $self->{distaff}->{directory} . '/' . $handle->basename,
                 $self->{keepcopy} . '/' . $handle->basename
             )
-            ) {
+        ) {
             $log->syslog(
                 'notice',
                 'Could not rename %s/%s to %s/%s: %m',
@@ -258,7 +258,7 @@ sub _twist {
         and Sympa::Tools::Data::smart_eq(
             $list->{'admin'}{'reject_mail_from_automates_feature'}, 'on'
         )
-        ) {
+    ) {
         my $conf_loop_prevention_regex;
         $conf_loop_prevention_regex =
             $list->{'admin'}{'loop_prevention_regex'};
@@ -399,7 +399,7 @@ sub _splicing_to {
         subscribe   => 'Sympa::Spindle::DoCommand',
         sympa       => 'Sympa::Spindle::DoCommand',
         unsubscribe => 'Sympa::Spindle::DoCommand',
-        }->{$message->{listtype} || ''}
+    }->{$message->{listtype} || ''}
         || 'Sympa::Spindle::DoMessage';
 }
 

--- a/src/lib/Sympa/Spindle/ProcessOutgoing.pm
+++ b/src/lib/Sympa/Spindle/ProcessOutgoing.pm
@@ -245,7 +245,7 @@ sub _twist {
             if (Sympa::Tools::Data::smart_eq(
                     $new_message->{shelved}{tracking}, qr/dsn|mdn/
                 )
-                ) {
+            ) {
                 # tracking by MDN required tracking by DSN to
                 my $msgid = $new_message->{'message_id'};
                 $envid =
@@ -260,13 +260,13 @@ sub _twist {
                 Sympa::Tools::Data::smart_eq(
                     $new_message->{shelved}{tracking}, 'w'
                 )
-                ) {
+            ) {
                 $return_path = $list->get_bounce_address($rcpt, 'w');
             } elsif (
                 Sympa::Tools::Data::smart_eq(
                     $new_message->{shelved}{tracking}, 'r'
                 )
-                ) {
+            ) {
                 $return_path = $list->get_bounce_address($rcpt, 'r');
             } elsif ($new_message->{shelved}{tracking}) {    # simple VERP
                 $return_path = $list->get_bounce_address($rcpt);
@@ -345,7 +345,7 @@ sub _twist {
                     envid => $envid,
                     tag   => $new_message->{serial}
                 )
-                ) {
+            ) {
                 $log->syslog('err', 'Failed to store message %s into mailer',
                     $new_message);
                 # Quarantine packet into bad spool.
@@ -392,7 +392,7 @@ sub _twist {
             defined $mailer->store(
                 $new_message, [@rcpts], tag => $new_message->{serial}
             )
-            ) {
+        ) {
             $log->syslog('err', 'Failed to store message %s into mailer',
                 $new_message);
             # Quarantine packet into bad spool.

--- a/src/lib/Sympa/Spindle/ToArchive.pm
+++ b/src/lib/Sympa/Spindle/ToArchive.pm
@@ -59,7 +59,7 @@ sub _twist {
                 /no\-external\-archive/i
             } $message->get_header('Restrict')
         )
-        ) {
+    ) {
         # Ignoring message with a no-archive flag.
         $log->syslog('info',
             "Do not archive message with no-archive flag for list %s", $list);

--- a/src/lib/Sympa/Spindle/ToAuth.pm
+++ b/src/lib/Sympa/Spindle/ToAuth.pm
@@ -72,7 +72,7 @@ sub _twist {
                 auto_submitted => 'auto-replied',
             }
         )
-        ) {
+    ) {
         my $error = sprintf
             'Unable to request authentication for command "%s"',
             $request->{action};

--- a/src/lib/Sympa/Spindle/ToAuthOwner.pm
+++ b/src/lib/Sympa/Spindle/ToAuthOwner.pm
@@ -73,7 +73,7 @@ sub _twist {
                 'gecos'   => $request->{gecos},
             }
         )
-        ) {
+    ) {
         #FIXME: Why is error reported only in this case?
         $log->syslog('info', 'Unable to send notify "%s" to %s list owner',
             $tpl, $list);

--- a/src/lib/Sympa/Spindle/ToDigest.pm
+++ b/src/lib/Sympa/Spindle/ToDigest.pm
@@ -49,7 +49,7 @@ sub _twist {
             $message->{'smime_crypted'},
             'smime_crypted'
         )
-        ) {
+    ) {
         my $spool_digest = Sympa::Spool::Digest->new(context => $list);
         $spool_digest->store($message) if $spool_digest;
     }

--- a/src/lib/Sympa/Spindle/ToEditor.pm
+++ b/src/lib/Sympa/Spindle/ToEditor.pm
@@ -165,7 +165,7 @@ sub _send_confirm_to_editor {
             Sympa::send_file(
                 $list, 'moderate', $recipient, $param, date => time + 1
             )
-            ) {
+        ) {
             return undef;
         }
     }

--- a/src/lib/Sympa/Spindle/ToHeld.pm
+++ b/src/lib/Sympa/Spindle/ToHeld.pm
@@ -130,7 +130,7 @@ sub _send_confirm_to_sender {
         Sympa::send_file(
             $list, 'send_auth', $sender, $param, date => time + 1
         )
-        ) {
+    ) {
         return undef;
     }
 

--- a/src/lib/Sympa/Spindle/ToList.pm
+++ b/src/lib/Sympa/Spindle/ToList.pm
@@ -273,7 +273,7 @@ sub _send_msg {
         my @possible_verptabrcpt;
         if (not $resent_by    # Not in ResendArchive spindle.
             and $list->is_there_msg_topic
-            ) {
+        ) {
             my $topic = Sympa::Topic->load($message);
             my $topic_list = $topic ? $topic->{topic} : '';
 

--- a/src/lib/Sympa/Spindle/ToModeration.pm
+++ b/src/lib/Sympa/Spindle/ToModeration.pm
@@ -191,7 +191,7 @@ sub _send_confirm_to_editor {
                 $recipient,                    $list->{'domain'},
                 'modindex/' . $list->{'name'}, 'mail'
             )
-            ) {
+        ) {
             $log->syslog(
                 'notice',
                 'Unable to create one_time_ticket for %s, service modindex/%s',
@@ -211,7 +211,7 @@ sub _send_confirm_to_editor {
             Sympa::send_file(
                 $list, 'moderate', $recipient, $param, date => time + 1
             )
-            ) {
+        ) {
             return undef;
         }
     }

--- a/src/lib/Sympa/Spindle/TransformDigestFinal.pm
+++ b/src/lib/Sympa/Spindle/TransformDigestFinal.pm
@@ -43,7 +43,7 @@ sub _twist {
         @{  Sympa::Robot::list_params($list->{'domain'})
                 ->{'rfc2369_header_fields'}->{'format'}
         }
-        ) {
+    ) {
         if (scalar grep { $_ eq $field }
             @{$list->{'admin'}{'rfc2369_header_fields'}}) {
             $list->add_list_header($message, $field);

--- a/src/lib/Sympa/Spindle/TransformOutgoing.pm
+++ b/src/lib/Sympa/Spindle/TransformOutgoing.pm
@@ -122,7 +122,7 @@ sub _twist {
         @{  Sympa::Robot::list_params($list->{'domain'})
                 ->{'rfc2369_header_fields'}->{'format'}
         }
-        ) {
+    ) {
         if (scalar grep { $_ eq $field }
             @{$list->{'admin'}{'rfc2369_header_fields'}}) {
             $list->add_list_header($message, $field);

--- a/src/lib/Sympa/Spool.pm
+++ b/src/lib/Sympa/Spool.pm
@@ -83,7 +83,7 @@ sub _create {
                     user  => Sympa::Constants::USER(),
                     group => Sympa::Constants::GROUP()
                 )
-                ) {
+            ) {
                 die sprintf 'Cannot create %s: %s', $directory, $ERRNO;
             }
         }

--- a/src/lib/Sympa/Template.pm
+++ b/src/lib/Sympa/Template.pm
@@ -168,9 +168,10 @@ sub locdatetime {
 
     if (defined $arg and $arg =~ /\A-?\d+\z/) {
         return sub { $language->gettext_strftime($_[0], localtime $arg); };
-    } elsif (defined $arg and $arg =~
+    } elsif (defined $arg
+        and $arg =~
         /\A(\d{4})\D(\d\d?)(?:\D(\d\d?)(?:\D(\d\d?)\D(\d\d?)(?:\D(\d\d?))?)?)?/
-        ) {
+    ) {
         my @arg =
             ($6 || 0, $5 || 0, $4 || 0, $3 || 1, $2 - 1, $1 - 1900, 0, 0, 0);
         return sub { $language->gettext_strftime($_[0], @arg); };
@@ -317,7 +318,7 @@ sub parse {
     }
 
     my $config = {
-        ABSOLUTE => ($self->{allow_absolute} ? 1 : 0),
+        ABSOLUTE     => ($self->{allow_absolute} ? 1 : 0),
         INCLUDE_PATH => [@include_path],
         PLUGIN_BASE  => 'Sympa::Template::Plugin',
         # PRE_CHOMP  => 1,

--- a/src/lib/Sympa/Ticket.pm
+++ b/src/lib/Sympa/Ticket.pm
@@ -67,7 +67,7 @@ sub create {
             $data_string,
             $remote_addr, 'open'
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to insert new one time ticket for user %s, robot %s in the database',
@@ -103,7 +103,7 @@ sub load {
               WHERE ticket_one_time_ticket = ? AND robot_one_time_ticket = ?},
             $ticket_number, $robot
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to retrieve one time ticket %s from database',
             $ticket_number);
@@ -155,7 +155,7 @@ sub load {
                         robot_one_time_ticket = ?},
                 $addr, $ticket_number, $robot
             )
-            ) {
+        ) {
             $log->syslog('err',
                 'Unable to set one time ticket %s status to %s',
                 $ticket_number, $addr);

--- a/src/lib/Sympa/Tools/SMIME.pm
+++ b/src/lib/Sympa/Tools/SMIME.pm
@@ -211,7 +211,7 @@ sub smime_extract_certs {
             '|-', $Conf::Conf{openssl}, 'pkcs7', '-print_certs',
             '-inform' => 'der',
             '-out'    => $outfile
-            ) {
+        ) {
             $log->syslog('err', 'Unable to run openssl pkcs7: %m');
             return 0;
         }

--- a/src/lib/Sympa/Tools/Text.pm
+++ b/src/lib/Sympa/Tools/Text.pm
@@ -191,7 +191,7 @@ sub escape_chars {
         0x5b, 0x5d,
         0x80 .. 0x9f,
         0xa0 .. 0xff
-        ) {
+    ) {
         next if defined $ord_except and $i == $ord_except;
         my $hex_i = sprintf "%lx", $i;
         $s =~ s/\x$hex_i/%$hex_i/g;

--- a/src/lib/Sympa/Topic.pm
+++ b/src/lib/Sympa/Topic.pm
@@ -97,7 +97,7 @@ sub _create {
                 user  => Sympa::Constants::USER(),
                 group => Sympa::Constants::GROUP()
             )
-            ) {
+        ) {
             die sprintf 'Cannot create %s: %s', $spool_dir, $ERRNO;
         }
 

--- a/src/lib/Sympa/Tracking.pm
+++ b/src/lib/Sympa/Tracking.pm
@@ -79,7 +79,7 @@ sub _create_spool {
                     user  => Sympa::Constants::USER(),
                     group => Sympa::Constants::GROUP()
                 )
-                ) {
+            ) {
                 die sprintf 'Cannot create %s: %s', $directory, $ERRNO;
             }
         }
@@ -131,7 +131,7 @@ sub get_recipients_status {
             $msgid,
             '<' . $msgid . '>'
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to retrieve tracking information for message %s, list %s@%s',
@@ -180,7 +180,7 @@ sub db_fetch {
             $list->{'name'}, $list->{'domain'},
             $recipient,      $envid
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to retrieve tracking information for message %s, list %s',
@@ -230,7 +230,7 @@ sub register {
                   VALUES (?, ?, ?, ?, ?, ?)},
                 $msgid, $email, $reception_option, $listname, $robot, $time
             )
-            ) {
+        ) {
             $log->syslog(
                 'err',
                 'Unable to prepare notification table for user %s, message %s, list %s@%s',
@@ -350,7 +350,7 @@ sub _db_insert_notification {
             $arrival_epoch,
             $rcpt, $notification_id
         )
-        ) {
+    ) {
         $log->syslog('err', 'Unable to update notification <%s> in database',
             $notification_id);
         return undef;
@@ -441,7 +441,7 @@ sub find_notification_id_by_message {
             $msgid,
             '<' . $msgid . '>'
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to retrieve the tracking information for user %s, message %s, list %s@%s',
@@ -480,7 +480,7 @@ sub remove_message_by_email {
 
     my $bounce_dir    = $self->{directory};
     my $escaped_email = Sympa::Tools::Text::escape_chars($email);
-    my $ret = unlink sprintf('%s/%s', $bounce_dir, $escaped_email);
+    my $ret           = unlink sprintf('%s/%s', $bounce_dir, $escaped_email);
 
     # Remove HTML view.
     Sympa::Tools::File::remove_dir(
@@ -527,7 +527,7 @@ sub remove_message_by_id {
             $msgid,
             $listname, $robot
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to search tracking information for message %s, list %s@%s',
@@ -555,7 +555,7 @@ sub remove_message_by_id {
             $msgid,
             $listname, $robot
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to remove the tracking information for message %s, list %s@%s',
@@ -606,7 +606,7 @@ sub remove_message_by_period {
             $limit,
             $listname, $robot
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to search tracking information for older than %s days for list %s@%s',
@@ -634,7 +634,7 @@ sub remove_message_by_period {
             $limit,
             $listname, $robot
         )
-        ) {
+    ) {
         $log->syslog(
             'err',
             'Unable to remove the tracking information older than %s days for list %s@%s',

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -144,7 +144,8 @@ sub upgrade {
         }
     } else {
         # Prevent empty admin table (GH #71).
-        $log->syslog('notice', 'Skipping rebuild, no list config files found');
+        $log->syslog('notice',
+            'Skipping rebuild, no list config files found');
     }
 
     ## Migration to tt2
@@ -293,7 +294,7 @@ sub upgrade {
                             $table,
                             $sdm->quote($list->{'name'})
                         )
-                        ) {
+                    ) {
                         $log->syslog(
                             'err',
                             'Unable to fille the robot_admin and robot_subscriber fields in database for robot %s',
@@ -388,7 +389,7 @@ sub upgrade {
                         q{SELECT max(%s) FROM %s},
                         $field, $check{$field}
                     )
-                    ) {
+                ) {
                     $log->syslog('err', 'Unable to prepare SQL statement');
                     return undef;
                 }
@@ -608,7 +609,7 @@ sub upgrade {
             'mail_tt2', 'web_tt2',
             'scenari',  'create_list_templates',
             'families'
-            ) {
+        ) {
             if (-d $Conf::Conf{'etc'} . '/' . $type) {
                 push @directories,
                     [$Conf::Conf{'etc'} . '/' . $type, $Conf::Conf{'lang'}];
@@ -620,7 +621,7 @@ sub upgrade {
             Conf::get_wwsympa_conf(),
             $Conf::Conf{'etc'} . '/' . 'topics.conf',
             $Conf::Conf{'etc'} . '/' . 'auth.conf'
-            ) {
+        ) {
             if (-f $f) {
                 push @files, [$f, $Conf::Conf{'lang'}];
             }
@@ -632,7 +633,7 @@ sub upgrade {
                 'mail_tt2', 'web_tt2',
                 'scenari',  'create_list_templates',
                 'families'
-                ) {
+            ) {
                 if (-d $Conf::Conf{'etc'} . '/' . $vr . '/' . $type) {
                     push @directories,
                         [
@@ -660,7 +661,7 @@ sub upgrade {
                 'config',   'info',
                 'homepage', 'message.header',
                 'message.footer'
-                ) {
+            ) {
                 if (-f $list->{'dir'} . '/' . $f) {
                     push @files,
                         [$list->{'dir'} . '/' . $f, $list->{'admin'}{'lang'}];
@@ -750,14 +751,14 @@ sub upgrade {
                 if (-e $list->{'dir'} . '/subscribers'
                     and rename $list->{'dir'} . '/subscribers',
                     $list->{'dir'} . '/member.dump'
-                    ) {
+                ) {
                     $list->restore_users('member');
 
                     my $total = $list->{'add_outcome'}{'added_members'};
                     if (defined $list->{'add_outcome'}{'errors'}) {
                         $log->syslog('err', 'Failed to add users: %s',
-                            $list->{'add_outcome'}{'errors'}
-                                {'error_message'});
+                            $list->{'add_outcome'}{'errors'}{'error_message'}
+                        );
                     }
                     $log->syslog('notice',
                         '%d subscribers have been loaded into the database',
@@ -865,7 +866,7 @@ sub upgrade {
                         $sdm->quote($data->{'list_exclusion'}),
                         $sdm->quote($data->{'user_exclusion'})
                     )
-                    ) {
+                ) {
                     $log->syslog(
                         'err',
                         'Unable to update entry (%s, %s) in exclusions table (trying to add robot %s)',
@@ -1436,7 +1437,7 @@ sub upgrade {
                   SET number_messages_subscriber = 0
                   WHERE number_messages_subscriber IS NULL}
             )
-            ) {
+        ) {
             $log->syslog('err',
                 'Can\'t update number_messages_subscriber field of subscriber_table.  You must update it manually.'
             );
@@ -1506,7 +1507,7 @@ sub upgrade {
                     qr/\A\.remove\.([^\s\@]+)(?:\@([\w\.\-]+))?\.(\d\d\d\d\-\d\d)\.(\d+)\z/,
                     [qw(localpart domainpart arc date)]
                 )
-                ) {
+            ) {
                 my $arc  = $metadata->{arc};
                 my $date = $metadata->{date};
                 my $list = $metadata->{context};
@@ -1545,7 +1546,7 @@ sub upgrade {
                     qr/\A\.rebuild\.([^\s\@]+)(?:\@([\w\.\-]+))?\z/,
                     [qw(localpart domainpart)]
                 )
-                ) {
+            ) {
                 my $list = $metadata->{context};
                 next unless ref $list eq 'Sympa::List';
 
@@ -1591,7 +1592,7 @@ sub upgrade {
                         qr/\A([^\s\@]+)\@([\w\.\-]+)\.(\d+)\.(\d+)\z/,
                         [qw(localpart domainpart date)]
                     )
-                    ) {
+                ) {
                     my $list = $metadata->{context};
                     next unless ref $list eq 'Sympa::List';
 
@@ -1796,8 +1797,8 @@ sub upgrade {
             my $config = do { local $RS; <$fh> };
             close $fh;
             # Write out initial permanent owners/editors in <role>.dump files.
-            $config =~ s/(\A|\n)[\t ]+(?=\n)/$1/g;  # normalize empty lines
-            open my $ifh, '<', \$config;            # open "in memory" file
+            $config =~ s/(\A|\n)[\t ]+(?=\n)/$1/g;    # normalize empty lines
+            open my $ifh, '<', \$config;              # open "in memory" file
             my @config = do { local $RS = ''; <$ifh> };
             close $ifh;
             foreach my $role (qw(owner editor)) {
@@ -1838,8 +1839,8 @@ sub upgrade {
         foreach my $robot_id (@robot_ids) {
             next if $robot_id eq $Conf::Conf{'domain'};    # Primary domain
 
-            my $config_file =
-                sprintf '%s/%s/robot.conf', $Conf::Conf{'etc'}, $robot_id;
+            my $config_file = sprintf '%s/%s/robot.conf', $Conf::Conf{'etc'},
+                $robot_id;
 
             my $ifh;
             next unless open $ifh, '<', $config_file;
@@ -1854,7 +1855,7 @@ sub upgrade {
                 next;
             }
             printf $ofh "\n\n# Added by upgrade from %s\n", $previous_version;
-            printf $ofh "wwsympa_url\thttp://%s/sympa\n", $robot_id;
+            printf $ofh "wwsympa_url\thttp://%s/sympa\n",   $robot_id;
             close $ofh;
         }
     }
@@ -1966,7 +1967,7 @@ sub to_utf8 {
                 group => Sympa::Constants::GROUP,
                 mode  => 0644,
             )
-            ) {
+        ) {
             $log->syslog('err', 'Unable to set rights on %s',
                 $Conf::Conf{'db_name'});
             next;
@@ -2039,7 +2040,7 @@ sub fix_colors {
                     'DELETE FROM conf_table WHERE label_conf like %s',
                     $sdm->quote($name)
                 )
-                ) {
+            ) {
                 $log->syslog('err',
                     'Cannot clean color parameters from database.');
             }
@@ -2136,7 +2137,7 @@ sub _get_canonical_read_date {
     } elsif ($sdm->isa('Sympa::DatabaseDriver::Sybase')) {
         return sprintf 'datediff(second, \'01/01/1970\',%s)', $target;
     } else {
-	# Unknown driver
+        # Unknown driver
         return $target;
     }
 }
@@ -2161,7 +2162,7 @@ sub _get_cacnonical_write_date {
     } elsif ($sdm->isa('Sympa::DatabaseDriver::Sybase')) {
         return sprintf 'dateadd(second,%s,\'01/01/1970\')', $target;
     } else {
-	# Unknown driver
+        # Unknown driver
         return $target;
     }
 }

--- a/src/lib/Sympa/User.pm
+++ b/src/lib/Sympa/User.pm
@@ -175,7 +175,7 @@ sub moveto {
               WHERE email_user = ?},
             $newemail, $self->email
         )
-        ) {
+    ) {
         $log->syslog('err', 'Can\'t move user %s to %s', $self, $newemail);
         $sth = pop @sth_stack;
         return undef;
@@ -313,9 +313,10 @@ my %fingerprint_hashes = (
         my $fingerprint = Digest::MD5::md5_hex($pwd);
         my $match = ($fingerprint eq $salt) ? "yes" : "no";
 
-        $log->syslog('debug', "md5: match $match salt \"$salt\" fingerprint $fingerprint");
+        $log->syslog('debug',
+            "md5: match $match salt \"$salt\" fingerprint $fingerprint");
 
-	return $fingerprint;
+        return $fingerprint;
     },
     # bcrypt uses a salt and has a configurable "cost" parameter
     'bcrypt' => sub {
@@ -326,24 +327,27 @@ my %fingerprint_hashes = (
 
         # A bcrypt-encrypted password contains the settings at the front.
         # If this not look like a settings string, create one.
-        unless (defined($salt) && $salt =~ m#\A\$2(a?)\$([0-9]{2})\$([./A-Za-z0-9]{22})#x) {
+        unless (defined($salt)
+            && $salt =~ m#\A\$2(a?)\$([0-9]{2})\$([./A-Za-z0-9]{22})#x) {
             my $bcrypt_cost = Conf::get_robot_conf('*', 'bcrypt_cost');
             my $cost = sprintf("%02d", 0 + $bcrypt_cost);
-	    my $newsalt = "";
+            my $newsalt = "";
 
-            for my $i (0..15) {
+            for my $i (0 .. 15) {
                 $newsalt .= chr(rand(256));
             }
             $newsalt = '$2a$' . $cost . '$' . en_base64($newsalt);
-            $log->syslog('debug', "bcrypt: create new salt: cost $cost \"$newsalt\"");
+            $log->syslog('debug',
+                "bcrypt: create new salt: cost $cost \"$newsalt\"");
 
-	    $salt = $newsalt;
+            $salt = $newsalt;
         }
 
         my $fingerprint = bcrypt($pwd, $salt);
         my $match = ($fingerprint eq $salt) ? "yes" : "no";
 
-        $log->syslog('debug', "bcrypt: match $match salt $salt fingerprint $fingerprint");
+        $log->syslog('debug',
+            "bcrypt: match $match salt $salt fingerprint $fingerprint");
 
         return $fingerprint;
     }
@@ -356,7 +360,7 @@ sub password_fingerprint {
     $log->syslog('debug', "salt \"%s\"", $salt);
 
     my $password_hash = Conf::get_robot_conf('*', 'password_hash');
-    my $password_hash_update = 
+    my $password_hash_update =
         Conf::get_robot_conf('*', 'password_hash_update');
 
     if (Conf::get_robot_conf('*', 'password_case') eq 'insensitive') {
@@ -394,8 +398,9 @@ Returns undef if no supported hash type is detected
 sub hash_type {
     my $hash = shift;
 
-    return 'md5'    if ($hash =~ /^[a-f0-9]{32}$/i);
-    return 'bcrypt' if ($hash =~ m#\A\$2(a?)\$([0-9]{2})\$([./A-Za-z0-9]{22})#);
+    return 'md5' if ($hash =~ /^[a-f0-9]{32}$/i);
+    return 'bcrypt'
+        if ($hash =~ m#\A\$2(a?)\$([0-9]{2})\$([./A-Za-z0-9]{22})#);
     return undef;
 }
 
@@ -425,7 +430,7 @@ sub update_password_hash {
     # instead of using any other logic to determine which to call
 
     $log->syslog('debug', 'update password hash for %s from %s to %s',
-                 $user->{'email'}, $user_hash, $system_hash);
+        $user->{'email'}, $user_hash, $system_hash);
 
     # note that we use the cleartext password here, not the hash
     update_global_user($user->{'email'}, {password => $pwd});
@@ -476,7 +481,7 @@ sub delete_global_user {
             and $sdm->do_prepared_query(
                 q{DELETE FROM user_table WHERE email_user = ?}, $who
             )
-            ) {
+        ) {
             $log->syslog('err', 'Unable to delete user %s', $who);
             next;
         }
@@ -516,7 +521,7 @@ sub get_global_user {
             ),
             $who
         )
-        ) {
+    ) {
         $log->syslog('err', 'Failed to prepare SQL query');
         $sth = pop @sth_stack;
         return undef;
@@ -607,7 +612,7 @@ sub is_global_user {
         and $sth = $sdm->do_prepared_query(
             q{SELECT COUNT(*) FROM user_table WHERE email_user = ?}, $who
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to check whether user %s is in the user table');
         $sth = pop @sth_stack;

--- a/src/lib/Sympa/WWW/Auth.pm
+++ b/src/lib/Sympa/WWW/Auth.pm
@@ -79,7 +79,8 @@ sub check_auth {
             };
 
         } else {
-            Sympa::WWW::Report::reject_report_web('user', 'incorrect_passwd', {})
+            Sympa::WWW::Report::reject_report_web('user', 'incorrect_passwd',
+                {})
                 unless ($ENV{'SYMPA_SOAP'});
             $log->syslog('err', "Incorrect LDAP password");
             return undef;
@@ -132,7 +133,8 @@ sub authentication {
         # too many wrong login attemp
         Sympa::User::update_global_user($email,
             {wrong_login_count => $user->{'wrong_login_count'} + 1});
-        Sympa::WWW::Report::reject_report_web('user', 'too_many_wrong_login', {})
+        Sympa::WWW::Report::reject_report_web('user', 'too_many_wrong_login',
+            {})
             unless ($ENV{'SYMPA_SOAP'});
         $log->syslog('err',
             'Login is blocked: too many wrong password submission for %s',
@@ -167,7 +169,7 @@ sub authentication {
             if ($canonic = ldap_authentication(
                     $robot, $auth_service, $email, $pwd, 'email_filter'
                 )
-                ) {
+            ) {
                 unless ($user = Sympa::User::get_global_user($canonic)) {
                     $user = {'email' => $canonic};
                 }

--- a/src/lib/Sympa/WWW/Marc/Search.pm
+++ b/src/lib/Sympa/WWW/Marc/Search.pm
@@ -167,7 +167,7 @@ sub _find_match {
                     foreach $hit (
                         sort { $matches{$a} <=> $matches{$b} }
                         keys %matches
-                        ) {
+                    ) {
                         # no duplicates please
                         next if ($matches{$hit} + 1 == $line);
                         # arrays start from 0

--- a/src/lib/Sympa/WWW/SOAP.pm
+++ b/src/lib/Sympa/WWW/SOAP.pm
@@ -193,8 +193,12 @@ sub login {
     }
 
     ## Create Sympa::WWW::Session object
-    my $session = Sympa::WWW::Session->new($robot,
-        {'cookie' => Sympa::WWW::Session::encrypt_session_id($ENV{'SESSION_ID'})});
+    my $session = Sympa::WWW::Session->new(
+        $robot,
+        {   'cookie' =>
+                Sympa::WWW::Session::encrypt_session_id($ENV{'SESSION_ID'})
+        }
+    );
     $ENV{'USER_EMAIL'} = $email;
     $session->{'email'} = $email;
     $session->store();
@@ -272,8 +276,11 @@ sub casLogin {
     }
 
     ## Now fetch email attribute from LDAP
-    unless ($email =
-        Sympa::WWW::Auth::get_email_by_net_id($robot, $cas_id, {'uid' => $user})) {
+    unless (
+        $email = Sympa::WWW::Auth::get_email_by_net_id(
+            $robot, $cas_id, {'uid' => $user}
+        )
+    ) {
         $log->syslog('err',
             'Could not get email address from LDAP for user %s', $user);
         die SOAP::Fault->faultcode('Server')
@@ -282,8 +289,12 @@ sub casLogin {
     }
 
     ## Create Sympa::WWW::Session object
-    my $session = Sympa::WWW::Session->new($robot,
-        {'cookie' => Sympa::WWW::Session::encrypt_session_id($ENV{'SESSION_ID'})});
+    my $session = Sympa::WWW::Session->new(
+        $robot,
+        {   'cookie' =>
+                Sympa::WWW::Session::encrypt_session_id($ENV{'SESSION_ID'})
+        }
+    );
     $ENV{'USER_EMAIL'} = $email;
     $session->{'email'} = $email;
     $session->store();
@@ -388,8 +399,8 @@ sub authenticateRemoteAppAndRun {
             ->faultdetail('Use : <appname> <apppassword> <vars> <service>');
     }
     my ($proxy_vars, $set_vars) =
-        Sympa::WWW::Auth::remote_app_check_password($appname, $apppassword, $robot,
-        $service);
+        Sympa::WWW::Auth::remote_app_check_password($appname, $apppassword,
+        $robot, $service);
 
     unless (defined $proxy_vars) {
         $log->syslog('notice', 'Authentication failed');
@@ -560,9 +571,11 @@ sub info {
 }
 
 sub createList {
-    $log->syslog('info', 
+    $log->syslog(
+        'info',
         '(%s, listname=%s, subject=%s, template=%s, description=%s, topics=%s)',
-        @_);
+        @_
+    );
     my $class       = shift;
     my $listname    = shift;
     my $subject     = shift;
@@ -612,14 +625,15 @@ sub createList {
         if Sympa::User::is_global_user($sender);
 
     my $spindle = Sympa::Spindle::ProcessRequest->new(
-        context      => $robot,
-        action       => 'create_list',
-        listname     => $listname,
+        context    => $robot,
+        action     => 'create_list',
+        listname   => $listname,
         parameters => {
-            owner => [{
-                email => $sender,
-                gecos => ($user ? $user->{gecos} : undef),
-            }],
+            owner => [
+                {   email => $sender,
+                    gecos => ($user ? $user->{gecos} : undef),
+                }
+            ],
             subject        => $subject,
             creation_email => $sender,
             template       => $list_tpl,
@@ -706,9 +720,9 @@ sub closeList {
     }
 
     my $spindle = Sympa::Spindle::ProcessRequest->new(
-        context          => $list,
-        action           => 'close_list',
-        current_list     => $list,
+        context      => $list,
+        action       => 'close_list',
+        current_list => $list,
         mode =>
             (($list->{'admin'}{'status'} eq 'pending') ? 'purge' : 'close'),
         sender           => $sender,

--- a/src/lib/Sympa/WWW/Session.pm
+++ b/src/lib/Sympa/WWW/Session.pm
@@ -151,7 +151,7 @@ sub load {
                         refresh_date_session IS NULL},
                 $id_session
             )
-            ) {
+        ) {
             $log->syslog('err', 'Unable to load session %s', $id_session);
             return undef;
         }
@@ -178,7 +178,7 @@ sub load {
                         prev_id_session = ?},
                 $id_session, $id_session
             )
-            ) {
+        ) {
             $log->syslog('err', 'Unable to load session %s', $id_session);
             return undef;
         }
@@ -279,7 +279,7 @@ sub store {
                 $self->{'email'}, $self->{'start_date'}, $self->{'hit'},
                 $data_string
             )
-            ) {
+        ) {
             $log->syslog('err',
                 'Unable to add new information for session %s in database',
                 $self->{'id_session'});
@@ -300,7 +300,7 @@ sub store {
                   WHERE prev_id_session = ?},
                 $self->{'id_session'}
             )
-            ) {
+        ) {
             $log->syslog('err',
                 'Unable to update session information in database');
             return undef;
@@ -328,7 +328,7 @@ sub store {
                 $self->{'id_session'},
                 $self->{'id_session'}
             )
-            ) {
+        ) {
             $log->syslog('err',
                 'Unable to update information for session %s in database',
                 $self->{'id_session'});
@@ -372,7 +372,7 @@ sub renew {
               WHERE prev_id_session = ?},
             $self->{'id_session'}
         )
-        ) {
+    ) {
         $log->syslog('err',
             'Unable to update information for session %s in database',
             $self->{'id_session'});
@@ -531,7 +531,8 @@ sub list_sessions {
 ## Subroutine to get session cookie value
 sub get_session_cookie {
     my $http_cookie = shift;
-    return Sympa::WWW::Session::_generic_get_cookie($http_cookie, 'sympa_session');
+    return Sympa::WWW::Session::_generic_get_cookie($http_cookie,
+        'sympa_session');
 }
 
 ## Generic subroutine to set a cookie

--- a/src/lib/Sympa/WWW/Tools.pm
+++ b/src/lib/Sympa/WWW/Tools.pm
@@ -251,15 +251,15 @@ sub get_robot {
             my $uri = URI->new($local_url);
             next
                 unless $uri
-                    and $uri->scheme
-                    and grep { $uri->scheme eq $_ } qw(http https);
+                and $uri->scheme
+                and grep { $uri->scheme eq $_ } qw(http https);
 
-            my $host = lc ($uri->host || '');
+            my $host = lc($uri->host || '');
             my $path = $uri->path || '/';
             #FIXME:might need percent-decode hosts and/or paths
             next
                 unless $request_host eq $host
-                    and 0 == index $request_path, $path;
+                and 0 == index $request_path, $path;
 
             # The longest path wins.
             ($robot_id, $selected_path) = ($rid, $path)
@@ -407,7 +407,7 @@ sub get_list_list_tpl {
                 lang   => $language->get_lang
             )
         }
-        ) {
+    ) {
         my $dh;
         if (opendir $dh, $directory) {
             foreach my $tpl_name (readdir $dh) {
@@ -692,7 +692,7 @@ sub _get_css_url {
     foreach my $p (
         grep { /_color\z/ or /\Acolor_/ or /_url\z/ }
         map { $_->{name} } grep { $_->{name} } @Sympa::ConfDef::params
-        ) {
+    ) {
         $param->{$p} = Conf::get_robot_conf($robot, $p);
     }
     if (%colors) {
@@ -790,7 +790,7 @@ sub _get_css_url {
             (exists $hash{$lang || '_main'})
             ? ($hash{$lang || '_main'} eq $hash)
             : ($template_mtime < Sympa::Tools::File::get_mtime($path))
-            ) {
+        ) {
             return ($url, $hash);
         }
     }


### PR DESCRIPTION
The interest in having perltidy tests in Travis is to check for non-tidy code introduction, but it can only be achieved if Sympa itself passes the test.  This PR makes Sympa passes the test successfully.

Use `git diff --ignore-all-space` on the commit to show only non-spaces changes (there is a **lot** of space changes)