### PR TITLE
`make distcheck` fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,12 @@ Makefile
 
 /sympa-*.tar.gz
 
+# make distcheck
+
+/sympa-*/
+/sympa-*.tar.gz.md5
+/sympa-*.tar.gz.sha256
+
 # perltidy
 
 *.bak

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Makefile
 /po/web_help/remove-potcdate.sed
 /po/web_help/stamp-po
 /src/etc/script/sympa
+/src/lib/stamp-man3
 /src/lib/Sympa/Constants.pm
 /src/lib/Sympa/Internals.pod
 /src/libexec/bouncequeue

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,11 +65,12 @@ noinst_SCRIPTS = \
 	xt/pod-coverage.t \
 	xt/pod-spelling.t \
 	xt/perltidy.t
+nobase_modules_DATA = \
+	cpanfile
 
 EXTRA_DIST = \
 	AUTHORS.md \
 	CONTRIBUTING.md \
-	cpanfile \
 	INSTALL.md \
 	NEWS.md \
 	OChangeLog \
@@ -77,7 +78,8 @@ EXTRA_DIST = \
 	README.md \
 	etc_README \
 	$(check_SCRIPTS) $(check_DATA) \
-	$(noinst_SCRIPTS)
+	$(noinst_SCRIPTS) \
+	$(nobase_modules_DATA)
 
 CLEANFILES = sympa_wizard.pl.inst
 
@@ -85,10 +87,13 @@ MSGFMT=@MSGFMT@
 .po.mo:
 	$(MSGFMT) -o $@ $<
 
+# Skip this with "make distcheck"
 check-local: $(check_DATA)
-	[ -z "$(TEST_FILES)" ] && TEST_FILES="$(check_SCRIPTS)"; \
-	PERL5LIB=src/lib; export PERL5LIB; \
-	$(PERL) -MTest::Harness -e 'runtests @ARGV' $$TEST_FILES
+	if test -d t; then \
+		[ -z "$(TEST_FILES)" ] && TEST_FILES="$(check_SCRIPTS)"; \
+		PERL5LIB=src/lib; export PERL5LIB; \
+		$(PERL) -MTest::Harness -e 'runtests @ARGV' $$TEST_FILES; \
+	fi
 
 authorcheck:
 	[ -z "$(TEST_FILES)" ] && TEST_FILES="$(noinst_SCRIPTS)"; \
@@ -169,10 +174,9 @@ installconfig: installdir sympa_wizard.pl.inst
 		$(SED) \
 			-e 's|--sysconfdir--|$(sysconfdir)|' \
 			-e 's|--defaultdir--|$(defaultdir)|' \
-			etc_README > $(DESTDIR)$(sysconfdir)/README; \
+			$(srcdir)/etc_README > $(DESTDIR)$(sysconfdir)/README; \
 		chmod 644 $(DESTDIR)$(sysconfdir)/README; \
 	fi
-	@$(INSTALL_DATA) cpanfile $(DESTDIR)$(modulesdir)/;
 
 nextstep: 
 	@echo ""
@@ -195,11 +199,19 @@ nextstep:
 	@echo "#######################################################"
 
 uninstall-hook:
-	rm -f $(DESTDIR)$(confdir)/sympa.conf
-	rm -f $(DESTDIR)$(confdir)/wwsympa.conf
+	cd $(DESTDIR)$(confdir) && rm -f sympa.conf
+	cd $(DESTDIR)$(confdir) && rm -f wwsympa.conf
+	cd $(DESTDIR)$(sysconfdir) && rm -f data_structure.version
+	cd $(DESTDIR)$(sysconfdir) && rm -f README
+
+DISTCHECK_CONFIGURE_FLAGS = --enable-fhs --with-perl=$(PERL)
 
 dist-hook:
 	$(MAKE) check
+
+distcheck-hook:
+	-md5sum $(DIST_ARCHIVES) > $(DIST_ARCHIVES).md5
+	-sha256sum $(DIST_ARCHIVES) > $(DIST_ARCHIVES).sha256
 
 tidyall:
 	tidyall --conf-file doc/dot.tidyallrc --root-dir . -r src t xt

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -77,11 +77,12 @@ CLEANFILES = $(man1_MANS) $(man5_MANS)
 
 .pod.1:
 	$(AM_V_GEN)$(POD2MAN) --section=1 --center="sympa $(VERSION)" \
