### PR TITLE
Let the default of `--with-lockdir` be `/var/lock/subsys` always

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ if test "$fhs" = "yes"; then
     unitsdir=
     smrshdir=$sysconfdir/smrsh
     piddir=$localstatedir/run/sympa
-    lockdir=$localstatedir/lock/subsys
+    lockdir=/var/lock/subsys
     modulesdir=$datadir/sympa/lib
     scriptdir=$datadir/sympa/bin
     defaultdir=$datadir/sympa/default
@@ -88,7 +88,7 @@ else
     unitsdir=
     smrshdir=/etc/smrsh
     piddir=$prefix
-    lockdir=$localstatedir/lock/subsys
+    lockdir=/var/lock/subsys
     modulesdir=$prefix/bin
     scriptdir=$prefix/bin
     defaultdir=$prefix/default
@@ -275,7 +275,7 @@ AC_ARG_WITH(
     lockdir,
     AS_HELP_STRING(
 	[--with-lockdir=DIR],
-	[lock files @<:@LOCALSTATEDIR/lock/subsys@:>@]
+	[lock files @<:@/var/lock/subsys@:>@]
     ),
     [lockdir="$withval"]
 )


### PR DESCRIPTION
This directory was originally prepared for [upstart](http://upstart.ubuntu.com/) which has been adopted by Fedora/RHEL, Debian/Ubuntu etc. (On Systemd, this directory is included in `tmpfiles.d/legacy.conf` for compatibility with "legacy" systems).

Thus, I believe the default value of this option should not depend on `--prefix` option of each application.

See also issue #274.
