### PR TITLE
The lists with "bounce" addresses should not be created

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -3081,12 +3081,12 @@ sub do_login {
     my $previous_action = $in{'previous_action'}
         if $in{'previous_action'}
         and $in{'previous_action'} =~ /\A\w+\z/;
-    my $listname_re   = Sympa::Regexps::listname();
+    my $listname_re   = Sympa::Regexps::listname();    #FIXME:Check required?
     my $previous_list = $in{'previous_list'}
         if $in{'previous_list'}
         and $in{'previous_list'} =~ /\A$listname_re\z/;
     my $only_passwd = $in{'only_passwd'};
-    $only_passwd ||= $in{'login_method'};    # Compat. <= 6.2.36
+    $only_passwd ||= $in{'login_method'};              # Compat. <= 6.2.36
     my $success_referer = _clean_referer($in{'referer'});
     my $failure_referer = _clean_referer($in{'failure_referer'});
     my $ldap_auth_info  = is_ldap_user($email);

--- a/src/lib/Sympa/Aliases.pm
+++ b/src/lib/Sympa/Aliases.pm
@@ -27,8 +27,11 @@ use strict;
 use warnings;
 use English qw(-no_match_vars);
 
+use Conf;
 use Sympa::Constants;
+use Sympa::List;
 use Sympa::Log;
+use Sympa::Regexps;
 
 my $log = Sympa::Log->instance;
 
@@ -84,6 +87,65 @@ sub check {0}
 sub add {0}
 
 sub del {0}
+
+# Check listname.
+sub check_new_listname {
+    my $listname = shift;
+    my $robot_id = shift;
+
+    die 'bug in logic. Ask developer'
+        unless defined $listname and length $listname;
+
+    $listname = lc $listname;
+
+    my $listname_re = Sympa::Regexps::listname();
+    unless (defined $listname
+        and $listname =~ /^$listname_re$/i
+        and length $listname <= Sympa::Constants::LIST_LEN()) {
+        $log->syslog('err', 'Incorrect listname %s', $listname);
+        return ('user', 'incorrect_listname', {bad_listname => $listname});
+    }
+
+    my $regx = Conf::get_robot_conf($robot_id, 'list_check_regexp');
+    if ($regx) {
+        if ($listname =~ /^(\S+)-($regx)$/) {
+            $log->syslog('err',
+                'Incorrect listname %s matches one of service aliases',
+                $listname);
+            return ('user', 'listname_matches_aliases',
+                {new_listname => $listname});
+        }
+    }
+
+    if (   $listname eq Conf::get_robot_conf($robot_id, 'email')
+        or $listname eq Conf::get_robot_conf($robot_id, 'listmaster_email')) {
+        $log->syslog('err',
+            'Incorrect listname %s matches one of service aliases',
+            $listname);
+        return ('user', 'listname_matches_aliases',
+            {new_listname => $listname});
+    }
+
+    # Check listname on SMTP server.
+    my $aliases =
+        Sympa::Aliases->new(Conf::get_robot_conf($robot_id, 'alias_manager'));
+    my $res = $aliases->check($listname, $robot_id) if $aliases;
+    unless (defined $res) {
+        $log->syslog('err', 'Can\'t check list %.128s on %s',
+            $listname, $robot_id);
+        return ('intern');
+    }
+
+    # Check this listname doesn't exist already.
+    if ($res or Sympa::List->new($listname, $robot_id, {'just_try' => 1})) {
+        $log->syslog('err',
+            'Could not create list %s: list on %s already exist',
+            $listname, $robot_id);
+        return ('user', 'list_already_exists', {new_listname => $listname});
+    }
+
+    return;
+}
 
 1;
 __END__
@@ -155,6 +217,7 @@ Parameters:
 =item $listname
 
 Name of the list.
+Mandatory.
 
 =item $robot_id
 
@@ -215,6 +278,44 @@ C<0> if there were no aliases to be removed.
 C<undef> if not applicable.
 
 By default, this method always returns C<0>.
+
+=back
+
+=head2 Function
+
+=over
+
+=item check_new_listname ( $listname, $robot )
+
+I<Function>.
+Checks if a new listname is allowed.
+
+TBD.
+
+Parameteres:
+
+=over
+
+=item $listname
+
+A list name to be checked.
+
+=item $robot
+
+Robot context.
+
+=back
+
+Returns:
+
+If check fails, an array including information of errors.
+If it succeeds, empty array.
+
+B<Note>:
+This should be used to check name of list to be created.
+Names of existing lists may not necessarily pass checks by this function.
+
+This function was added on Sympa 6.2.37b.2.
 
 =back
 

--- a/src/lib/Sympa/Aliases.pm
+++ b/src/lib/Sympa/Aliases.pm
@@ -117,8 +117,11 @@ sub check_new_listname {
         }
     }
 
