### PR TITLE
Update startup scripts

### DIFF
--- a/src/etc/script/Makefile.am
+++ b/src/etc/script/Makefile.am
@@ -35,8 +35,8 @@ units_DATA = \
 	sympa-task.service \
 	sympa.service
 noinst_DATA = \
-	nginx-sympasoap.service \
-	nginx-wwsympa.service \
+	sympasoap.service \
+	wwsympa.service \
 	sympa-tmpfiles.conf
 endif
 
@@ -47,8 +47,8 @@ EXTRA_DIST = \
 	sympa-outgoing.servicein \
 	sympa-task.servicein \
 	sympa.servicein \
-	nginx-sympasoap.servicein \
-	nginx-wwsympa.servicein \
+	sympasoap.servicein \
+	wwsympa.servicein \
 	sympa-tmpfiles.confin
 
 CLEANFILES = $(init_SCRIPTS) $(units_DATA) $(noinst_DATA)

--- a/src/etc/script/Makefile.am
+++ b/src/etc/script/Makefile.am
@@ -57,7 +57,6 @@ sympa: sympa.in Makefile
 	@rm -f $@
 	$(AM_V_GEN)$(SED) \
 		-e 's|--CONFIG--|$(CONFIG)|' \
-		-e 's|--WWSCONFIG--|$(WWSCONFIG)|' \
 		-e 's|--sbindir--|$(sbindir)|' \
 		-e 's|--initdir--|$(initdir)|' \
 		-e 's|--piddir--|$(piddir)|' \

--- a/src/etc/script/sympa.servicein
+++ b/src/etc/script/sympa.servicein
@@ -13,6 +13,8 @@ Before=sympa-task.service
 [Service]
 Type=forking
 PIDFile=--piddir--/sympa_msg.pid
+ExecStartPre=/bin/mkdir -p --piddir--
+ExecStartPre=/bin/chown --USER--:--GROUP-- --piddir--
 ExecStartPre=--sbindir--/sympa.pl --health_check
 ExecStart=--sbindir--/sympa_msg.pl
  

--- a/src/etc/script/sympasoap.servicein
+++ b/src/etc/script/sympasoap.servicein
@@ -1,21 +1,21 @@
 [Unit]
-Description=WWSympa - Web interface for Sympa mailing list manager
+Description=SympaSOAP - SOAP interface for Sympa mailing list manager
 After=syslog.target
 BindTo=sympa.service
  
 [Service]
 Type=forking
-PIDFile=--piddir--/wwsympa.pid
+PIDFile=--piddir--/sympasoap.pid
 ExecStart=/usr/bin/spawn-fcgi -F $FCGI_CHILDREN \
-    -P --piddir--/wwsympa.pid \
+    -P --piddir--/sympasoap.pid \
+    -s --piddir--/sympasoap.socket \
     -u $FCGI_USER -g $FCGI_GROUP $FCGI_OPTS -- \
-    --execcgidir--/wwsympa.fcgi
+    --execcgidir--/sympa_soap_server.fcgi
 Environment="FCGI_CHILDREN=5"
 Environment="FCGI_USER=--USER--"
 Environment="FCGI_GROUP=--GROUP--"
-Environment="FCGI_OPTS=-s --piddir--/wwsympa.socket -M 0600 -U nginx"
+Environment="FCGI_OPTS=-M 0600 -U nginx"
 EnvironmentFile=-/etc/sysconfig/sympa
-Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/src/etc/script/wwsympa.servicein
+++ b/src/etc/script/wwsympa.servicein
@@ -1,20 +1,22 @@
 [Unit]
-Description=SympaSOAP - SOAP interface for Sympa mailing list manager
+Description=WWSympa - Web interface for Sympa mailing list manager
 After=syslog.target
 BindTo=sympa.service
  
 [Service]
 Type=forking
-PIDFile=--piddir--/sympasoap.pid
+PIDFile=--piddir--/wwsympa.pid
 ExecStart=/usr/bin/spawn-fcgi -F $FCGI_CHILDREN \
-    -P --piddir--/sympasoap.pid \
+    -P --piddir--/wwsympa.pid \
+    -s --piddir--/wwsympa.socket \
     -u $FCGI_USER -g $FCGI_GROUP $FCGI_OPTS -- \
-    --execcgidir--/sympa_soap_server.fcgi
+    --execcgidir--/wwsympa.fcgi
 Environment="FCGI_CHILDREN=5"
 Environment="FCGI_USER=--USER--"
 Environment="FCGI_GROUP=--GROUP--"
-Environment="FCGI_OPTS=-s --piddir--/sympasoap.socket -M 0600 -U nginx"
+Environment="FCGI_OPTS=-M 0600 -U nginx"
 EnvironmentFile=-/etc/sysconfig/sympa
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- [bug] Systemd: PIDDIR may not exist at startup. Fixed by creating it with `sympa.service`.
- [-change] Rename `nginx-wwsympa.service` and `nginx-sympasoap.service` files to `wwsympa.service` and `sympasoap.service`: They may be used by other httpd.
