### PR TITLE
CSS cannot be updated if css.tt2 was older than previously generated CSS.

### DIFF
--- a/src/lib/Sympa/WWW/Tools.pm
+++ b/src/lib/Sympa/WWW/Tools.pm
@@ -790,7 +790,7 @@ sub _get_css_url {
         } elsif (
             (exists $hash{$lang || '_main'})
             ? ($hash{$lang || '_main'} eq $hash)
-            : ($template_mtime < Sympa::Tools::File::get_mtime($path))
+            : ($template_mtime == Sympa::Tools::File::get_mtime($path))
         ) {
             return ($url, $hash);
         }
@@ -894,6 +894,8 @@ sub _get_css_url {
 
         return;
     }
+    # Set mtime of source template to detect update of it.
+    utime $template_mtime, $template_mtime, $path;
 
     return ($url, $hash);
 }


### PR DESCRIPTION
Timestamp of css.tt2 is not always increased by each new installation: It can be decreased.

Fixed by copying timestamp of original css.tt2 to generated CSS.
