### PR TITLE
Fix SQL query to fetch all lists of a family

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -7630,7 +7630,8 @@ sub get_lists {
             sprintf(
             '$list->{"admin"}{"family_name"} and $list->{"admin"}{"family_name"} eq "%s"',
             quotemeta $family_name);
-        push @clause_sql, q{family_list LIKE '$family_name'};
+        push @clause_sql,
+          sprintf(q{family_list LIKE '%s'}, $family_name);
     }
 
     while (1 < scalar @query) {


### PR DESCRIPTION
## Description

When instantiating a family, unknown lists are never closed because the SQL query to retrieve the existing instantiated lists of the family is incorrect.

## Impacts

This PR fixes the SQL query and makes the "--close_unknown" argument work again.