### PR TITLE
Add support for TLSv1.3

### DIFF
--- a/src/bin/sympa_test_ldap.pl.in
+++ b/src/bin/sympa_test_ldap.pl.in
@@ -142,7 +142,7 @@ sympa_test_ldap, sympa_test_ldap.pl - Testing LDAP connection for Sympa
     [ --ca_file=string ] [ --ca_path=string ]
     [ --ca_verify=none|optional|require ]
     [ --ssl_cert=string ] [ --ssl_ciphers=string ] [ --ssl_key=string ]
-    [ --ssl_version=sslv2|sslv3|tlsv1|tlsv1_1|tlsv1_2 ] ]
+    [ --ssl_version=sslv2|sslv3|tlsv1|tlsv1_1|tlsv1_2|tlsv1_3 ] ]
 
   sympa_test_ldap.pl --help
 

--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -944,7 +944,7 @@ sub _load_auth {
             'use_tls'                 => 'starttls|ldaps|none',
             'use_ssl'                 => '1',                     # Obsoleted
             'use_start_tls'           => '1',                     # Obsoleted
-            'ssl_version' => 'sslv2/3|sslv2|sslv3|tlsv1|tlsv1_1|tlsv1_2',
+            'ssl_version' => 'sslv2/3|sslv2|sslv3|tlsv1|tlsv1_[123]',
             'ssl_ciphers' => '[\w:]+',
             'ssl_cert'    => '.+',
             'ssl_key'     => '.+',
@@ -980,7 +980,7 @@ sub _load_auth {
             'use_tls'                 => 'starttls|ldaps|none',
             'use_ssl'       => '1',    # Obsoleted
             'use_start_tls' => '1',    # Obsoleted
-            'ssl_version' => 'sslv2/3|sslv2|sslv3|tlsv1|tlsv1_1|tlsv1_2',
+            'ssl_version' => 'sslv2/3|sslv2|sslv3|tlsv1|tlsv1_[123]',
             'ssl_ciphers' => '[\w:]+',
             'ssl_cert'    => '.+',
             'ssl_key'     => '.+',
@@ -1007,7 +1007,7 @@ sub _load_auth {
             'use_tls'                 => 'starttls|ldaps|none',
             'use_ssl'       => '1',    # Obsoleted
             'use_start_tls' => '1',    # Obsoleted
-            'ssl_version' => 'sslv2/3|sslv2|sslv3|tlsv1|tlsv1_1|tlsv1_2',
+            'ssl_version' => 'sslv2/3|sslv2|sslv3|tlsv1|tlsv1_[123]',
             'ssl_ciphers' => '[\w:]+',
             'ssl_cert'    => '.+',
             'ssl_key'     => '.+',

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -1263,7 +1263,7 @@ our %pinfo = (
             'ssl_version' => {
                 'order'      => 2.6,
                 'gettext_id' => 'SSL version',
-                'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
+                'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2', 'tlsv1_3'],
                 'synonym'    => {'tls' => 'tlsv1'},
                 'occurrence' => '1',
                 'default'    => 'tlsv1'
@@ -1389,7 +1389,7 @@ our %pinfo = (
             'ssl_version' => {
                 'order'      => 2.6,
                 'gettext_id' => 'SSL version',
-                'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
+                'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2', 'tlsv1_3'],
                 'synonym'    => {'tls' => 'tlsv1'},
                 'occurrence' => '1',
                 'default'    => 'tlsv1'
@@ -1705,7 +1705,7 @@ our %pinfo = (
             'ssl_version' => {
                 'order'      => 2.6,
                 'gettext_id' => 'SSL version',
-                'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
+                'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2', 'tlsv1_3'],
                 'synonym'    => {'tls' => 'tlsv1'},
                 'occurrence' => '1',
                 'default'    => 'tlsv1'
@@ -1835,7 +1835,7 @@ our %pinfo = (
             'ssl_version' => {
                 'order'      => 2.6,
                 'gettext_id' => 'SSL version',
-                'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2'],
+                'format' => ['sslv2', 'sslv3', 'tlsv1', 'tlsv1_1', 'tlsv1_2', 'tlsv1_3'],
                 'synonym'    => {'tls' => 'tlsv1'},
                 'occurrence' => '1',
                 'default'    => 'tlsv1'

--- a/src/lib/Sympa/ListOpt.pm
+++ b/src/lib/Sympa/ListOpt.pm
@@ -115,6 +115,7 @@ my %list_option = (
     'tlsv1'   => {'gettext_id' => 'TLS version 1'},
     'tlsv1_1' => {'gettext_id' => 'TLS version 1.1'},
     'tlsv1_2' => {'gettext_id' => 'TLS version 1.2'},
+    'tlsv1_3' => {'gettext_id' => 'TLS version 1.3'},
 
     # editor.reception, owner_include.reception, owner.reception,
     # editor_include.reception

--- a/src/libexec/ldap_alias_manager.pl.in
+++ b/src/libexec/ldap_alias_manager.pl.in
@@ -84,7 +84,7 @@ $ldap_mail_attribute = $ldap_params{'ldap_mail_attribute'}
 $ldap_ssl_version = lc($ldap_params{'ldap_ssl_version'} || '');
 unless ($ldap_ssl_version) {
     $ldap_ssl_version = $ldap_ssl ? 'tlsv1' : undef;
-} elsif ($ldap_ssl_version !~ /\A(sslv2|sslv3|tlsv1|tlsv1_1|tlsv1_2)\z/) {
+} elsif ($ldap_ssl_version !~ /\A(sslv2|sslv3|tlsv1|tlsv1_[123])\z/) {
     printf STDERR
         "Invalid parameter ldap_ssl_version in the config file %s\n",
         $manager_conf_file;


### PR DESCRIPTION
This PR may add support for TLSv1.3 (RFC8446) for LDAP-related functions of Sympa.

Change:
  - Corresponding parameters and command line arguments allow an additional option `tlsv1_3`.

Note:
  - Actual support needs following components:
      - OpenSSL library 1.1.1 or later
      - IO-Socket-SSL 2.060 or later
