### PR TITLE
WWSympa: Older CSS files would be cleared

### DIFF
--- a/src/lib/Sympa/WWW/Tools.pm
+++ b/src/lib/Sympa/WWW/Tools.pm
@@ -927,9 +927,8 @@ sub _get_css_url {
     foreach my $file (<$path.*>) {
         next
             unless 0 == index($file, $path)
-            and substr($file, length $path) =~ /\A[.]\d+\z/;
-        next unless -f $file;
-        next if time - 3600 < Sympa::Tools::File::get_mtime($file);
+            and substr($file, length $path) =~ /\A[.]\d+\z/
+            and -f $file;
         unlink $file;
     }
 

--- a/src/lib/Sympa/WWW/Tools.pm
+++ b/src/lib/Sympa/WWW/Tools.pm
@@ -923,6 +923,16 @@ sub _get_css_url {
     # Set mtime of source template to detect update of it.
     utime $template_mtime, $template_mtime, $path;
 
+    # Expire old files.
+    foreach my $file (<$path.*>) {
+        next
+            unless 0 == index($file, $path)
+            and substr($file, length $path) =~ /\A[.]\d+\z/;
+        next unless -f $file;
+        next if time - 3600 < Sympa::Tools::File::get_mtime($file);
+        unlink $file;
+    }
+
     return ($url, $hash);
 }
 


### PR DESCRIPTION
[bug] Older CSS files would be cleared.

Fixed by clearing older `style.css*` and `lang.css*` under $CSSDIR when they would be updated.

Note:
  * Among files under $CSSDIR, `fullPage.css*`, `print.css*` and `print-preview.css*` will no longer be used nor updated. These may be removed manuallly.