-		--lax --release="$(VERSION)" $*.pod $@
+		--lax --release="$(VERSION)" $< $@
 .pod.5:
 	$(AM_V_GEN)$(POD2MAN) --section=5 --center="sympa $(VERSION)" \
-		--lax --release="$(VERSION)" $*.pod $@
+		--lax --release="$(VERSION)" $< $@
 
 .podpl.pod:
-	$(AM_V_GEN)PERL5LIB=$(top_srcdir)/src/lib; export PERL5LIB; \
-	$(PERL) $(srcdir)/$< > $*.pod
+	$(AM_V_GEN)PERL5LIB=$(top_builddir)/src/lib:$(top_srcdir)/src/lib; \
+	export PERL5LIB; \
+	$(PERL) $< --top_srcdir=$(top_srcdir) > $*.pod

--- a/doc/list_config.podpl
+++ b/doc/list_config.podpl
@@ -4,10 +4,15 @@ use strict;
 use warnings;
 use Cwd qw();
 use English qw(-no_match_vars);
+use Getopt::Long;
 
 use Sympa::ConfDef;
 use Sympa::ListDef;
 use Sympa::ListOpt;
+
+my $top_srcdir;
+GetOptions('top_srcdir=s' => \$top_srcdir);
+$top_srcdir ||= '..';
 
 my @groups = (
     [description => 'List definition'],
@@ -184,7 +189,7 @@ sub _format {
     } elsif (exists $pinfo->{scenario}) {
         my $function = $pinfo->{scenario};
         my $cwd      = Cwd::getcwd();
-        chdir '../default/scenari/' or die $ERRNO;
+        chdir $top_srcdir . '/default/scenari/' or die $ERRNO;
         $parameters .= sprintf "Name of C<%s> scenario:\n\n",
             $pinfo->{scenario};
 

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -188,19 +188,23 @@ nobase_modules_DATA = \
 	Sympa/WWW/SOAP/Transport.pm \
 	Sympa/WWW/Tools.pm
 
-man3dir = $(mandir)/man3
 man3ext = 3Sympa
 MAN3POD = \
 	$(nobase_nodist_modules_DATA) \
 	$(nobase_dist_modules_DATA) \
 	$(nobase_modules_DATA)
+man3_MANS =
+noinst_DATA = stamp-man3
 
 EXTRA_DIST = \
 	Sympa/Constants.pm.in \
 	Sympa/Internals.podpl \
 	$(nobase_modules_DATA)
 
-CLEANFILES = Sympa/Constants.pm Sympa/Internals.pod *.$(man3ext)
+CLEANFILES = \
+	Sympa/Constants.pm \
+	Sympa/Internals.pod \
+	stamp-man3T stamp-man3 *.$(man3ext)
 
 Sympa/Constants.pm: Sympa/Constants.pm.in Makefile
 	@[ -d Sympa ] || mkdir Sympa
@@ -235,8 +239,9 @@ Sympa/Internals.pod: Sympa/Internals.podpl Sympa/Constants.pm.in $(nobase_module
 	@rm -f $@
 	$(AM_V_GEN)$(PERL) $< Sympa/Constants.pm.in $(nobase_modules_DATA) > $@
 
-man3pm: $(MAN3POD) Makefile
+stamp-man3: $(MAN3POD) Makefile
 	@test -n "$(man3ext)" || exit 0; \
+	rm -f *.$(man3ext); \
 	for pm in $(MAN3POD); do \
 		echo "$$pm" \
 		| $(SED) -e 's/\.pm$$//' -e 's/\.pod$$//' -e 's/\//::/g' \
@@ -250,34 +255,20 @@ man3pm: $(MAN3POD) Makefile
 			if grep '^=head1 NAME$$' $$pmfile > /dev/null; then \
 				echo "  GEN   " $$pod.$(man3ext); \
 				$(POD2MAN) --section=$(man3ext) \
+					--name $$pod \
 					--center="sympa $(VERSION)" \
 					--lax --release="$(VERSION)" \
 					$$pmfile $$pod.$(man3ext); \
 			fi; \
 		done; \
-	done
+	done; \
+	echo timestamp > stamp-man3T && mv stamp-man3T stamp-man3
 
-install-data-hook: man3pm
-	@test -n "$(man3ext)" || exit 0; \
-	test -n "$(man3dir)" || exit 0; \
-	$(INSTALL) -d "$(DESTDIR)$(man3dir)" || exit 1; \
-	for pm in $(MAN3POD); do \
-		echo "$$pm" \
-		| $(SED) -e 's/\.pm$$//' -e 's/\.pod$$//' -e 's/\//::/g' \
-		| while read pod; do \
-			if test -f $(top_builddir)/src/lib/$$pm; then \
-				pmfile=$(top_builddir)/src/lib/$$pm; \
-			else \
-				pmfile=$(top_srcdir)/src/lib/$$pm; \
-			fi; \
-			if grep '^=head1 NAME$$' $$pmfile > /dev/null; then \
-				echo "installing $$pod.$(man3ext)"; \
-				$(INSTALL_DATA) "$$pod.$(man3ext)" "$(DESTDIR)$(man3dir)" \
-				|| exit $$?; \
-			fi; \
-		done; \
+install-data-hook: stamp-man3
+	for file in *.$(man3ext); do \
+		$(INSTALL_DATA) "$$file" "$(DESTDIR)$(man3dir)"; \
 	done
 
 uninstall-hook:
-	rm -f $(DESTDIR)$(man3dir)/*.$(man3ext)
+	cd "$(DESTDIR)$(man3dir)" && rm -f *.$(man3ext)
 

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -242,12 +242,17 @@ man3pm: $(MAN3POD) Makefile
 		| $(SED) -e 's/\.pm$$//' -e 's/\.pod$$//' -e 's/\//::/g' \
 		| while read pod; do \
 			rm -f $$pod.$(man3ext); \
-			if grep '^=head1 NAME$$' $$pm > /dev/null; then \
+			if test -f $(top_builddir)/src/lib/$$pm; then \
+				pmfile=$(top_builddir)/src/lib/$$pm; \
+			else \
+				pmfile=$(top_srcdir)/src/lib/$$pm; \
+			fi; \
+			if grep '^=head1 NAME$$' $$pmfile > /dev/null; then \
 				echo "  GEN   " $$pod.$(man3ext); \
 				$(POD2MAN) --section=$(man3ext) \
 					--center="sympa $(VERSION)" \
 					--lax --release="$(VERSION)" \
-					$$pm $$pod.$(man3ext); \
+					$$pmfile $$pod.$(man3ext); \
 			fi; \
 		done; \
 	done
@@ -260,11 +265,19 @@ install-data-hook: man3pm
 		echo "$$pm" \
 		| $(SED) -e 's/\.pm$$//' -e 's/\.pod$$//' -e 's/\//::/g' \
 		| while read pod; do \
-			if grep '^=head1 NAME$$' $$pm > /dev/null; then \
+			if test -f $(top_builddir)/src/lib/$$pm; then \
+				pmfile=$(top_builddir)/src/lib/$$pm; \
+			else \
+				pmfile=$(top_srcdir)/src/lib/$$pm; \
+			fi; \
+			if grep '^=head1 NAME$$' $$pmfile > /dev/null; then \
 				echo "installing $$pod.$(man3ext)"; \
 				$(INSTALL_DATA) "$$pod.$(man3ext)" "$(DESTDIR)$(man3dir)" \
 				|| exit $$?; \
 			fi; \
 		done; \
 	done
+
+uninstall-hook:
+	rm -f $(DESTDIR)$(man3dir)/*.$(man3ext)
 


### PR DESCRIPTION
Running `make distcheck` aborts due to missing dependencies, because some rules in `Makefile.am` didn't take care of `$(srcdir)` and `$(builddir)`.
