### PR TITLE
family_exclusion field can break not_null constraint during upgrade #442

### DIFF
--- a/src/lib/Sympa/DatabaseManager.pm
+++ b/src/lib/Sympa/DatabaseManager.pm
@@ -473,6 +473,18 @@ sub _check_primary_key {
             } else {
                 return undef;
             }
+
+            # Fixup: At 6.2a.29 r7637, family_exclusion field became a part of
+            # primary key.  But it could contain NULL and may break not_null
+            # constraint.
+            if (grep { $_ eq 'family_exclusion' } @{$primary{$t}}) {
+                $sdm->do_query(
+                    q{UPDATE exclusion_table
+                      SET family_exclusion = ''
+                      WHERE family_exclusion IS NULL}
+                );
+            }
+
             ## Add primary key
             if (@{$primary{$t}}) {
                 $rep = undef;


### PR DESCRIPTION
At 6.2a.29 r7637, family_exclusion field became a part of primary key.  But it could contain NULL and may break not_null constraint during upgrade from earlier version.

Fixed by replacing NULL with '' before primary key will be added.

This PR may fix issue #442.
