### PR TITLE
Datasource: On LDAP 2 level query, attr1 as DN should not be canonicalized

### DIFF
--- a/src/lib/Sympa/DatabaseDriver/LDAP.pm
+++ b/src/lib/Sympa/DatabaseDriver/LDAP.pm
@@ -274,6 +274,8 @@ TBD.
 
 =item canonical_dn ( $dn )
 
+B<Obsoleted>.
+
 I<Instance method>.
 See L<Net::LDAP::Util/canonical_dn>.
 
@@ -281,10 +283,14 @@ However, this method try to use RFC 1779 escaping as much as possible.
 
 =item escape_dn_value ( $string )
 
+B<Obsoleted>.
+
 I<Instance method>.
 See L<Net::LDAP::Util/escape_dn_value>.
 
 =item escape_filter_value ( $string )
+
+B<Obsoleted>.
 
 I<Instance method>.
 See L<Net::LDAP::Util/escape_filter_value>.

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -34,6 +34,7 @@ use English qw(-no_match_vars);
 use HTTP::Request;
 use IO::Scalar;
 use LWP::UserAgent;
+use Net::LDAP::Util qw();
 use POSIX qw();
 use Storable qw();
 BEGIN { eval 'use IO::Socket::SSL'; }
@@ -5381,19 +5382,19 @@ sub _include_users_ldap_2level {
             # Note: Don't canonicalize DN, because some LDAP servers e.g. AD
             #   don't conform to standard on matching rule and canonicalization
             #   might hurt integrity (cf. GH #474).
-            unless (defined $db->canonical_dn($attr)) {
+            unless (defined Net::LDAP::Util::canonical_dn($attr)) {
                 $log->syslog('err', 'Attribute value is not a DN: %s', $attr);
                 next;
             }
             $escaped_attr = $attr;
         } else {
             # [attrs1] may be an attributevalue in DN.
-            $escaped_attr = $db->escape_dn_value($attr);
+            $escaped_attr = Net::LDAP::Util::escape_dn_value($attr);
         }
         ($suffix2 = $ldap_suffix2) =~ s/\[attrs1\]/$escaped_attr/g;
 
         # Escape LDAP characters occurring in attribute for search filter.
-        $escaped_attr = $db->escape_filter_value($attr);
+        $escaped_attr = Net::LDAP::Util::escape_filter_value($attr);
         ($filter2 = $ldap_filter2) =~ s/\[attrs1\]/$escaped_attr/g;
 
         $log->syslog('debug2',

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -5378,11 +5378,14 @@ sub _include_users_ldap_2level {
         # Escape LDAP characters occurring in attribute for search base.
         if ($ldap_suffix2 =~ /[[]attrs1[]]\z/) {
             # [attrs1] should be a DN, because it is search base or its root.
-            $escaped_attr = $db->canonical_dn($attr);
-            unless (defined $escaped_attr) {
+            # Note: Don't canonicalize DN, because some LDAP servers e.g. AD
+            #   don't conform to standard on matching rule and canonicalization
+            #   might hurt integrity (cf. GH #474).
+            unless (defined $db->canonical_dn($attr)) {
                 $log->syslog('err', 'Attribute value is not a DN: %s', $attr);
                 next;
             }
+            $escaped_attr = $attr;
         } else {
             # [attrs1] may be an attributevalue in DN.
             $escaped_attr = $db->escape_dn_value($attr);


### PR DESCRIPTION
This PR may fix #474.
