### PR TITLE
Use rsa-sha256 for DKIM signatures

### DIFF
--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -493,7 +493,7 @@ sub dkim_sign {
     }
     # create a signer object
     my $dkim = Mail::DKIM::Signer->new(
-        Algorithm => "rsa-sha1",
+        Algorithm => "rsa-sha256",
         Method    => "relaxed",
         Domain    => $dkim_d,
         Selector  => $dkim_selector,


### PR DESCRIPTION
Sympa currently uses rsa-sha1 for DKIM signature attached to outgoing mails. It [has been shown](https://shattered.io/) that SHA-1 can no longer be considered resistant to collisions in practice, which means that it is inadequate to be used with DKIM. Since Mail::DKIM supports rsa-sha256, this is easy to fix.