### PR TITLE
Fix typo in web_tt2/confirm_action.tt2

### DIFF
--- a/default/web_tt2/confirm_action.tt2
+++ b/default/web_tt2/confirm_action.tt2
@@ -12,7 +12,7 @@
       [%|loc%]Add subscribers[%END%]
     </h2>
     <p><strong>
-      [%|loc(email.0)%]Dou you really want to add %1?[%END%] 
+      [%|loc(email.0)%]Do you really want to add %1?[%END%] 
     </strong></p>
   [%~ END %]
 [%~ ELSIF confirm_action == 'add_frommod' ~%]
@@ -20,7 +20,7 @@
     [%|loc%]Add subscribers[%END%] 
   </h2>
   <p><strong>
-    [%|loc(email.0.email)%]Dou you really want to add %1?[%END%] 
+    [%|loc(email.0.email)%]Do you really want to add %1?[%END%] 
   </strong></p>
 [%~ ELSIF confirm_action == 'arc' || confirm_action == 'arcsearch_id' ~%]
   <h2><i class="fa fa-check-circle"></i>

--- a/po/sympa/af.po
+++ b/po/sympa/af.po
@@ -5598,7 +5598,7 @@ msgstr ""
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr ""
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/ar.po
+++ b/po/sympa/ar.po
@@ -5883,7 +5883,7 @@ msgstr "إضافة مشتركين"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "هل فعلا تريد إلغاء هذه الرسالة ؟"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/bg.po
+++ b/po/sympa/bg.po
@@ -5693,7 +5693,7 @@ msgstr ""
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr ""
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/br.po
+++ b/po/sympa/br.po
@@ -5663,7 +5663,7 @@ msgstr ""
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr ""
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/ca.po
+++ b/po/sympa/ca.po
@@ -6324,7 +6324,7 @@ msgstr "Afegeix subscriptors"
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Esteu segur que voleu afegir %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/cs.po
+++ b/po/sympa/cs.po
@@ -5969,7 +5969,7 @@ msgstr "Přidat členy"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Opravdu chcete odstranit %1 ?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/de.po
+++ b/po/sympa/de.po
@@ -6342,7 +6342,7 @@ msgstr "Abonnenten hinzufügen"
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Wollen Sie %1 wirklich hinzufügen?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/el.po
+++ b/po/sympa/el.po
@@ -6240,7 +6240,7 @@ msgstr "Προσθήκη συνδρομητών"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Επιθυμείτε τη διαγραφή του(της) %1;"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/en_US.po
+++ b/po/sympa/en_US.po
@@ -6264,7 +6264,7 @@ msgstr "Add subscribers"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Do you really want to delete %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/eo.po
+++ b/po/sympa/eo.po
@@ -5598,7 +5598,7 @@ msgstr ""
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr ""
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/es.po
+++ b/po/sympa/es.po
@@ -6555,7 +6555,7 @@ msgstr "Añadir suscriptores"
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "¿De verdad quieres añadir a %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/et.po
+++ b/po/sympa/et.po
@@ -6132,7 +6132,7 @@ msgstr "Lisa tellijaid"
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Olete kindel, et soovite lisada %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/eu.po
+++ b/po/sympa/eu.po
@@ -6254,7 +6254,7 @@ msgstr "Harpidedunak gehitu"
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Benetan %1 gehitu nahi duzu?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/fi.po
+++ b/po/sympa/fi.po
@@ -6203,7 +6203,7 @@ msgstr "Lisää tilaajia"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Haluatko varmasti poistaa kohteen %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/fr.po
+++ b/po/sympa/fr.po
@@ -6730,7 +6730,7 @@ msgstr "Ajout d'abonnés"
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Voulez-vous vraiment ajouter %1 ?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/gl.po
+++ b/po/sympa/gl.po
@@ -6486,7 +6486,7 @@ msgstr "Engadir subscritores"
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "De verdade queres engadir a %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/hu.po
+++ b/po/sympa/hu.po
@@ -6361,7 +6361,7 @@ msgstr "Tagok hozzáadása"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Tényleg törölni akarja a %1 mappát?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/id.po
+++ b/po/sympa/id.po
@@ -5757,7 +5757,7 @@ msgstr ""
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Apakah Anda benar-benar ingin daftar milis %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/io.po
+++ b/po/sympa/io.po
@@ -5596,7 +5596,7 @@ msgstr ""
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr ""
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/it.po
+++ b/po/sympa/it.po
@@ -6558,7 +6558,7 @@ msgstr "Aggiungi iscritti"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Vuoi davvero rimuovere %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/ja.po
+++ b/po/sympa/ja.po
@@ -6095,7 +6095,7 @@ msgstr "読者を追加"
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "本当に %1 を追加してよいのですか。"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/ko.po
+++ b/po/sympa/ko.po
@@ -6122,7 +6122,7 @@ msgstr "가입자 추가"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "%1 를 삭제하시겠습니까?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/la.po
+++ b/po/sympa/la.po
@@ -5597,7 +5597,7 @@ msgstr ""
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr ""
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/ml.po
+++ b/po/sympa/ml.po
@@ -5627,7 +5627,7 @@ msgstr ""
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr ""
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/nb.po
+++ b/po/sympa/nb.po
@@ -6034,7 +6034,7 @@ msgstr "Legg til abonnenter"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Ønsker du virkelig å slette %1 ?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/nl.po
+++ b/po/sympa/nl.po
@@ -6021,7 +6021,7 @@ msgstr "Voeg abonnees toe"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Wilt u het volgende %1 echt verwijderen?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/nn.po
+++ b/po/sympa/nn.po
@@ -5598,7 +5598,7 @@ msgstr ""
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr ""
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/oc.po
+++ b/po/sympa/oc.po
@@ -6383,7 +6383,7 @@ msgstr "Apondon d'abonats"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Sètz segur(a) que volètz suprimir %1 ?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/pl.po
+++ b/po/sympa/pl.po
@@ -6151,7 +6151,7 @@ msgstr "Dodaj subskrybentów"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Czy na pewno chcesz usunąć %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/pt.po
+++ b/po/sympa/pt.po
@@ -5766,7 +5766,7 @@ msgstr "Adicionar subscritores"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Tem a certeza que deseja subscrever a lista %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/pt_BR.po
+++ b/po/sympa/pt_BR.po
@@ -6223,7 +6223,7 @@ msgstr "Adicionar assinantes"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Você realmente quer remover %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/rm.po
+++ b/po/sympa/rm.po
@@ -5599,7 +5599,7 @@ msgstr ""
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr ""
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/ro.po
+++ b/po/sympa/ro.po
@@ -6336,7 +6336,7 @@ msgstr "Adauga abonati noi"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Do you really want to delete %1 ?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/ru.po
+++ b/po/sympa/ru.po
@@ -6496,7 +6496,7 @@ msgstr "Добавить подписчиков"
 #. (email.0)
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Вы действительно хотите добавить %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/sv.po
+++ b/po/sympa/sv.po
@@ -5992,7 +5992,7 @@ msgstr "Lägg till prenumeranter"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Vill du verkligen radera %1?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/sympa.pot
+++ b/po/sympa/sympa.pot
@@ -4819,7 +4819,7 @@ msgstr ""
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #. (email.0)
 #. (email.0.email)
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr ""
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/tr.po
+++ b/po/sympa/tr.po
@@ -5960,7 +5960,7 @@ msgstr "Üyeleri Ekle"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "%1 : Silmek istediğinizden emin misiniz?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/vi.po
+++ b/po/sympa/vi.po
@@ -5953,7 +5953,7 @@ msgstr "Thêm người đăng ký"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "Bạn thực sự muốn xoá %1 không?"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/zh_CN.po
+++ b/po/sympa/zh_CN.po
@@ -6063,7 +6063,7 @@ msgstr "添加订阅者"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "确定要删除%1吗？"
 
 #: default/web_tt2/confirm_action.tt2:34

--- a/po/sympa/zh_TW.po
+++ b/po/sympa/zh_TW.po
@@ -6067,7 +6067,7 @@ msgstr "添加訂閱者"
 #. (email.0.email)
 #: default/web_tt2/confirm_action.tt2:15 default/web_tt2/confirm_action.tt2:23
 #, fuzzy
-msgid "Dou you really want to add %1?"
+msgid "Do you really want to add %1?"
 msgstr "確定要刪除%1嗎？"
 
 #: default/web_tt2/confirm_action.tt2:34


### PR DESCRIPTION
## Description

There's a typo in a localized string of `confirm_action.tt2`.

## Impacts

This PR fixes the typo that appears in the template and all the localization files.