### PR TITLE
Broken `custom_attribute` field in `member.dump`

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -742,8 +742,16 @@ sub dump_users {
             $user = $self->get_next_list_member()
         ) {
             foreach my $k (sort keys %map_field) {
-                printf $lock_fh "%s %s\n", $k, $user->{$k}
-                    if defined $user->{$k} and length $user->{$k};
+                if ($k eq 'custom_attribute') {
+                    next unless ref $user->{$k} eq 'HASH' and %{$user->{$k}};
+                    my $encoded = Sympa::Tools::Data::encode_custom_attribute(
+                        $user->{$k});
+                    $encoded =~ s/[\r\n]+/ /g;
+                    printf $lock_fh "%s %s\n", $k, $encoded;
+                } else {
+                    next unless defined $user->{$k} and length $user->{$k};
+                    printf $lock_fh "%s %s\n", $k, $user->{$k};
+                }
             }
             print $lock_fh "\n";
         }
@@ -4386,6 +4394,11 @@ sub restore_users {
                     #FIMXE: Define appropriate schema.
                     if (/^\s*(suspend|subscribed|included)\s+(\S+)\s*$/) {
                         ($1 => !!$2);
+                    } elsif (/^\s*(custom_attribute)\s+(.+)\s*$/) {
+                        my $k = $1;
+                        my $decoded =
+                            Sympa::Tools::Data::decode_custom_attribute($2);
+                        ($decoded and %$decoded) ? ($k => $decoded) : ();
                     } elsif (
                         /^\s*(date|update_date|startdate|enddate|bounce_score|number_messages)\s+(\d+)\s*$/
                         or

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -746,7 +746,6 @@ sub dump_users {
                     next unless ref $user->{$k} eq 'HASH' and %{$user->{$k}};
                     my $encoded = Sympa::Tools::Data::encode_custom_attribute(
                         $user->{$k});
-                    $encoded =~ s/[\r\n]+/ /g;
                     printf $lock_fh "%s %s\n", $k, $encoded;
                 } else {
                     next unless defined $user->{$k} and length $user->{$k};

--- a/src/lib/Sympa/Tools/Data.pm
+++ b/src/lib/Sympa/Tools/Data.pm
@@ -494,10 +494,11 @@ sub encode_custom_attribute {
 
         $XMLstr .=
               "<custom_attribute id=\"$k\"><value>"
-            . Sympa::Tools::Text::encode_html($value)
+            . Sympa::Tools::Text::encode_html($value, '\000-\037')
             . "</value></custom_attribute>";
     }
     $XMLstr .= "</custom_attributes>";
+    $XMLstr =~ s/\s*\n\s*/ /g;
 
     return $XMLstr;
 }

--- a/src/lib/Sympa/Tools/Text.pm
+++ b/src/lib/Sympa/Tools/Text.pm
@@ -8,6 +8,9 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
+# Copyright 2018 The Sympa Community. See the AUTHORS.md file at the
+# top-level directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -157,9 +160,10 @@ sub encode_filesystem_safe {
 }
 
 sub encode_html {
-    my $str = shift;
+    my $str               = shift;
+    my $additional_unsafe = shift || '';
 
-    HTML::Entities::encode_entities($str, '<>&"');
+    HTML::Entities::encode_entities($str, '<>&"' . $additional_unsafe);
 }
 
 sub encode_uri {
@@ -572,10 +576,11 @@ two hexdigits.
 
 Note that C<'/'> will also be encoded.
 
-=item encode_html ( $str )
+=item encode_html ( $str, [ $additional_unsafe ] )
 
 I<Function>.
 Encodes characters in a string $str to HTML entities.
+By default
 C<'E<lt>'>, C<'E<gt>'>, C<'E<amp>'> and C<'E<quot>'> are encoded.
 
 Parameter:
@@ -585,6 +590,12 @@ Parameter:
 =item $str
 
 String to be encoded.
+
+=item $additional_unsafe
+
+Character or range of characters additionally encoded as entity references.
+
+This optional parameter was introduced on Sympa 6.2.37b.3.
 
 =back
 


### PR DESCRIPTION
`custom_attribute` field in `member.dump` control file is broken. Fixed by serializing content.

