### PR TITLE
split the test in separated ones

### DIFF
--- a/src/lib/Sympa/Bulk.pm
+++ b/src/lib/Sympa/Bulk.pm
@@ -79,19 +79,27 @@ sub _create_spool {
         $self->{pct_directory},     $self->{bad_directory},
         $self->{bad_msg_directory}, $self->{bad_pct_directory}
     ) {
-        unless (-d $directory) {
-            $log->syslog('info', 'Creating spool %s', $directory);
-            unless (
-                mkdir($directory, 0755)
-                and Sympa::Tools::File::set_file_rights(
-                    file  => $directory,
-                    user  => Sympa::Constants::USER(),
-                    group => Sympa::Constants::GROUP()
-                )
-            ) {
-                die sprintf 'Cannot create %s: %s', $directory, $ERRNO;
-            }
-        }
+
+        next if -d $directory;
+
+        $log->syslog('info', 'Creating spool %s', $directory);
+
+        mkdir $directory, 0755
+            or die "Cannot create $directory: $ERRNO";
+
+        Sympa::Tools::File::set_file_rights(
+            file  => $directory,
+            user  => Sympa::Constants::USER,
+            group => Sympa::Constants::GROUP,
+        ) or die sprintf (
+            'Cannot change ownership of %s to %s:%s : %s',
+            $directory,
+            Sympa::Constants::USER,
+            Sympa::Constants::GROUP,
+            $ERRNO,
+        );
+
+
     }
     umask $umask;
 }


### PR DESCRIPTION
the previous message was unclear: you didn't know if it failed to create
the directory or to apply the ownership.

i split the test to be able to write a more informative message.