### PR TITLE
Formally drop support for Sybase

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -232,9 +232,9 @@ feature 'sqlite', 'SQLite database driver, required if you connect to a SQLite d
     requires 'DBD::SQLite', '>= 1.31';
 };
 
-feature 'sybase', 'Sybase database driver, required if you connect to a Sybase database.' => sub {
-    requires 'DBD::Sybase', '>= 0.90';
-};
+#feature 'sybase', 'Sybase database driver, required if you connect to a Sybase database.' => sub {
+#    requires 'DBD::Sybase', '>= 0.90';
+#};
 
 feature 'mysql', 'MySQL / MariaDB database driver, required if you connect to a MySQL (or MariaDB) database.' => sub {
     # mysql-devel and myslq-server. MySQL (or MariaDB) server should be running for make test to succeed

--- a/po/sympa/es.po
+++ b/po/sympa/es.po
@@ -895,6 +895,10 @@ msgstr ""
 "Los tipos posibles son \"MySQL\", \"PostgreSQL\", \"Oracle\", \"Sybase\" y "
 "\"SQLite\"."
 
+#: src/lib/Sympa/ConfDef.pm:116
+msgid "Possible types are \"MySQL\", \"PostgreSQL\", \"Oracle\" and \"SQLite\"."
+msgstr "Los tipos posibles son \"MySQL\", \"PostgreSQL\", \"Oracle\" y \"SQLite\"."
+
 #: src/lib/Sympa/ConfDef.pm:123
 msgid "Hostname of the database server"
 msgstr "Nombre del servidor de bases de datos"
@@ -2677,6 +2681,10 @@ msgstr ""
 "(DBD): DBD-CSV, DBD-mysql, DBD-ODBC, DBD-Oracle, DBD-Pg, DBD-SQLite, DBD-"
 "Sybase y/o Net-LDAP. Y también, si necesitas conexión segura (LDAPS) al "
 "servidor LDAP: IO-Socket-SSL."
+
+#: src/lib/Sympa/ConfDef.pm:1784
+msgid "Including subscribers, owners and moderators from data sources. Appropriate database driver (DBD) modules are required: DBD-CSV, DBD-mysql, DBD-ODBC, DBD-Oracle, DBD-Pg, DBD-SQLite and/or Net-LDAP. And also, if secure connection (LDAPS) to LDAP server is required: IO-Socket-SSL."
+msgstr "Inclusión de suscriptores, propietarios y moderadores desde fuentes de datos. Se necesitan los módulos de control de base de datos apropiados (DBD): DBD-CSV, DBD-mysql, DBD-ODBC, DBD-Oracle, DBD-Pg, DBD-SQLite y/o Net-LDAP. Y también, si necesitas conexión segura (LDAPS) al servidor LDAP: IO-Socket-SSL."
 
 #: src/lib/Sympa/ConfDef.pm:1788
 msgid "Default of SQL fetch timeout"

--- a/po/sympa/fr.po
+++ b/po/sympa/fr.po
@@ -825,6 +825,10 @@ msgstr ""
 "Les types de bases de données supportées sont : \"MySQL\", \"PostgreSQL\", "
 "\"Oracle\", \"Sybase\" et \"SQLite\"."
 
+#: src/lib/Sympa/ConfDef.pm:116
+msgid "Possible types are \"MySQL\", \"PostgreSQL\", \"Oracle\" and \"SQLite\"."
+msgstr "Les types de bases de données supportées sont : \"MySQL\", \"PostgreSQL\", \"Oracle\" et \"SQLite\"."
+
 #: src/lib/Sympa/ConfDef.pm:123
 msgid "Hostname of the database server"
 msgstr "Nom du serveur de la base de données"

--- a/po/sympa/gl.po
+++ b/po/sympa/gl.po
@@ -880,6 +880,10 @@ msgstr ""
 "Los tipos posibles son \"MySQL\", \"PostgreSQL\", \"Oracle\", \"Sybase\" y "
 "\"SQLite\"."
 
+#: src/lib/Sympa/ConfDef.pm:116
+msgid "Possible types are \"MySQL\", \"PostgreSQL\", \"Oracle\" and \"SQLite\"."
+msgstr "Los tipos posibles son \"MySQL\", \"PostgreSQL\", \"Oracle\" y \"SQLite\"."
+
 #: src/lib/Sympa/ConfDef.pm:123
 msgid "Hostname of the database server"
 msgstr "Nombre del servidor de bases de datos"
@@ -2660,6 +2664,10 @@ msgstr ""
 "(DBD): DBD-CSV, DBD-mysql, DBD-ODBC, DBD-Oracle, DBD-Pg, DBD-SQLite, DBD-"
 "Sybase y/o Net-LDAP. Y también, si necesitas conexión segura (LDAPS) al "
 "servidor LDAP: IO-Socket-SSL."
+
+#: src/lib/Sympa/ConfDef.pm:1784
+msgid "Including subscribers, owners and moderators from data sources. Appropriate database driver (DBD) modules are required: DBD-CSV, DBD-mysql, DBD-ODBC, DBD-Oracle, DBD-Pg, DBD-SQLite and/or Net-LDAP. And also, if secure connection (LDAPS) to LDAP server is required: IO-Socket-SSL."
+msgstr "Inclusión de suscriptores, propietarios y moderadores desde fuentes de datos. Se necesitan los módulos de control de base de datos apropiados (DBD): DBD-CSV, DBD-mysql, DBD-ODBC, DBD-Oracle, DBD-Pg, DBD-SQLite y/o Net-LDAP. Y también, si necesitas conexión segura (LDAPS) al servidor LDAP: IO-Socket-SSL."
 
 #: src/lib/Sympa/ConfDef.pm:1788
 msgid "Default of SQL fetch timeout"

--- a/src/bin/Makefile.am
+++ b/src/bin/Makefile.am
@@ -6,6 +6,9 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
+# Copyright 2018 The Sympa Community. See the AUTHORS.md file at the
+# top-level directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,9 +22,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-dbscripts = \
-	create_db.Sybase
 
 perlscripts = \
 	arc2webarc.pl \
@@ -37,7 +37,7 @@ perlscripts = \
 	upgrade_shared_repository.pl \
 	upgrade_sympa_password.pl
 
-script_SCRIPTS = $(dbscripts) $(perlscripts)
+script_SCRIPTS = $(perlscripts)
 
 man1_MANS = \
 	mod2html.1 \
@@ -47,7 +47,7 @@ man1_MANS = \
 	upgrade_shared_repository.1 \
 	upgrade_sympa_password.1
 
-EXTRA_DIST = $(dbscripts) \
+EXTRA_DIST = \
 	arc2webarc.pl.in \
 	init_comment.pl.in \
 	mod2html.pl.in \

--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -1316,14 +1316,15 @@ sub load_sql_filter {
         'sql_named_filter_query' => {
             'occurrence' => '1',
             'format'     => {
-                'db_type'   => {'format' => 'mysql|SQLite|Pg|Oracle|Sybase',},
-                'db_name'   => {'format' => '.*', 'occurrence' => '1',},
-                'db_host'   => {'format' => '.*', 'occurrence' => '1',},
-                'statement' => {'format' => '.*', 'occurrence' => '1',},
-                'db_user'   => {'format' => '.*', 'occurrence' => '0-1',},
-                'db_passwd' => {'format' => '.*', 'occurrence' => '0-1',},
-                'db_options' => {'format' => '.*', 'occurrence' => '0-1',},
-                'db_env'     => {'format' => '.*', 'occurrence' => '0-1',},
+                'db_type' =>
+                    {'format' => 'mysql|MySQL|Oracle|Pg|PostgreSQL|SQLite',},
+                'db_name'    => {'format' => '.*',  'occurrence' => '1',},
+                'db_host'    => {'format' => '.*',  'occurrence' => '1',},
+                'statement'  => {'format' => '.*',  'occurrence' => '1',},
+                'db_user'    => {'format' => '.*',  'occurrence' => '0-1',},
+                'db_passwd'  => {'format' => '.*',  'occurrence' => '0-1',},
+                'db_options' => {'format' => '.*',  'occurrence' => '0-1',},
+                'db_env'     => {'format' => '.*',  'occurrence' => '0-1',},
                 'db_port'    => {'format' => '\d+', 'occurrence' => '0-1',},
                 'db_timeout' => {'format' => '\d+', 'occurrence' => '0-1',},
             }

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -54,7 +54,6 @@ nobase_modules_DATA = \
 	Sympa/DatabaseDriver/Oracle/St.pm \
 	Sympa/DatabaseDriver/PostgreSQL.pm \
 	Sympa/DatabaseDriver/SQLite.pm \
-	Sympa/DatabaseDriver/Sybase.pm \
 	Sympa/DatabaseManager.pm \
 	Sympa/Datasource.pm \
 	Sympa/Family.pm \

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -113,7 +113,7 @@ our @params = (
         'default'    => 'mysql',
         'gettext_id' => 'Type of the database',
         'gettext_comment' =>
-            'Possible types are "MySQL", "PostgreSQL", "Oracle", "Sybase" and "SQLite".',
+            'Possible types are "MySQL", "PostgreSQL", "Oracle" and "SQLite".',
         'file' => 'sympa.conf',
         'edit' => '1',
     },
@@ -1781,7 +1781,7 @@ our @params = (
 
     {   'gettext_id' => 'Data sources setup',
         'gettext_comment' =>
-            'Including subscribers, owners and moderators from data sources. Appropriate database driver (DBD) modules are required: DBD-CSV, DBD-mysql, DBD-ODBC, DBD-Oracle, DBD-Pg, DBD-SQLite, DBD-Sybase and/or Net-LDAP. And also, if secure connection (LDAPS) to LDAP server is required: IO-Socket-SSL.',
+            'Including subscribers, owners and moderators from data sources. Appropriate database driver (DBD) modules are required: DBD-CSV, DBD-mysql, DBD-ODBC, DBD-Oracle, DBD-Pg, DBD-SQLite and/or Net-LDAP. And also, if secure connection (LDAPS) to LDAP server is required: IO-Socket-SSL.',
     },
 
     {   'name'       => 'default_sql_fetch_timeout',

--- a/src/sbin/sympa_wizard.pl.in
+++ b/src/sbin/sympa_wizard.pl.in
@@ -471,7 +471,6 @@ Press the Enter key to continue..."
             'PostgreSQL'    => 'DBD::Pg',
             'SQLite'        => 'DBD::SQLite',
             'Oracle'        => 'DBD::Oracle',
-            'Sybase'        => 'DBD::Sybase',
         );
         my $selected;
         while (1) {


### PR DESCRIPTION
I hear there are no users using Sybase (Adaptive Server Enterprise).  This PR will drop support for it.
This may close issue #147.