### PR TITLE
Avoid rehashing user password hashes in {add,update}_global_user()

### DIFF
--- a/src/lib/Sympa/User.pm
+++ b/src/lib/Sympa/User.pm
@@ -642,9 +642,17 @@ sub update_global_user {
 
     ## use hash fingerprint to store password
     ## hashes that use salts will randomly generate one
-    $values->{'password'} =
-        Sympa::User::password_fingerprint($values->{'password'}, undef)
-        if ($values->{'password'});
+    ## avoid rehashing passwords that are already hash strings
+    if ($values->{'password'}) {
+        if (defined(hash_type($values->{'password'}))) {
+            $log->syslog('debug',
+                         'password is in %s format, not rehashing',
+                         hash_type($values->{'password'}));
+        } else {
+            $values->{'password'} =
+                Sympa::User::password_fingerprint($values->{'password'}, undef);
+        }
+    }
 
     ## Canonicalize lang if possible.
     $values->{'lang'} = Sympa::Language::canonic_lang($values->{'lang'})
@@ -722,9 +730,17 @@ sub add_global_user {
 
     ## encrypt password with the configured password hash algorithm
     ## an salt of 'undef' means generate a new random one
-    $values->{'password'} =
-        Sympa::User::password_fingerprint($values->{'password'}, undef)
-        if ($values->{'password'});
+    ## avoid rehashing passwords that are already hash strings
+    if ($values->{'password'}) {
+        if (defined(hash_type($values->{'password'}))) {
+            $log->syslog('debug',
+                         'password is in %s format, not rehashing',
+                         hash_type($values->{'password'}));
+        } else {
+            $values->{'password'} =
+                Sympa::User::password_fingerprint($values->{'password'}, undef);
+        }
+    }
 
     ## Canonicalize lang if possible
     $values->{'lang'} = Sympa::Language::canonic_lang($values->{'lang'})


### PR DESCRIPTION
In 6.2.32 and 6.2.34, our testing shows that using the GUI to add an existing address to a list causes the user's current password hash to be rehashed and stored. This renders the user's password unusable and effectively forces a password reset sequence. The behavior seems to correspond with the spontaneous password reinitialization problem discussed in #269. 

This targeted fix uses `hash_type()` to detect password hashes and avoid rehashing them. For the sake of consistent behavior, both `update_global_user()` and `add_global_user()` are updated.

The change does not address all of the design concerns of #269 but in our testing it does prevent the seemingly spontaneous password resets caused by being added to a list using the GUI.
