### PR TITLE
Allow to use Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,42 @@
+.job-template: &job
+  image: "hatsoftwares/sympa-perl-${CI_JOB_NAME}:latest"
+  retry: 2
+  script:
+    - export p=$(pwd)
+    - . ~/.bash_profile
+    - . ~/bashrc
+    - coverage-install
+    - coverage-setup
+    - cpanm --quiet --notest --installdeps . --with-develop
+    - autoreconf -i
+    - ./configure
+    - cd src; make; cd ..
+    - make check-local TEST_FILES='xt/perltidy.t' || true
+    - make check-local TEST_FILES='t/compile_executables.t t/compile_modules.t t/Language.t t/parse_templates.t t/pod-syntax.t'
+    - coverage-report
+    - make clean
+
+"5.8":
+  <<: *job
+"5.10":
+  <<: *job
+"5.12":
+  <<: *job
+"5.14":
+  <<: *job
+"5.16":
+  <<: *job
+  variables:
+    COVERAGE: 1
+"5.18":
+  <<: *job
+"5.20":
+  <<: *job
+"5.22":
+  <<: *job
+"5.24":
+  <<: *job
+"5.26":
+  <<: *job
+"5.28":
+  <<: *job


### PR DESCRIPTION
For those who prefer to work on Gitlab (or [use Gitlab CI while using Github](https://about.gitlab.com/solutions/github/)), here's a working `.gitlab-ci.yml`.

Docker images for the CI are published on https://framagit.org/luc/DockerFiles/tree/master/sympa-perl