### PR TITLE
File extension may contain spaces by using gettext_strftime()

### DIFF
--- a/default/web_tt2/viewlogs.tt2
+++ b/default/web_tt2/viewlogs.tt2
@@ -80,7 +80,11 @@
   [%# Reset button will be inserted here. ~%]
 </form>
 
-<em>[%|loc%]Search period: [%END%]<strong>[%|locdt(date_from_formated)%]%d %b %Y %H:%M:%S[%END%]</strong> [%|loc%]to[%END%] <strong>[%|locdt(date_to_formated)%]%d %b %Y %H:%M:%S[%END%]</strong></em><br />
+<em>[%|loc%]Search period: [%END%]
+  <strong>[% date_from_formated | optdesc('unixtime') %]</strong>
+  [%|loc%]to[%END%]
+  <strong>[% date_to_formated | optdesc('unixtime') %]</strong>
+</em><br />
 [% IF total_results %]
 <em>[%|loc(list)%]Research was carried out in list <strong>%1</strong>.[%END%]</em><br />
 <br />

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -16196,11 +16196,9 @@ sub do_viewlogs {
 
     $param->{'total_results'} = 0;
 
-    my @date = $log->get_log_date();
-    $param->{'date_from_formated'} =
-        $language->gettext_strftime("%Y-%m-%d-%H-%M-%S", localtime($date[0]));
-    $param->{'date_to_formated'} =
-        $language->gettext_strftime("%Y-%m-%d-%H-%M-%S", localtime($date[1]));
+    my @dates = $log->get_log_date;
+    ($param->{'date_from_formated'}, $param->{'date_to_formated'}) = @dates
+        if @dates;
 
     # Display and search parameters preparation.
     my $select = {

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -32,7 +32,6 @@ use warnings;
 use Encode qw();
 use English qw(-no_match_vars);
 use MIME::Base64 qw();
-use POSIX qw();
 use Time::Local qw();
 
 use Sympa;
@@ -934,7 +933,7 @@ sub upgrade {
         my $fh;
         my %migrated = ();
         my @newconf  = ();
-        my $date;
+        my ($date, $human_date);
 
         ## Some sympa.conf parameters were overridden by wwsympa.conf.
         ## Others prefer sympa.conf.
@@ -978,8 +977,9 @@ sub upgrade {
 
         ## Set language of new file content
         $language->push_lang($Conf::Conf{'lang'});
-        $date =
-            $language->gettext_strftime("%d.%b.%Y-%H.%M.%S", localtime time);
+        $date = time;
+        $human_date = $language->gettext_strftime('%d %b %Y at %H:%M:%S',
+            localtime $date);
 
         if (-r $wwsympa_conf) {
             ## load only sympa.conf
@@ -1077,7 +1077,7 @@ sub upgrade {
                 . ('#' x 76) . "\n" . '#### '
                 . $language->gettext("Migration from wwsympa.conf") . "\n"
                 . '#### '
-                . $date . "\n"
+                . $human_date . "\n"
                 . ('#' x 76) . "\n\n";
 
             foreach my $type (qw(duplicate add obsolete unknown)) {
@@ -1989,8 +1989,8 @@ sub to_utf8 {
 
         next unless $modified;
 
-        my $date = POSIX::strftime("%Y.%m.%d-%H.%M.%S", localtime(time));
-        unless (rename $file, $file . '@' . $date) {
+        my $date = time;
+        unless (rename $file, $file . '.' . $date) {
             $log->syslog('err', "Cannot rename old template %s", $file);
             next;
         }
@@ -2013,7 +2013,7 @@ sub to_utf8 {
             next;
         }
         $log->syslog('notice', 'Modified file %s; original file kept as %s',
-            $file, $file . '@' . $date);
+            $file, $file . '.' . $date);
 
         $total++;
     }
@@ -2099,8 +2099,7 @@ sub fix_colors {
         $new_conf .= "$line\n";
     }
     # Save previous config file
-    my $date =
-        $language->gettext_strftime("%d.%b.%Y-%H.%M.%S", localtime time);
+    my $date = time;
     unless (rename($file, "$file.upgrade$date")) {
         $log->syslog(
             'err',
@@ -2143,8 +2142,7 @@ sub save_web_tt2 {
         );
         return 0;
     }
-    my $date =
-        $language->gettext_strftime("%d.%b.%Y-%H.%M.%S", localtime time);
+    my $date = time;
     unless (rename($dir, "$dir.upgrade$date")) {
         $log->syslog(
             'err',

--- a/src/sbin/sympa_wizard.pl.in
+++ b/src/sbin/sympa_wizard.pl.in
@@ -89,7 +89,6 @@ if ($modfail) {
             ? Sympa::Tools::Text::pad($language->gettext($_[0]), $_[1])
             : $language->gettext($_[0]);
     };
-    *gettext_strftime = sub { $language->gettext_strftime(@_) };
 
     my $lang = $ENV{'LANGUAGE'} || $ENV{'LC_ALL'} || $ENV{'LANG'};
     $lang =~ s/\..*// if $lang;
@@ -400,7 +399,9 @@ sub edit_configuration {
     }
 
     if ($somechange) {
-        my $date = gettext_strftime("%d.%b.%Y-%H.%M.%S", localtime(time));
+        my @time = localtime time;
+        my $date = sprintf '%d%02d%02d%02d%02d%02d',
+            $time[5] + 1900, $time[4] + 1, @time[3, 2, 1, 0];
 
         ## Keep old config file
         unless (rename $sympa_conf, $sympa_conf . '.' . $date) {


### PR DESCRIPTION
  * [bug] Extension of backup files created during upgrade process were localised by gettext_strftime() so that they may contain inappropriate characters such as spece.  Fixed by making extensions untranslated.
  * Another unuseful use of gettext_strftime() in a template.
