### PR TITLE
Notify user that he already subscribed to a list #386

### DIFF
--- a/default/mail_tt2/user_notification.tt2
+++ b/default/mail_tt2/user_notification.tt2
@@ -53,6 +53,25 @@ Subject: [% FILTER qencode %][%|loc(list.name)%]No valid recipient in list %1[%E
 [%|loc(list.name,conf.listmaster_email,domain) %]Your message to list %1 could not be delivered. All the subscribers to this list have their address in error.
 Please contact the listmaster (%2@%3) to fix this problem before re-posting your message.[% END %]
 
+[% ELSIF type == 'vain_request_by_other' -%]
+[% IF request.action == 'subscribe' -%]
+Subject: [% FILTER qencode %][%|loc(list.name)%]FYI: subscribing to %1[%END%][%END%]
+[%- ELSIF request.action == 'signoff' -%]
+Subject: [% FILTER qencode %][%|loc(conf.title,list.name)%]FYI: unsubscribing from %1[%END%][%END%]
+[%- ELSE -%]
+Subject: [% request.action %]
+[%- END %]
+
+[% IF request.action == 'subscribe' -%]
+[%|loc(list.name)%]Someone (probably you) requested for subscribing to list %1, but you have already subscribed to this list.[%END%]
+[%- ELSIF request.action == 'signoff' -%]
+[%|loc(list.name)%]Someone (probably you) requested for unsubscribing from list %1, but you have not subscribed to this list.[%END%]
+[%- ELSE -%]
+[% request.action %]
+[%- END %]
+
+[%|loc%]No action is needed on your side.[%END%]
+
 [% ELSIF type == 'plugin' -%]
 [%- TRY -%][%- INCLUDE $entry -%]
 [%- CATCH -%]

--- a/default/scenari/subscribe.auth
+++ b/default/scenari/subscribe.auth
@@ -1,5 +1,7 @@
+# subscribe.auth
 title.gettext subscription request confirmed
 
-is_subscriber([listname],[sender]) smtp,dkim,smime     -> do_it
-true()				   smtp,dkim           -> request_auth
-true()				   md5,smime           -> do_it
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+true()                             smtp,dkim           -> request_auth([email])
+true()                             md5,smime           -> do_it

--- a/default/scenari/subscribe.auth_notify
+++ b/default/scenari/subscribe.auth_notify
@@ -1,6 +1,7 @@
+# subscribe.auth_notify
 title.gettext need authentication (notification is sent to owners)
 
-# do not authentify nor notify updates 
-is_subscriber ([listname],[sender])  smtp,dkim,smime,md5 -> do_it
-true()				     smtp,dkim           -> request_auth
-true()				     md5,smime           -> do_it,notify
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+true()                             smtp,dkim           -> request_auth([email])
+true()                             md5,smime           -> do_it,notify

--- a/default/scenari/subscribe.auth_notifydkim
+++ b/default/scenari/subscribe.auth_notifydkim
@@ -1,6 +1,7 @@
+# subscribe.auth_notifydkim
 title.gettext need authentication unless DKIM signature is OK (notification is sent to owners)
 
-# do not authentify nor notify updates 
-is_subscriber ([listname],[sender])  smtp,dkim,smime,md5 -> do_it
-true()				     smtp                -> request_auth
-true()				     dkim,md5,smime      -> do_it,notify
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+true()                             smtp                -> request_auth([email])
+true()                             dkim,md5,smime      -> do_it,notify

--- a/default/scenari/subscribe.auth_owner
+++ b/default/scenari/subscribe.auth_owner
@@ -1,8 +1,7 @@
+# subscribe.auth_owner
 title.gettext requires authentication then owner approval
 
-# subscription under owner control but previously email are checked by auth
-true()                                     smtp,dkim      -> request_auth
-is_subscriber([listname],[previous_email]) md5,smime -> do_it
-true()                                     md5,smime -> owner
-
-
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+true()                             smtp,dkim           -> request_auth([email])
+true()                             md5,smime           -> owner

--- a/default/scenari/subscribe.auth_ownerdkim
+++ b/default/scenari/subscribe.auth_ownerdkim
@@ -1,8 +1,7 @@
+# subscribe.auth_ownerdkim
 title.gettext requires authentication unless DKIM signature is OK, then owner approval
 
-# subscription under owner control but previously email are checked by auth
-true()                                     smtp      -> request_auth
-is_subscriber([listname],[previous_email]) dkim,md5,smime -> do_it
-true()                                     dkim,md5,smime -> owner
-
-
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+true()                             smtp                -> request_auth([email])
+true()                             dkim,md5,smime      -> owner

--- a/default/scenari/subscribe.authdkim
+++ b/default/scenari/subscribe.authdkim
@@ -1,5 +1,7 @@
+# subscribe.authdkim
 title.gettext subscription request confirmed
 
-is_subscriber([listname],[sender]) smtp,dkim,smime     -> do_it
-true()				   smtp                -> request_auth
-true()				   dkim,md5,smime          -> do_it
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+true()                             smtp                -> request_auth([email])
+true()                             dkim,md5,smime      -> do_it

--- a/default/scenari/subscribe.closed
+++ b/default/scenari/subscribe.closed
@@ -1,4 +1,4 @@
+# subscribe.closed
 title.gettext subscription is impossible
 
-true()   smtp,dkim,md5,smime -> reject(reason='subscribe_closed')
-
+true()  smtp,dkim,md5,smime -> reject(reason='subscribe_closed')

--- a/default/scenari/subscribe.intranet
+++ b/default/scenari/subscribe.intranet
@@ -1,11 +1,14 @@
+# subscribe.intranet
 title.gettext restricted to local domain users
 
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+
 # if subscriber request come from local domain do_it else reject
-is_subscriber([listname],[sender]) smtp,dkim,smime,md5    -> do_it
-match([sender],/[domain]$/)          smtp,dkim,smime,md5    -> do_it
+match([email],/[domain]$/)         smtp,dkim,md5,smime -> do_it
 #
 # this is example of a rule to check local adresses
 # verify_netmask('1.12.123.0/24') smtp,dkim,md5,smime -> do_it
 #
-true()                         smtp,dkim,md5,smime -> reject(reason='subscribe_local_user')	
 
+true()  smtp,dkim,md5,smime -> reject(reason='subscribe_local_user')

--- a/default/scenari/subscribe.intranetorowner
+++ b/default/scenari/subscribe.intranetorowner
@@ -1,8 +1,14 @@
+# subscribe.intranetorowner
 title.gettext local domain users or owner approval
 
-# if subscriber request come from local domain do_it else reject
-is_subscriber([listname],[sender]) smtp,smime,md5    -> do_it
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+
+#
 # this is example of a rule to check local adresses
 # verify_netmask('1.12.123.0/24') smtp,md5,smime -> do_it
-match([sender],/[domain]$/)          smtp,dkim,smime,md5    -> do_it
-true()                             smtp,dkim,smime,md5    -> owner
+#
+# if subscriber request come from local domain do_it else reject
+match([email],/[domain]$/)         smtp,dkim,md5,smime -> do_it
+
+true()                             smtp,dkim,md5,smime -> owner

--- a/default/scenari/subscribe.open
+++ b/default/scenari/subscribe.open
@@ -1,3 +1,5 @@
+# subscribe.open
 title.gettext for anyone without authentication
 
-true()  smtp,dkim,smime,md5 -> do_it
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+true()                             smtp,dkim,md5,smime -> do_it

--- a/default/scenari/subscribe.open_notify
+++ b/default/scenari/subscribe.open_notify
@@ -1,5 +1,5 @@
+# subscribe.open_notify
 title.gettext anyone, notification is sent to list owner
 
-# do not notify if it is just an update
-is_subscriber([listname],[sender])	 smtp,dkim,smime,md5 -> do_it
-true()					 smtp,dkim,smime,md5 -> do_it,notify
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+true()                             smtp,dkim,md5,smime -> do_it,notify

--- a/default/scenari/subscribe.open_quiet
+++ b/default/scenari/subscribe.open_quiet
@@ -1,3 +1,5 @@
+# subscribe.open_quiet
 title.gettext anyone, no welcome message
 
-true()  smtp,dkim,smime,md5 -> do_it,quiet
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+true()                             smtp,dkim,md5,smime -> do_it,quiet

--- a/default/scenari/subscribe.owner
+++ b/default/scenari/subscribe.owner
@@ -1,8 +1,6 @@
+# subscribe.owner
 title.gettext owners approval
 
-# if subscriber request come from a subscriber, it's just an update, do it
-is_subscriber([listname],[sender]) smtp,smime,md5    -> do_it
-# if subscribtion request is just a change email, it is open :
-is_subscriber([listname],[previous_email]) smtp,smime,md5    -> do_it
-true()                             smtp,dkim,smime,md5    -> owner
-
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+true()                             smtp,dkim,md5,smime -> owner

--- a/default/scenari/subscribe.smime
+++ b/default/scenari/subscribe.smime
@@ -1,6 +1,7 @@
+# subscribe.smime
 title.gettext requires S/MIME signed
 
-is_subscriber([listname],[sender]) smtp,dkim,smime -> do_it
-true()				   smime           -> do_it
-true()                             smtp,dkim,md5        -> reject(reason='subscribe_smime')	
-
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+true()                             smime               -> do_it
+true()                             smtp,dkim,md5       -> reject(reason='subscribe_smime')

--- a/default/scenari/subscribe.smimeorowner
+++ b/default/scenari/subscribe.smimeorowner
@@ -1,7 +1,7 @@
+# subscribe.smimeorowner
 title.gettext requires S/MIME signed or owner approval
 
-# if subscriber request come from a subscriber, it's just an update, do it
-is_subscriber([listname],[sender]) smtp,dkim,smime,md5    -> do_it
-true()                             smtp,dkim,md5          -> owner
-true()                             smime                  -> do_it
-
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+true()                             smtp,dkim,md5       -> owner
+true()                             smime               -> do_it

--- a/default/scenari/unsubscribe.auth
+++ b/default/scenari/unsubscribe.auth
@@ -1,5 +1,7 @@
+# unsubscribe.auth
 title.gettext need authentication
 
-!is_subscriber ([listname],[email]) smtp,dkim,smime,md5 -> do_it
-true()                              smtp, dkim          -> request_auth([email])
-true()			            md5,smime           -> do_it
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+!is_subscriber([listname],[email]) smtp,dkim,md5,smime -> do_it
+true()                             smtp,dkim           -> request_auth([email])
+true()                             md5,smime           -> do_it

--- a/default/scenari/unsubscribe.auth_notify
+++ b/default/scenari/unsubscribe.auth_notify
@@ -1,6 +1,7 @@
+# unsubscribe.auth_notify
 title.gettext authentication requested, notification sent to owner
 
-!is_subscriber ([listname],[email]) smtp,dkim,md5,smime -> do_it,notify
-true()                              smtp,dkim          -> request_auth([email])
-true()			            md5,smime      -> do_it,notify
-
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+!is_subscriber([listname],[email]) smtp,dkim,md5,smime -> do_it,notify
+true()                             smtp,dkim           -> request_auth([email])
+true()                             md5,smime           -> do_it,notify

--- a/default/scenari/unsubscribe.auth_notifydkim
+++ b/default/scenari/unsubscribe.auth_notifydkim
@@ -1,6 +1,7 @@
+# unsubscribe.auth_notifydkim
 title.gettext authentication requested unless DKIM signature is OK, notification sent to owner
 
-!is_subscriber ([listname],[email]) smtp,dkim,md5,smime -> do_it,notify
-true()                              smtp           -> request_auth([email])
-true()			            dkim,md5,smime      -> do_it,notify
-
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+!is_subscriber([listname],[email]) smtp,dkim,md5,smime -> do_it,notify
+true()                             smtp                -> request_auth([email])
+true()                             dkim,md5,smime      -> do_it,notify

--- a/default/scenari/unsubscribe.authdkim
+++ b/default/scenari/unsubscribe.authdkim
@@ -1,5 +1,7 @@
+# unsubscribe.authdkim
 title.gettext need authentication unless DKIM signature is OK
 
-!is_subscriber ([listname],[email]) smtp,dkim,smime,md5 -> do_it
-true()                              smtp                -> request_auth([email])
-true()			            dkim,md5,smime      -> do_it
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+!is_subscriber([listname],[email]) smtp,dkim,md5,smime -> do_it
+true()                             smtp                -> request_auth([email])
+true()                             dkim,md5,smime      -> do_it

--- a/default/scenari/unsubscribe.closed
+++ b/default/scenari/unsubscribe.closed
@@ -1,3 +1,4 @@
+# unsubscribe.closed
 title.gettext impossible
 
-true()                              smtp,dkim,md5,smime -> reject(reason='unsub_closed')
+true()  smtp,dkim,md5,smime -> reject(reason='unsub_closed')

--- a/default/scenari/unsubscribe.open
+++ b/default/scenari/unsubscribe.open
@@ -1,6 +1,5 @@
+# unsubscribe.open
 title.gettext open
 
-!is_subscriber ([listname],[email]) smtp,dkim,smime,md5 -> do_it
-!equal ([sender],[email])           smtp,dkim           -> request_auth([email])
-true()			            smtp,md5,smime      -> do_it
-
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+true()                             smtp,dkim,md5,smime -> do_it

--- a/default/scenari/unsubscribe.open_notify
+++ b/default/scenari/unsubscribe.open_notify
@@ -1,5 +1,5 @@
+# unsubscribe.open_notify
 title.gettext open with mail confirmation, owner is notified
 
-!is_subscriber ([listname],[email]) smtp,dkim,md5,smime -> do_it,notify
-!equal ([sender],[email])           smtp                -> request_auth([email])
-true()			            smtp,dkim,md5,smime -> do_it,notify
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+true()                             smtp,dkim,md5,smime -> do_it,notify

--- a/default/scenari/unsubscribe.owner
+++ b/default/scenari/unsubscribe.owner
@@ -1,5 +1,6 @@
+# unsubscribe.owner
 title.gettext owners approval
 
-!equal ([sender],[email])            smtp             -> request_auth([email])
-is_subscriber([listname],[sender])   smtp,dkim,smime,md5  -> owner
-true()                               smtp,dkim,smime,md5  -> do_it
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+!is_subscriber([listname],[email]) smtp,dkim,smime,md5 -> do_it
+true()                             smtp,dkim,md5,smime -> owner

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -5746,14 +5746,16 @@ sub do_subscribe {
         return 1;
     }
 
-    my ($email, $gecos);
+    my ($sender, $email, $gecos);
     if ($param->{'user'} and $param->{'user'}{'email'}) {
-        $email = $param->{'user'}{'email'};
-        $gecos = $in{'gecos'} || $param->{'user'}{'gecos'};
+        $sender = $param->{'user'}{'email'};
+        $email  = $param->{'user'}{'email'};
+        $gecos  = $in{'gecos'} || $param->{'user'}{'gecos'};
     } else {
         # User is not autenticated.
-        $email = Sympa::Tools::Text::canonic_email($in{'email'});
-        $gecos = $in{'gecos'};
+        $sender = 'nobody';
+        $email  = Sympa::Tools::Text::canonic_email($in{'email'});
+        $gecos  = $in{'gecos'};
     }
 
     @{$param}{qw(email gecos custom_attribute)} =
@@ -5787,7 +5789,7 @@ sub do_subscribe {
     my $spindle = Sympa::Spindle::ProcessRequest->new(
         context => $list,
         action  => 'subscribe',
-        sender  => $email,
+        sender  => $sender,
         email   => $email,
         gecos   => $gecos,
         (   $in{'custom_attribute'}
@@ -5799,7 +5801,7 @@ sub do_subscribe {
             : ()
         ),
         scenario_context => {
-            sender      => $email,
+            sender      => $sender,
             remote_host => $param->{'remote_host'},
             remote_addr => $param->{'remote_addr'},
         },
@@ -5812,12 +5814,6 @@ sub do_subscribe {
     foreach my $report (@{$spindle->{stash} || []}) {
         if ($report->[1] eq 'notice') {
             Sympa::WWW::Report::notice_report_web(@{$report}[2, 3],
-                $param->{'action'});
-        } elsif ($report->[1] eq 'user'
-            and $report->[2] eq 'already_subscriber') {
-            # To prevent sniffing users, fake "You requested a subscription"
-            # notice.
-            Sympa::WWW::Report::notice_report_web('sent_to_user', {},
                 $param->{'action'});
         } else {
             Sympa::WWW::Report::reject_report_web(@{$report}[1 .. 3],
@@ -5921,10 +5917,10 @@ sub do_auto_signoff {
     my $spindle = Sympa::Spindle::ProcessRequest->new(
         context => $list,
         action  => 'signoff',
-        sender  => $email,
+        sender  => 'nobody',
         email   => $email,
         scenario_context => {
-            sender      => $email,
+            sender      => 'nobody',
             remote_host => $param->{'remote_host'},
             remote_addr => $param->{'remote_addr'},
         },
@@ -5937,13 +5933,6 @@ sub do_auto_signoff {
     foreach my $report (@{$spindle->{stash} || []}) {
         if ($report->[1] eq 'notice') {
             Sympa::WWW::Report::notice_report_web(@{$report}[2, 3],
-                $param->{'action'});
-        } elsif ($report->[1] eq 'user'
-            and grep { $report->[2] eq $_ }
-            qw(user_not_subscriber not_subscriber)) {
-            # To prevent sniffing users, fake "We've sent validation link"
-            # notice.
-            Sympa::WWW::Report::notice_report_web('sent_to_user', {},
                 $param->{'action'});
         } else {
             Sympa::WWW::Report::reject_report_web(@{$report}[1 .. 3],
@@ -6018,12 +6007,14 @@ sub do_signoff {
         return 1;
     }
 
-    my $email;
+    my ($sender, $email);
     if ($param->{'user'} and $param->{'user'}{'email'}) {
-        $email = $param->{'user'}{'email'};
+        $sender = $param->{'user'}{'email'};
+        $email  = $param->{'user'}{'email'};
     } else {
         # User is not autenticated.
-        $email = Sympa::Tools::Text::canonic_email($in{'email'});
+        $sender = 'nobody';
+        $email  = Sympa::Tools::Text::canonic_email($in{'email'});
     }
 
     $param->{email} = $email;
@@ -6043,14 +6034,14 @@ sub do_signoff {
     my $spindle = Sympa::Spindle::ProcessRequest->new(
         context => $list,
         action  => 'signoff',
-        sender  => $email,
+        sender  => $sender,
         email   => $email,
         (   $param->{'user'}{'email'}
             ? (md5_check => 1)
             : ()
         ),
         scenario_context => {
-            sender      => $email,
+            sender      => $sender,
             remote_host => $param->{'remote_host'},
             remote_addr => $param->{'remote_addr'},
         },
@@ -6063,13 +6054,6 @@ sub do_signoff {
     foreach my $report (@{$spindle->{stash} || []}) {
         if ($report->[1] eq 'notice') {
             Sympa::WWW::Report::notice_report_web(@{$report}[2, 3],
-                $param->{'action'});
-        } elsif ($report->[1] eq 'user'
-            and grep { $report->[2] eq $_ }
-            qw(user_not_subscriber not_subscriber)) {
-            # To prevent sniffing users, fake "We've sent validation link"
-            # notice.
-            Sympa::WWW::Report::notice_report_web('sent_to_user', {},
                 $param->{'action'});
         } else {
             Sympa::WWW::Report::reject_report_web(@{$report}[1 .. 3],


### PR DESCRIPTION
- [feature] When an other user (or anonymous user on web interface) requested subscribing/unsubscribing, if target user already subscribed / not yet subscribed to the list, they will be informed someone requested action while no actions will be taken.  Also, fake response will be sent to requester to prevent sniffing users.
- [change] Update subscribe.* and unsubscribe.* scenarios: Now authentication by target user is required when anonymous/other user requested these actions.  Previously, if "open" scenario was used, an anonymous user on web interface could add subscriber without confirmation.

This may fix issue #386.
This is not applicable to Sympa 6.2.24 and earlier (due to changes of module names).
