### PR TITLE
edit_list: Paragraph including obsoleted sub-parameter is ignored #412

### DIFF
--- a/src/lib/Sympa/Config.pm
+++ b/src/lib/Sympa/Config.pm
@@ -528,7 +528,8 @@ sub _sanitize_changes_paragraph {
     # the whole parameter instance is removed.
     return (_pname($ppaths) => undef)
         if grep {
-        $pitem->{format}->{$_}->{occurrence} =~ /^1/
+                not $pitem->{format}->{$_}->{obsolete}
+            and $pitem->{format}->{$_}->{occurrence} =~ /^1/
             and not defined $cur->{$_}
         } _keys($pitem->{format});
     # If all children are removed, remove parent.

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -8170,6 +8170,7 @@ sub _save_list_param {
 
             } elsif (($pinfo->{$key}{'file_format'}{$k}{'occurrence'} =~ /n$/)
                 && $pinfo->{$key}{'file_format'}{$k}{'split_char'}) {
+                next unless $p->{$k} and @{$p->{$k}};
 
                 $fd->print(
                     sprintf "%s %s\n",


### PR DESCRIPTION
Edit list page omits paragraph including a sub-parameter which is obsoleted (deprecated or unimplemented) _and_ mandatory (occurrence is `1` or `1-n`).

Currently, `dkim_parameters.header_list` corresponds: In this case whole of `dkim_parameters` paragraph cannot be saved by web interface (see [code](https://github.com/sympa-community/sympa/blob/6.2.34/src/lib/Sympa/ListDef.pm#L2104-L2115)).

This PR may fix issue #412.
