### PR TITLE
Long email addresses in system messages may be folded #502

### DIFF
--- a/src/lib/Sympa/Tools/Text.pm
+++ b/src/lib/Sympa/Tools/Text.pm
@@ -123,10 +123,12 @@ sub wrap_text {
     $cols = 78 unless defined $cols;
     return $text unless $cols;
 
+    my $email_re = Sympa::Regexps::email();
     $text = Text::LineFold->new(
         Language      => Sympa::Language->instance->get_lang,
         OutputCharset => (Encode::is_utf8($text) ? '_UNICODE_' : 'utf8'),
         Prep          => 'NONBREAKURI',
+        prep          => [qr{\b$email_re\b}, sub { shift; @_ }],
         ColumnsMax    => $cols
     )->fold($init, $subs, $text);
 

--- a/src/lib/Sympa/Tools/Text.pm
+++ b/src/lib/Sympa/Tools/Text.pm
@@ -128,7 +128,7 @@ sub wrap_text {
         Language      => Sympa::Language->instance->get_lang,
         OutputCharset => (Encode::is_utf8($text) ? '_UNICODE_' : 'utf8'),
         Prep          => 'NONBREAKURI',
-        prep          => [qr{\b$email_re\b}, sub { shift; @_ }],
+        prep          => [$email_re, sub { shift; @_ }],
         ColumnsMax    => $cols
     )->fold($init, $subs, $text);
 


### PR DESCRIPTION
Fixed by preventing folding words matching email regexp.

This may fix #502.
