### PR TITLE
#316: Don't show "Autocrypt:" and "Openpgp:" header fields in web archives.

### DIFF
--- a/default/mhonarc-ressources.tt2
+++ b/default/mhonarc-ressources.tt2
@@ -563,6 +563,8 @@ thread-
 User-agent
 Mail-followup-to
 Dkim-signature
+autocrypt
+openpgp
 </EXCS>
 
 <!-- Field order in message header -->


### PR DESCRIPTION
  - Autocrypt: Autocrypt level 1 header field https://autocrypt.org/
  - Openpgp: The "OpenPGP" mail and news header field https://tools.ietf.org/html/draft-josefsson-openpgp-mailnews-header-07

Note: Rebuilding archives is required to apply this modification to past archives.

This may fix issue #316.
