### PR TITLE
WWSympa: Rendering bug with IE

### DIFF
--- a/default/web_tt2/css.tt2
+++ b/default/web_tt2/css.tt2
@@ -2156,6 +2156,11 @@ nav menu form{
 .is-dropdown-submenu {
     border: 0;
 }
+[%# Bug with IE (at least 11 or earlier): menu items may be off to bottom. ~%]
+.top-bar menu ul li {
+    vertical-align: top;
+}
+
 [%# Color of submenu icons ~%]
 [% IF 0 # We use default of F6 for accordion menu. ~%]
 .accordion-menu .is-accordion-submenu-parent:not(.has-submenu-toggle) > a:after,


### PR DESCRIPTION
With IE at least 11 or earlier.  Menu items may be off to bottom.

| Broken | Fixed by this PR |
| ------ | ---------------- |
| ![ie](https://user-images.githubusercontent.com/5743546/42742761-ab575b2c-88f8-11e8-911c-0e31cc25cb24.png) | ![ie_fixed](https://user-images.githubusercontent.com/5743546/42742782-d31efc6e-88f8-11e8-8914-7ba68d7bf655.png) |
