### PR TITLE
add create_dir and use it in Bulk to make error messages more useful

### DIFF
--- a/src/lib/Sympa/Bulk.pm
+++ b/src/lib/Sympa/Bulk.pm
@@ -74,25 +74,17 @@ sub _create_spool {
     my $self = shift;
 
     my $umask = umask oct $Conf::Conf{'umask'};
-    foreach my $directory (
-        $Conf::Conf{queuebulk},     $self->{msg_directory},
-        $self->{pct_directory},     $self->{bad_directory},
-        $self->{bad_msg_directory}, $self->{bad_pct_directory}
-    ) {
-        unless (-d $directory) {
-            $log->syslog('info', 'Creating spool %s', $directory);
-            unless (
-                mkdir($directory, 0755)
-                and Sympa::Tools::File::set_file_rights(
-                    file  => $directory,
-                    user  => Sympa::Constants::USER(),
-                    group => Sympa::Constants::GROUP()
-                )
-            ) {
-                die sprintf 'Cannot create %s: %s', $directory, $ERRNO;
-            }
-        }
+
+    for my $directory (
+        $Conf::Conf{queuebulk}, @$self{qw(
+            msg_directory pct_directory
+            bad_directory bad_msg_directory bad_pct_directory
+        )}
+    ) { next if -d $directory;
+        $log->syslog('info', 'Creating spool %s', $directory);
+        Sympa::Tools::File::create_dir $directory;
     }
+
     umask $umask;
 }
 

--- a/src/lib/Sympa/Tools/File.pm
+++ b/src/lib/Sympa/Tools/File.pm
@@ -98,6 +98,29 @@ sub del_dir {
     }
 }
 
+sub create_dir {
+
+    my ( $directory ) = @_ ? @_ : $_;
+
+    mkdir $directory, 0755
+        or die "Cannot create $directory: $ERRNO";
+
+    Sympa::Tools::File::set_file_rights(
+        file  => $directory,
+        user  => Sympa::Constants::USER,
+        group => Sympa::Constants::GROUP,
+    ) or die sprintf (
+        'Cannot change ownership of %s to %s:%s : %s',
+        $directory,
+        Sympa::Constants::USER,
+        Sympa::Constants::GROUP,
+        $ERRNO,
+    );
+
+}
+
+
+
 sub mk_parent_dir {
     my $file = shift;
     $file =~ /^(.*)\/([^\/])*$/;
@@ -273,6 +296,21 @@ If superuser was specified as owner, this function will die.
 =item copy_dir($dir1, $dir2)
 
 Copy a directory and its content
+
+=item create_dir | create_dir $path
+
+mkdir the C<$path> ($_ by default) with the mode 0755 then change the ownership
+set to Sympa::Constants::USER and Sympa::Constants::GROUP.
+
+returns the value of Sympa::Tools::File::set_file_rights.
+
+equivalent to the unix command
+
+    # when
+    # $user  = Sympa::Constants::USER
+    # $group = Sympa::Constants::GROUP
+
+    install -m0755 -o$user -g $group -d $path
 
 =item del_dir($dir)
 

--- a/t/lib/Sympa/Constants.pm
+++ b/t/lib/Sympa/Constants.pm
@@ -1,0 +1,73 @@
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+# $Id$
+
+# Sympa - SYsteme de Multi-Postage Automatique
+#
+# Copyright (c) 1997, 1998, 1999 Institut Pasteur & Christophe Wolfhugel
+# Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
+# 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
+# Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
+# Copyright 2018 The Sympa Community. See the AUTHORS.md file at the
+# top-level directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package Sympa::Constants;
+use English;
+
+use constant VERSION => '7.0' ;
+use constant USER    => (getpwuid $UID)[0];
+use constant GROUP   => (getgrgid $GID)[0];
+use constant CONFIG           => 't/data/sympa.conf' ;
+use constant WWSCONFIG        => 't/data/wwsympa.conf' ;
+use constant SENDMAIL_ALIASES => 't/tmp/sympa_aliases' ;
+
+use constant PIDDIR      => 't/tmp/piddir' ;
+use constant EXPLDIR     => 't/tmp/expldir' ;
+use constant SPOOLDIR    => 't/tmp/spooldir' ;
+use constant SYSCONFDIR  => 't/tmp/sysconfdir' ;
+use constant LOCALEDIR   => 't/tmp/localedir' ;
+use constant LIBEXECDIR  => 't/tmp/libexecdir' ;
+use constant SBINDIR     => 't/tmp/sbindir' ;
+use constant SCRIPTDIR   => 't/tmp/scriptdir' ;
+use constant MODULEDIR   => 't/tmp/moduledir' ;
+use constant DEFAULTDIR  => 't/tmp/defaultdir' ;
+use constant ARCDIR      => 't/tmp/arcdir' ;
+use constant BOUNCEDIR   => 't/tmp/bouncedir' ;
+use constant EXECCGIDIR  => 't/tmp/execcgidir' ;
+use constant STATICDIR   => 't/tmp/staticdir' ;
+use constant CSSDIR      => 't/tmp/cssdir' ;
+use constant PICTURESDIR => 't/tmp/picturesdir' ;
+
+use constant EMAIL_LEN  => 100;
+use constant FAMILY_LEN => 50;
+use constant LIST_LEN   => 50;
+use constant ROBOT_LEN  => 80;
+ 
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Sympa::Constants - Definition of constants
+
+=head1 DESCRIPTION
+
+This module keeps definition of constants used by Sympa software.
+
+=cut

--- a/t/tmp/readme
+++ b/t/tmp/readme
@@ -1,0 +1,4 @@
+this directory must exist for the purposes
+of t/tools_file.t.
+
+t/tools_bulk.t will use also use it.


### PR DESCRIPTION
when a bulk can't make its tree, there was no way to know if the
directory wasn't created or it it failed to get the good rights.

create_dir have error messages for both cases. Bulk.pm now benefit
of it.

related to #423 and #425