### PR TITLE
Implementing expire_members task

### DIFF
--- a/default/Makefile.am
+++ b/default/Makefile.am
@@ -171,6 +171,12 @@ nobase_default_DATA = \
 	scenari/visibility.secret \
 	tasks/eval_bouncers.daily.task \
 	tasks/expire_bounce.daily.task \
+	tasks/expire_members.2month.task \
+	tasks/expire_members.3month.task \
+	tasks/expire_members.4month.task \
+	tasks/expire_members.6month.task \
+	tasks/expire_members.9month.task \
+	tasks/expire_members.yearly.task \
 	tasks/process_bouncers.weekly.task \
 	tasks/purge_logs_table.daily.task \
 	tasks/purge_one_time_ticket_table.daily.task \
@@ -332,6 +338,9 @@ nobase_default_DATA = \
 	mail_tt2/digest.tt2 \
 	mail_tt2/d_install_shared.tt2 \
 	mail_tt2/d_reject_shared.tt2 \
+	mail_tt2/expire_deletion.tt2 \
+	mail_tt2/expire_warning1.tt2 \
+	mail_tt2/expire_warning2.tt2 \
 	mail_tt2/get_archive.tt2 \
 	mail_tt2/global_remind.tt2 \
 	mail_tt2/helpfile.tt2 \

--- a/default/tasks/expire_members.2month.task
+++ b/default/tasks/expire_members.2month.task
@@ -12,6 +12,6 @@ next ([execution_date]+1w, STEP3)
 
 /STEP3
 @selection = select_subs (older ([creation_date]-2m))
-@deleted = delete (@selection)
+@deleted = delete_subs (@selection)
 send_msg (@deleted, expire_deletion)
 stop ()

--- a/default/tasks/expire_members.3month.task
+++ b/default/tasks/expire_members.3month.task
@@ -12,6 +12,6 @@ next ([execution_date]+1w, STEP3)
 
 /STEP3
 @selection = select_subs (older ([creation_date]-3m))
-@deleted = delete (@selection)
+@deleted = delete_subs (@selection)
 send_msg (@deleted, expire_deletion)
 stop ()

--- a/default/tasks/expire_members.4month.task
+++ b/default/tasks/expire_members.4month.task
@@ -12,6 +12,6 @@ next ([execution_date]+1w, STEP3)
 
 /STEP3
 @selection = select_subs (older ([creation_date]-4m))
-@deleted = delete (@selection)
+@deleted = delete_subs (@selection)
 send_msg (@deleted, expire_deletion)
 stop ()

--- a/default/tasks/expire_members.6month.task
+++ b/default/tasks/expire_members.6month.task
@@ -12,6 +12,6 @@ next ([execution_date]+1w, STEP3)
 
 /STEP3
 @selection = select_subs (older ([creation_date]-6m))
-@deleted = delete (@selection)
+@deleted = delete_subs (@selection)
 send_msg (@deleted, expire_deletion)
 stop ()

--- a/default/tasks/expire_members.9month.task
+++ b/default/tasks/expire_members.9month.task
@@ -12,6 +12,6 @@ next ([execution_date]+1w, STEP3)
 
 /STEP3
 @selection = select_subs (older ([creation_date]-9m))
-@deleted = delete (@selection)
+@deleted = delete_subs (@selection)
 send_msg (@deleted, expire_deletion)
 stop ()

--- a/default/tasks/expire_members.yearly.task
+++ b/default/tasks/expire_members.yearly.task
@@ -12,6 +12,6 @@ next ([execution_date]+1w, STEP3)
 
 /STEP3
 @selection = select_subs (older ([creation_date]-1y))
-@deleted = delete (@selection)
+@deleted = delete_subs (@selection)
 send_msg (@deleted, expire_deletion)
 stop ()

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2272,14 +2272,20 @@ our %pinfo = (
         'occurrence' => '0-n'
     },
 
+    # "expire" task has never been implemented and parameter was kept
+    # ineffective. To avoid unintentional execution of task with old setting,
+    # new parameter for "expire_members" should not be an alias of old one.
     'expire_task' => {
+        'obsolete' => 1,
+        'format'   => '.+',
+    },
+    'expire_members_task' => {
         order        => 90.05,
         'group'      => 'other',
         'gettext_id' => "Periodical subscription expiration task",
         'gettext_comment' =>
             "This parameter states which model is used to create an expire task. An expire task regularly checks the subscription or resubscription  date of subscribers and asks them to renew their subscription. If they don't they are deleted.",
-        'task'     => 'expire',
-        'obsolete' => 1,
+        'task' => 'expire_members',
     },
 
     'latest_instantiation' => {

--- a/src/lib/Sympa/Spindle/ProcessTask.pm
+++ b/src/lib/Sympa/Spindle/ProcessTask.pm
@@ -336,7 +336,6 @@ sub do_select_subs {
 }
 
 # Old name: delete_subs_cmd() in task_manager.pl.
-# Not yet used.
 sub do_delete_subs {
     my $self  = shift;
     my $task  = shift;

--- a/src/lib/Sympa/Task.pm
+++ b/src/lib/Sympa/Task.pm
@@ -43,9 +43,9 @@ my $log      = Sympa::Log->instance;
 
 # List of list task models. FIXME:Refer Sympa::ListDef.
 use constant list_models => {
-    #expire       => 'expire_task',     # Not yet implemented.
-    remind       => 'remind_task',
-    sync_include => '',
+    expire_members => 'expire_members_task',
+    remind         => 'remind_task',
+    sync_include   => '',
 };
 
 # List of global task models. FIXME:Refer Sympa::ConfDef.


### PR DESCRIPTION
  - [feature] Implementing "expire_members" task.
    Note: "expire" task has never been implemented and expire_task parameter was kept but ineffective. To avoid unintentional execution of task with old setting, new parameter for "expire_members" should not be an alias of old one.
  - [bug] next() function in task resets original creation_date. Fixed by renaming task file instead of removing it (That's why "expire" task did not work as expected).

This PR depends on PR #394.
