### PR TITLE
Fix missing quotes in init script

### DIFF
--- a/src/etc/script/sympa.in
+++ b/src/etc/script/sympa.in
@@ -259,7 +259,7 @@ sympa_stop() {
 
 # Check that networking is up.
 if [ ${OSTYPE} != "Linux" -a ${OSTYPE} != "BSD" -a ${OSTYPE} != "SunOS" -a ${OSTYPE} != "Darwin" ]; then
-    if [ ${NETWORKING} = "no" ]
+    if [ "${NETWORKING}" = "no" ]
     then
 	    exit 0
     fi


### PR DESCRIPTION
Issue https://github.com/sympa-community/sympa/issues/72 states that "we should stop supporting init scripts as modern distributions are using systemd". I have to disagree. Gentoo Linux defaults to OpenRC, so I created a small pull request to fix missing quotes in the init script.