### PR TITLE
Fix #323 — Add "Report abuse" button to lists side menu

### DIFF
--- a/default/Makefile.am
+++ b/default/Makefile.am
@@ -321,6 +321,7 @@ nobase_default_DATA = \
 	web_tt2/remove_arc.tt2 \
 	web_tt2/rename_list_request.tt2 \
 	web_tt2/renewpasswd.tt2 \
+	web_tt2/report_abuse.tt2 \
 	web_tt2/requestpasswd.tt2 \
 	web_tt2/request_topic.tt2 \
 	web_tt2/reviewbouncing.tt2 \

--- a/default/web_tt2/list_menu.tt2
+++ b/default/web_tt2/list_menu.tt2
@@ -156,4 +156,10 @@
 [% PROCESS additional_list_menu_links.tt2 %]
 [% CATCH %]
 [% END %]
+
+[% IF conf.show_report_abuse %]
+    <li>
+        [% PROCESS report_abuse.tt2 ~%]
+    </li>
+[% END %]
 <!-- end list_menu.tt2 -->

--- a/default/web_tt2/report_abuse.tt2
+++ b/default/web_tt2/report_abuse.tt2
@@ -1,0 +1,3 @@
+<!-- report_abuse.tt2 -->
+[% | mailto("${conf.listmaster_email}@${domain}",{subject=>"Sympa abuse report: ${list}"}) %][%|loc%]Report abuse[%END%][%END%]
+<!-- end report_abuse.tt2 -->

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1146,6 +1146,7 @@ while ($query = CGI::Fast->new) {
         'automatic_list_families',
         'spam_protection',
         'pictures_max_size',
+        'show_report_abuse',
     ) {
 
         $param->{'conf'}{$p} = Conf::get_robot_conf($robot, $p);

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -2123,6 +2123,15 @@ our @params = (
         'file'       => 'wwsympa.conf',
         'optional'   => 1,
     },
+    {   'name' => 'show_report_abuse',
+        'gettext_id' =>
+            'Add a "Report abuse" link in the side menu of the lists (0|1)',
+        'gettext_comment' =>
+            'The link is a mailto link, you can change that by overriding web_tt2/report_abuse.tt2',
+        'default'  => '0',
+        'file'     => 'sympa.conf',
+        'optional' => 1,
+    },
 
 ## Not implemented yet.
 ##    {


### PR DESCRIPTION
- [X] create a template that is included into lists side menu (instead of just info page as said in #323, to be always visible, whatever the page of the list you visit)
- [X] the template is just a mailto link to listmaster with subject "Sympa abuse report: list_name"