### PR TITLE
Accept multiple attributes in include_ldap_ca.attrs

### DIFF
--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -1781,7 +1781,9 @@ our %pinfo = (
             'attrs' => {
                 'order'      => 8,
                 'gettext_id' => "extracted attribute",
-                'format'     => Sympa::Regexps::ldap_attrdesc(),
+                'format'     => Sympa::Regexps::ldap_attrdesc()
+                    . '(\s*,\s*'
+                    . Sympa::Regexps::ldap_attrdesc() . ')?',
                 'default'    => 'mail',
                 'length'     => 15
             },


### PR DESCRIPTION
To work propertly the include_ldap_ca source need to retrieve at least two attributes: the one specified in email_entry and the one you want to use to match with your custom attribute.