### PR TITLE
Additional fix for #474.

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -34,10 +34,10 @@ use English qw(-no_match_vars);
 use HTTP::Request;
 use IO::Scalar;
 use LWP::UserAgent;
-use Net::LDAP::Util qw();
 use POSIX qw();
 use Storable qw();
 BEGIN { eval 'use IO::Socket::SSL'; }
+BEGIN { eval 'use Net::LDAP::Util'; }
 
 use Sympa;
 use Conf;


### PR DESCRIPTION
Additional fix for #476 which is related to #474.
Net::LDAP::Util module is optional.
