### PR TITLE
Fix do_search_list sub to trim leading/trailig whitespace

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -10611,6 +10611,11 @@ sub do_search_list_request {
 sub do_search_list {
     wwslog('info', '(%s)', $in{'filter_list'});
 
+    ## trim leading/trailing whitespace
+    if (defined $in{'filter_list'}) {
+        $in{'filter_list'} =~ s/^\s+|\s+$//g;
+    }
+
     unless (defined $in{'filter_list'} and length $in{'filter_list'}) {
         wwslog('info', 'No filter');
         return 'search_list_request';


### PR DESCRIPTION
### **Description**
When searching for an _existing_ list using the 'Search Form', any leading or trailing whitespace is included in the submitted search value. This causes the search to fail to find any list by the submitted value.

![sympa-search-lists](https://user-images.githubusercontent.com/23345433/43471149-e5e18386-94af-11e8-9bb8-dffd6a10e6c8.png)

### **Impacts**
This PR fixes the 'Search Form' by removing any trailing/leading whitespace from the value submitted.