+    # Avoid "sympa", "listmaster", "bounce" and "bounce+XXX".
     if (   $listname eq Conf::get_robot_conf($robot_id, 'email')
-        or $listname eq Conf::get_robot_conf($robot_id, 'listmaster_email')) {
+        or $listname eq Conf::get_robot_conf($robot_id, 'listmaster_email')
+        or $listname eq 'bounce'
+        or 0 == index($listname, 'bounce+')) {
         $log->syslog('err',
             'Incorrect listname %s matches one of service aliases',
             $listname);

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -357,6 +357,7 @@ sub new {
     $options = {} unless (defined $options);
 
     ## Only process the list if the name is valid.
+    #FIXME: Existing lists may be checked with looser rule.
     my $listname_regexp = Sympa::Regexps::listname();
     unless ($name and ($name =~ /^($listname_regexp)$/io)) {
         $log->syslog('err', 'Incorrect listname "%s"', $name)
@@ -8670,6 +8671,7 @@ sub _load_include_admin_user_postprocess {
     my $config_hash = shift;
 
     # The include_list was obsoleted by include_sympa_list on 6.2.16.
+    #FIXME: Existing lists may be checked with looser rule.
     if ($config_hash->{'include_list'}) {
         my $listname_regex =
               Sympa::Regexps::listname() . '(?:\@'

--- a/src/lib/Sympa/Request/Handler/create_list.pm
+++ b/src/lib/Sympa/Request/Handler/create_list.pm
@@ -31,11 +31,9 @@ use English qw(-no_match_vars);
 use Sympa;
 use Sympa::Aliases;
 use Conf;
-use Sympa::Constants;
 use Sympa::List;
 use Sympa::LockedFile;
 use Sympa::Log;
-use Sympa::Regexps;
 use Sympa::Template;
 
 use base qw(Sympa::Request::Handler);
@@ -88,57 +86,10 @@ sub _twist {
         return undef;
     }
 
-    # Check listname.
-    my $listname_re = Sympa::Regexps::listname();
-    unless (defined $listname
-        and $listname =~ /^$listname_re$/i
-        and length $listname <= Sympa::Constants::LIST_LEN()) {
-        $log->syslog('err', 'Incorrect listname %s', $listname);
-        $self->add_stash($request, 'user', 'incorrect_listname',
-            {bad_listname => $listname});
-        return undef;
-    }
-
-    my $regx = Conf::get_robot_conf($robot_id, 'list_check_regexp');
-    if ($regx) {
-        if ($listname =~ /^(\S+)-($regx)$/) {
-            $log->syslog('err',
-                'Incorrect listname %s matches one of service aliases',
-                $listname);
-            $self->add_stash($request, 'user', 'listname_matches_aliases',
-                {new_listname => $listname});
-            return undef;
-        }
-    }
-
-    if (   $listname eq Conf::get_robot_conf($robot_id, 'email')
-        or $listname eq Conf::get_robot_conf($robot_id, 'listmaster_email')) {
-        $log->syslog('err',
-            'Incorrect listname %s matches one of service aliases',
-            $listname);
-        $self->add_stash($request, 'user', 'listname_matches_aliases',
-            {new_listname => $listname});
-        return undef;
-    }
-
-    ## Check listname on SMTP server
-    my $aliases =
-        Sympa::Aliases->new(Conf::get_robot_conf($robot_id, 'alias_manager'));
-    my $res = $aliases->check($listname, $robot_id) if $aliases;
-    unless (defined $res) {
-        $log->syslog('err', 'Can\'t check list %.128s on %s',
-            $listname, $robot_id);
-        $self->add_stash($request, 'intern');
-        return undef;
-    }
-
-    ## Check this listname doesn't exist already.
-    if ($res or Sympa::List->new($listname, $robot_id, {'just_try' => 1})) {
-        $log->syslog('err',
-            'Could not create list %s: list on %s already exist',
-            $listname, $robot_id);
-        $self->add_stash($request, 'user', 'list_already_exists',
-            {new_listname => $listname});
+    # Check new listname.
+    my @stash = Sympa::Aliases::check_new_listname($listname, $robot_id);
+    if (@stash) {
+        $self->add_stash($request, @stash);
         return undef;
     }
 

--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -31,11 +31,9 @@ use Sympa;
 use Sympa::Aliases;
 use Sympa::Bulk;
 use Conf;
-use Sympa::Constants;
 use Sympa::DatabaseManager;
 use Sympa::List;
 use Sympa::Log;
-use Sympa::Regexps;
 use Sympa::Spool;
 use Sympa::Spool::Archive;
 use Sympa::Spool::Auth;
@@ -86,17 +84,6 @@ sub _twist {
         return undef;
     }
 
-    # Check new listname syntax.
-    my $listname_re = Sympa::Regexps::listname();
-    unless (defined $listname
-        and $listname =~ /^$listname_re$/i
-        and length $listname <= Sympa::Constants::LIST_LEN()) {
-        $log->syslog('err', 'Incorrect listname %s', $listname);
-        $self->add_stash($request, 'user', 'incorrect_listname',
-            {bad_listname => $listname});
-        return undef;
-    }
-
     # If list is included by another list, then it cannot be renamed.
     unless ($mode and $mode eq 'copy') {
         if ($current_list->is_included) {
@@ -115,46 +102,10 @@ sub _twist {
         }
     }
 
-    # Check listname on SMTP server.
-    my $aliases =
-        Sympa::Aliases->new(Conf::get_robot_conf($robot_id, 'alias_manager'));
-    my $res = $aliases->check($listname, $robot_id) if $aliases;
-    unless (defined $res) {
-        $log->syslog('err', 'Can\'t check list %.128s on %.128s',
-            $listname, $robot_id);
-        $self->add_stash($request, 'intern');    #FIXME
-        return undef;
-    }
-
-    # Check this listname doesn't exist already.
-    if ($res or Sympa::List->new($listname, $robot_id, {'just_try' => 1})) {
-        $log->syslog('err',
-            'Could not rename list %s: new list %s on %s already exist',
-            $current_list, $listname, $robot_id);
-        $self->add_stash($request, 'user', 'list_already_exists',
-            {new_listname => $listname});
-        return undef;
-    }
-
-    my $regx = Conf::get_robot_conf($robot_id, 'list_check_regexp');
-    if ($regx) {
-        if ($listname =~ /^(\S+)-($regx)$/) {
-            $log->syslog('err',
-                'Incorrect listname %s matches one of service aliases',
-                $listname);
-            $self->add_stash($request, 'user', 'listname_matches_aliases',
-                {new_listname => $listname});
-            return undef;
-        }
-    }
-
-    if (   $listname eq Conf::get_robot_conf($robot_id, 'email')
-        or $listname eq Conf::get_robot_conf($robot_id, 'listmaster_email')) {
-        $log->syslog('err',
-            'Incorrect listname %s matches one of service aliases',
-            $listname);
-        $self->add_stash($request, 'user', 'listname_matches_aliases',
-            {new_listname => $listname});
+    # Check new listname.
+    my @stash = Sympa::Aliases::check_new_listname($listname, $robot_id);
+    if (@stash) {
+        $self->add_stash($request, @stash);
         return undef;
     }
 


### PR DESCRIPTION
  - [bug] The lists with bounce addresses for VERP/tracking can be created.
    By this PR, creation of lists with following addresses may be denied:
      - `bounce` `@`_`domain`_
      - `bounce` `+`_`emptyorarbitrarystring`_`@`_`domain`_

  - Small refactoring.

This PR depends on PR #454.
