### PR TITLE
Improve performance of purge operation

### DIFF
--- a/src/lib/Sympa/Request/Handler/close_list.pm
+++ b/src/lib/Sympa/Request/Handler/close_list.pm
@@ -201,7 +201,7 @@ sub _purge {
     my $sender = $request->{sender};
 
     # Remove tasks for this list.
-    Sympa::Task::list_tasks($Conf::Conf{'queuetask'});
+    Sympa::Task::list_tasks($Conf::Conf{'queuetask'}, $list->get_id);
     foreach my $task (Sympa::Task::get_tasks_by_list($list->get_id)) {
         unlink $task->{'filepath'};
     }

--- a/src/lib/Sympa/Task.pm
+++ b/src/lib/Sympa/Task.pm
@@ -96,6 +96,7 @@ sub new {
 ## Build all Sympa::Task objects
 sub list_tasks {
     my $spool_task = shift;
+    my $filter = shift;
 
     ## Create required tasks
     unless (opendir(DIR, $spool_task)) {
@@ -114,6 +115,7 @@ sub list_tasks {
     ## Create Sympa::Task objects
     foreach my $t (@task_files) {
         next if ($t =~ /^\./);
+        next if ($filter && grep !/\Q$filter/, $t);
         my $task = Sympa::Task->new($spool_task . '/' . $t);
 
         ## Maintain list of tasks


### PR DESCRIPTION
## Description

When purging a closed list, all tasks are instantiated which can be a very long process when you have thousands of lists defined.

## Impacts

This PR improves the purge operation by only instantiating tasks relevant to the list being purged.