### PR TITLE
Fix shared docs zip upload to send multiple files at once

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -12596,8 +12596,7 @@ sub do_d_unzip {
     my $fh = $query->upload('uploaded_file');
     if (defined $fh) {
         my $ioh = $fh->handle;
-        # The handle must know seek() in addition to opened().
-        bless $ioh => 'IO::File' unless $ioh->can('seek');
+        bless $ioh => 'IO::File';
         $zip = Archive::Zip->new();
         $az  = $zip->readFromFileHandle($ioh);
     }


### PR DESCRIPTION
On Debian 9, with perl 5.24.1 and Archive::Zip 1.59 and 1.64, uploading
a zip file to let Sympa (6.2.34) unzip it and put its files into shared
docs fails.
The zip member is a CGI::File::Temp instance and can seek but fails to
be extracted ("Unable to extract member XXX of the zip file" in Sympa
logs).
Unconditionnally blessing the file handle to IO::File fixes the failure.