### PR TITLE
Fix #300 — Allow to delete your own account

### DIFF
--- a/default/mail_tt2/report.tt2
+++ b/default/mail_tt2/report.tt2
@@ -836,6 +836,9 @@ Warning: this message may already have been sent by one of the list's moderators
 [%~ ELSIF report_entry == 'still_owner' ~%]
   [%|loc(report_param.lists)%]You are the only owner of the following list(s): %1. Please give ownership to other people before deleting your account. You have been unsubscribed from all your lists though.[%END%]
 
+[%~ ELSIF report_entry == 'no_classic_session' ~%]
+  [%|loc()%]You are not authorized to delete your account if you are not using the built-in authentication (i.e. you are using a LDAP authentication, a SSO system, etc.).[%END%]
+
 [%~ END ~%]
 
 [%~ END ~%]

--- a/default/mail_tt2/report.tt2
+++ b/default/mail_tt2/report.tt2
@@ -438,6 +438,9 @@
 [%~ ELSIF report_entry == 'logout' ~%]
   [%|loc%]You have logged out[%END%]
 
+[%~ ELSIF report_entry == 'account_deleted' ~%]
+  [%|loc%]You have been unsubscribed from all your lists and your account has been deleted[%END%]
+
 [%~ END ~%]
 
 [%################~%]
@@ -829,6 +832,9 @@ Warning: this message may already have been sent by one of the list's moderators
 
 [%~ ELSIF report_entry == 'owner_domain_min' ~%]
   [%|loc(report_param.value,report_param.owner_domain_min,report_param.owner_domain)%]Unable to reduce the number of list owners in required domains to %1. Domains that count toward the minimum requirement of %2: %3[%END%]
+
+[%~ ELSIF report_entry == 'still_owner' ~%]
+  [%|loc(report_param.lists)%]You are the only owner of the following list(s): %1. Please give ownership to other people before deleting your account. You have been unsubscribed from all your lists though.[%END%]
 
 [%~ END ~%]
 

--- a/default/web_tt2/confirm_action.tt2
+++ b/default/web_tt2/confirm_action.tt2
@@ -1,4 +1,7 @@
 <!-- confirm_action.tt2 -->
+[%#
+  # Set h2 title and text of confirmation page
+  #%]
 [% IF confirm_action == 'add' ~%]
   [% IF previous_action == 'show_exclude' ~%]
     <h2><i class="fa fa-check-circle"></i>
@@ -78,6 +81,15 @@
   </h2>
   <p><strong>
     [%|loc%]Do you really want to unsubscribe ALL selected subscribers?[%END%]
+  </strong></p>
+[%~ ELSIF confirm_action == 'delete_account' ~%]
+  <h2><i class="fa fa-check-circle"></i>
+    [%|loc%]Delete my account[%END%]
+  </h2>
+  <p><strong>
+    [%|loc%]Do you really want to unsubscribe you from all your lists, remove your ownership of your lists and permanently delete your account?[%END%]
+    <br />
+    [%|loc%]Please note that you will not be able to delete your account if you are the only owner of one or more list.[%END%]
   </strong></p>
 [%~ ELSIF confirm_action == 'auth_add' ~%]
   <h2><i class="fa fa-check-circle"></i>
@@ -226,6 +238,11 @@
   </strong></p>
 [%~ END %]
 
+
+[%#
+  # Create the form.
+  # Add hidden fields containing the values of the form you want to confirm
+  # %]
 <form action="[% path_cgi %]" method="POST">
 [% IF confirm_action == 'add' ~%]
   [% FOREACH e = email ~%]
@@ -291,6 +308,11 @@
       [% IF quiet %]checked="checked"[%END%] />
     <label for="quiet">[%|loc%]Quiet (don't send deletion email)[%END%]</label>
   </div>
+[%~ ELSIF confirm_action == 'delete_account' ~%]
+  <fieldset>
+    <input type="hidden" name="passwd" value="x"/>
+    <input type="hidden" name="i_understand_the_consequences" value="1"/>
+  </fieldset>
 [%~ ELSIF confirm_action == 'distribute' ~%]
   [% FOREACH i = id ~%]
     <input type="hidden" name="id" value="[% i %]" />
@@ -354,9 +376,17 @@
      value="[% i.value.value.replace('\n', '&#10;') %]" />
   [%~ END %]
 [%~ END %]
+
+[%#
+  # Confirmation common hidden fields
+  #%]
   <input type="hidden" name="action" value="[% confirm_action %]" />
   <input type="hidden" name="list" value="[% list %]" />
   <input type="hidden" name="previous_action" value="[% previous_action %]" />
+
+[%#
+  # Submit and cancel buttons
+  #%]
 [% IF confirm_action == 'arc' || confirm_action == 'arcsearch_id' ~%]
   <div>
     <input class="MainMenuLinks" type="submit"

--- a/default/web_tt2/pref.tt2
+++ b/default/web_tt2/pref.tt2
@@ -70,6 +70,22 @@
 </form>
 [% END %]
 
+<h4>[%|loc%]Deleting your account[%END%]</h4>
+<p>
+  [%|loc%]Deleting your account will unsubscribe you from all your lists, remove your ownership of your lists and permanently delete your account.[%END%]
+  <br />
+  [%|loc%]Please note that you will not be able to delete your account if you are the only owner of one or more list.[%END%]
+</p>
+<form action="[% path_cgi %]" method="post">
+  <fieldset>
+    <label for="password_for_account_deletion">[%|loc%]Enter your password:[%END%]</label>
+    <input type="password" name="passwd" id="password_for_account_deletion" size="25" />
+    <input type="checkbox" name="i_understand_the_consequences" id="i_understand_the_consequences" required><label for="i_understand_the_consequences">[%|loc%]I understand that I will be unsubscribed from all my lists and that my account will be permanently deleted[%END%]</label>
+    <br />
+    <input class="MainMenuLinks" type="submit" name="action_delete_account" value="[%|loc%]Submit[%END%]" />
+  </fieldset>
+</form>
+
 </div>
 
 <!-- end pref.tt2 -->

--- a/default/web_tt2/pref.tt2
+++ b/default/web_tt2/pref.tt2
@@ -80,7 +80,7 @@
   <fieldset>
     <label for="password_for_account_deletion">[%|loc%]Enter your password:[%END%]</label>
     <input type="password" name="passwd" id="password_for_account_deletion" size="25" />
-    <input type="checkbox" name="i_understand_the_consequences" id="i_understand_the_consequences" required><label for="i_understand_the_consequences">[%|loc%]I understand that I will be unsubscribed from all my lists and that my account will be permanently deleted[%END%]</label>
+    <input type="checkbox" name="i_understand_the_consequences" id="i_understand_the_consequences" required><label for="i_understand_the_consequences">[%|loc%]I understand that I will be unsubscribed from all my lists and that my account will be permanently deleted.[%END%]</label>
     <br />
     <input class="MainMenuLinks" type="submit" name="action_delete_account" value="[%|loc%]Submit[%END%]" />
   </fieldset>

--- a/default/web_tt2/pref.tt2
+++ b/default/web_tt2/pref.tt2
@@ -70,6 +70,7 @@
 </form>
 [% END %]
 
+[% IF session.auth == 'classic' %]
 <h4>[%|loc%]Deleting your account[%END%]</h4>
 <p>
   [%|loc%]Deleting your account will unsubscribe you from all your lists, remove your ownership of your lists and permanently delete your account.[%END%]
@@ -85,6 +86,7 @@
     <input class="MainMenuLinks" type="submit" name="action_delete_account" value="[%|loc%]Submit[%END%]" />
   </fieldset>
 </form>
+[% END %]
 
 </div>
 

--- a/default/web_tt2/pref.tt2
+++ b/default/web_tt2/pref.tt2
@@ -70,7 +70,7 @@
 </form>
 [% END %]
 
-[% IF session.auth == 'classic' %]
+[% IF session.auth == 'classic' AND conf.allow_account_deletion %]
 <h4>[%|loc%]Deleting your account[%END%]</h4>
 <p>
   [%|loc%]Deleting your account will unsubscribe you from all your lists, remove your ownership of your lists and permanently delete your account.[%END%]

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -17155,13 +17155,18 @@ sub do_auth {
 }
 
 sub do_delete_account {
-    wwslog('info', sprintf('Account deletion: %s asked for its account to be deleted', $param->{'user'}->{'email'}));
+    wwslog(
+        'info',
+        sprintf('Account deletion: %s asked for its account to be deleted',
+            $param->{'user'}->{'email'})
+    );
 
     # Show form if HTTP POST method not used.
     return 1 unless $ENV{'REQUEST_METHOD'} eq 'POST';
 
-    my $email  = Sympa::Tools::Text::canonic_email($param->{'user'}->{'email'});
-    my $passwd = delete $in{'passwd'};                         # Clear it.
+    my $email =
+        Sympa::Tools::Text::canonic_email($param->{'user'}->{'email'});
+    my $passwd = delete $in{'passwd'};    # Clear it.
 
     unless ($email) {
         Sympa::WWW::Report::reject_report_web('user', 'no_email', {},
@@ -17176,6 +17181,10 @@ sub do_delete_account {
         );
         return 'pref';
     }
+
+    my $next_action =
+        $session->confirm_action($in{'action'}, $in{'response_action'},
+        previous_action => 'pref');
 
     unless ($passwd) {
         Sympa::WWW::Report::reject_report_web('user', 'missing_arg',
@@ -17194,7 +17203,8 @@ sub do_delete_account {
 
     my $data;
 
-    unless ($data = Sympa::WWW::Auth::check_auth($robot, $email, $passwd)) {
+    unless (($next_action eq '1')
+        || ($data = Sympa::WWW::Auth::check_auth($robot, $email, $passwd))) {
         $log->syslog('notice', 'Authentication failed');
         web_db_log(
             {   'parameters'   => $email,
@@ -17206,8 +17216,9 @@ sub do_delete_account {
         return 'pref';
     }
 
+    return $next_action unless $next_action eq '1';
+
     $param->{'email'} = $email;
-    $param->{'user'}  = $data->{'user'};
 
     _set_my_lists_info();
 
@@ -17215,9 +17226,11 @@ sub do_delete_account {
     for my $list (sort keys %{$param->{'which'}}) {
         my $l = Sympa::List->new($list, $robot);
         # Unsubscribe
-        $l->delete_list_member('users' => [$email]) if $param->{'which'}->{$list}->{'is_subscriber'};
+        $l->delete_list_member('users' => [$email])
+            if $param->{'which'}->{$list}->{'is_subscriber'};
         # Remove from the editors
-        $l->delete_list_admin('editor', $email) if $param->{'which'}->{$list}->{'is_editor'};
+        $l->delete_list_admin('editor', $email)
+            if $param->{'which'}->{$list}->{'is_editor'};
         # Remove from the owners
         if ($param->{'which'}->{$list}->{'is_owner'}) {
             my @admins = $l->get_admins('owner');
@@ -17229,20 +17242,26 @@ sub do_delete_account {
                 unless (scalar(@privileged_admins)) {
                     @admins = $l->get_admins('owner');
                     for my $admin (@admins) {
-                        $l->update_list_admin($admin->{email}, 'owner', {profile => 'privileged'});
+                        $l->update_list_admin($admin->{email}, 'owner',
+                            {profile => 'privileged'});
                     }
                 }
             } else {
-                wwslog('info', sprintf('Account deletion: %s is the only owner of %s. The account will not be deleted.', $email, $list));
+                wwslog(
+                    'info',
+                    sprintf(
+                        'Account deletion: %s is the only owner of %s. The account will not be deleted.',
+                        $email, $list
+                    )
+                );
                 push @only_owner, $list;
             }
         }
     }
 
-
     if (@only_owner) {
         Sympa::WWW::Report::reject_report_web('user', 'still_owner',
-            { lists => join(', ', @only_owner) },
+            {lists => join(', ', @only_owner)},
             $param->{'action'});
         return 'pref';
     }
@@ -17250,9 +17269,14 @@ sub do_delete_account {
     my $user = Sympa::User->new($email);
     $user->expire;
 
-    wwslog('info', sprintf('Account deletion: the account of %s has been deleted', $email));
+    wwslog(
+        'info',
+        sprintf('Account deletion: the account of %s has been deleted',
+            $email)
+    );
 
-    Sympa::WWW::Report::notice_report_web('account_deleted', {}, $param->{'action'});
+    Sympa::WWW::Report::notice_report_web('account_deleted', {},
+        $param->{'action'});
 
     do_logout();
 }

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -17182,6 +17182,20 @@ sub do_delete_account {
         return 'pref';
     }
 
+    unless ($session->{auth} eq 'classic') {
+        Sympa::WWW::Report::reject_report_web('user', 'no_classic_session',
+            {}, $param->{'action'});
+        wwslog('info', 'No classic session');
+        web_db_log(
+            {   'parameters'   => $email,
+                'target_email' => $email,
+                'status'       => 'error',
+                'error_type'   => "no_classic_session"
+            }
+        );
+        return 'pref';
+    }
+
     my $next_action =
         $session->confirm_action($in{'action'}, $in{'response_action'},
         previous_action => 'pref');

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -731,12 +731,12 @@ our %required_privileges = (
 # as possible.
 
 our %require_csrftoken = (
-    'add'            => 1,
-    'del'            => 1,
-    'move_user'      => 1,
-    'savefile'       => 1,
-    'setpasswd'      => 1,
-    'setpref'        => 1,
+    'add'       => 1,
+    'del'       => 1,
+    'move_user' => 1,
+    'savefile'  => 1,
+    'setpasswd' => 1,
+    'setpref'   => 1,
 );
 
 # this definition is used to choose the left side menu type (admin ->
@@ -1169,6 +1169,7 @@ while ($query = CGI::Fast->new) {
         'pictures_max_size',
         'show_report_abuse',
         'quiet_subscription',
+        'allow_account_deletion',
     ) {
 
         $param->{'conf'}{$p} = Conf::get_robot_conf($robot, $p);
@@ -17155,144 +17156,156 @@ sub do_auth {
 }
 
 sub do_delete_account {
-    wwslog(
-        'info',
-        sprintf('Account deletion: %s asked for its account to be deleted',
-            $param->{'user'}->{'email'})
-    );
-
-    # Show form if HTTP POST method not used.
-    return 1 unless $ENV{'REQUEST_METHOD'} eq 'POST';
-
-    my $email =
-        Sympa::Tools::Text::canonic_email($param->{'user'}->{'email'});
-    my $passwd = delete $in{'passwd'};    # Clear it.
-
-    unless ($email) {
-        Sympa::WWW::Report::reject_report_web('user', 'no_email', {},
-            $param->{'action'});
-        wwslog('info', 'No email');
-        web_db_log(
-            {   'parameters'   => $email,
-                'target_email' => $email,
-                'status'       => 'error',
-                'error_type'   => "no_email"
-            }
+    if (Conf::get_robot_conf($robot, 'allow_account_deletion')) {
+        wwslog(
+            'info',
+            sprintf(
+                'Account deletion: %s asked for its account to be deleted',
+                $param->{'user'}->{'email'})
         );
-        return 'pref';
-    }
 
-    unless ($session->{auth} eq 'classic') {
-        Sympa::WWW::Report::reject_report_web('user', 'no_classic_session',
-            {}, $param->{'action'});
-        wwslog('info', 'No classic session');
-        web_db_log(
-            {   'parameters'   => $email,
-                'target_email' => $email,
-                'status'       => 'error',
-                'error_type'   => "no_classic_session"
-            }
-        );
-        return 'pref';
-    }
+        # Show form if HTTP POST method not used.
+        return 1 unless $ENV{'REQUEST_METHOD'} eq 'POST';
 
-    my $next_action =
-        $session->confirm_action($in{'action'}, $in{'response_action'},
-        previous_action => 'pref');
+        my $email =
+            Sympa::Tools::Text::canonic_email($param->{'user'}->{'email'});
+        my $passwd = delete $in{'passwd'};    # Clear it.
 
-    unless ($passwd) {
-        Sympa::WWW::Report::reject_report_web('user', 'missing_arg',
-            {'argument' => 'passwd'},
-            $param->{'action'});
-        wwslog('info', 'Missing parameter passwd');
-        web_db_log(
-            {   'parameters'   => $email,
-                'target_email' => $email,
-                'status'       => 'error',
-                'error_type'   => "missing_parameter"
-            }
-        );
-        return 'pref';
-    }
-
-    my $data;
-
-    unless (($next_action eq '1')
-        || ($data = Sympa::WWW::Auth::check_auth($robot, $email, $passwd))) {
-        $log->syslog('notice', 'Authentication failed');
-        web_db_log(
-            {   'parameters'   => $email,
-                'target_email' => $email,
-                'status'       => 'error',
-                'error_type'   => 'authentication'
-            }
-        );
-        return 'pref';
-    }
-
-    return $next_action unless $next_action eq '1';
-
-    $param->{'email'} = $email;
-
-    _set_my_lists_info();
-
-    my @only_owner;
-    for my $list (sort keys %{$param->{'which'}}) {
-        my $l = Sympa::List->new($list, $robot);
-        # Unsubscribe
-        $l->delete_list_member('users' => [$email])
-            if $param->{'which'}->{$list}->{'is_subscriber'};
-        # Remove from the editors
-        $l->delete_list_admin('editor', $email)
-            if $param->{'which'}->{$list}->{'is_editor'};
-        # Remove from the owners
-        if ($param->{'which'}->{$list}->{'is_owner'}) {
-            my @admins = $l->get_admins('owner');
-            if (scalar(@admins) > 1) {
-                $l->delete_list_admin('owner', $email);
-
-                # Don't let a list without a privileged admin
-                my @privileged_admins = $l->get_admins('privileged_owner');
-                unless (scalar(@privileged_admins)) {
-                    @admins = $l->get_admins('owner');
-                    for my $admin (@admins) {
-                        $l->update_list_admin($admin->{email}, 'owner',
-                            {profile => 'privileged'});
-                    }
+        unless ($email) {
+            Sympa::WWW::Report::reject_report_web('user', 'no_email', {},
+                $param->{'action'});
+            wwslog('info', 'No email');
+            web_db_log(
+                {   'parameters'   => $email,
+                    'target_email' => $email,
+                    'status'       => 'error',
+                    'error_type'   => "no_email"
                 }
-            } else {
-                wwslog(
-                    'info',
-                    sprintf(
-                        'Account deletion: %s is the only owner of %s. The account will not be deleted.',
-                        $email, $list
-                    )
-                );
-                push @only_owner, $list;
+            );
+            return 'pref';
+        }
+
+        unless ($session->{auth} eq 'classic') {
+            Sympa::WWW::Report::reject_report_web('user',
+                'no_classic_session', {}, $param->{'action'});
+            wwslog('info', 'No classic session');
+            web_db_log(
+                {   'parameters'   => $email,
+                    'target_email' => $email,
+                    'status'       => 'error',
+                    'error_type'   => "no_classic_session"
+                }
+            );
+            return 'pref';
+        }
+
+        my $next_action =
+            $session->confirm_action($in{'action'}, $in{'response_action'},
+            previous_action => 'pref');
+
+        unless ($passwd) {
+            Sympa::WWW::Report::reject_report_web('user', 'missing_arg',
+                {'argument' => 'passwd'},
+                $param->{'action'});
+            wwslog('info', 'Missing parameter passwd');
+            web_db_log(
+                {   'parameters'   => $email,
+                    'target_email' => $email,
+                    'status'       => 'error',
+                    'error_type'   => "missing_parameter"
+                }
+            );
+            return 'pref';
+        }
+
+        my $data;
+
+        unless (($next_action eq '1')
+            || ($data = Sympa::WWW::Auth::check_auth($robot, $email, $passwd))
+        ) {
+            $log->syslog('notice', 'Authentication failed');
+            web_db_log(
+                {   'parameters'   => $email,
+                    'target_email' => $email,
+                    'status'       => 'error',
+                    'error_type'   => 'authentication'
+                }
+            );
+            return 'pref';
+        }
+
+        return $next_action unless $next_action eq '1';
+
+        $param->{'email'} = $email;
+
+        _set_my_lists_info();
+
+        my @only_owner;
+        for my $list (sort keys %{$param->{'which'}}) {
+            my $l = Sympa::List->new($list, $robot);
+            # Unsubscribe
+            $l->delete_list_member('users' => [$email])
+                if $param->{'which'}->{$list}->{'is_subscriber'};
+            # Remove from the editors
+            $l->delete_list_admin('editor', $email)
+                if $param->{'which'}->{$list}->{'is_editor'};
+            # Remove from the owners
+            if ($param->{'which'}->{$list}->{'is_owner'}) {
+                my @admins = $l->get_admins('owner');
+                if (scalar(@admins) > 1) {
+                    $l->delete_list_admin('owner', $email);
+
+                    # Don't let a list without a privileged admin
+                    my @privileged_admins =
+                        $l->get_admins('privileged_owner');
+                    unless (scalar(@privileged_admins)) {
+                        @admins = $l->get_admins('owner');
+                        for my $admin (@admins) {
+                            $l->update_list_admin($admin->{email}, 'owner',
+                                {profile => 'privileged'});
+                        }
+                    }
+                } else {
+                    wwslog(
+                        'info',
+                        sprintf(
+                            'Account deletion: %s is the only owner of %s. The account will not be deleted.',
+                            $email, $list
+                        )
+                    );
+                    push @only_owner, $list;
+                }
             }
         }
-    }
 
-    if (@only_owner) {
-        Sympa::WWW::Report::reject_report_web('user', 'still_owner',
-            {lists => join(', ', @only_owner)},
+        if (@only_owner) {
+            Sympa::WWW::Report::reject_report_web('user', 'still_owner',
+                {lists => join(', ', @only_owner)},
+                $param->{'action'});
+            return 'pref';
+        }
+
+        my $user = Sympa::User->new($email);
+        $user->expire;
+
+        wwslog(
+            'info',
+            sprintf('Account deletion: the account of %s has been deleted',
+                $email)
+        );
+
+        Sympa::WWW::Report::notice_report_web('account_deleted', {},
             $param->{'action'});
-        return 'pref';
+
+        do_logout();
+    } else {
+        wwslog(
+            'info',
+            sprintf(
+                'Account deletion: %s asked for its account to be deleted but allow_account_deletion is not set to 1.',
+                $param->{'user'}->{'email'})
+        );
     }
-
-    my $user = Sympa::User->new($email);
-    $user->expire;
-
-    wwslog(
-        'info',
-        sprintf('Account deletion: the account of %s has been deleted',
-            $email)
-    );
-
-    Sympa::WWW::Report::notice_report_web('account_deleted', {},
-        $param->{'action'});
-
-    do_logout();
 }
 
 sub prevent_visibility_bypass {

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -333,6 +333,7 @@ our %comm = (
     'create_automatic_list'         => 'do_create_automatic_list',
     'create_automatic_list_request' => 'do_create_automatic_list_request',
     'auth'                          => 'do_auth',
+    'delete_account'                => 'do_delete_account',
 );
 
 my %comm_aliases = (
@@ -568,6 +569,7 @@ our %required_args = (
     'get_pending_lists'    => ['param.user.email'],
     'decl_del'             => ['param.list', 'param.user.email'],
     'decl_add'             => ['param.list', 'param.user.email'],
+    'delete_account'       => ['passwd', 'i_understand_the_consequences'],
     'including_lists'      => ['param.list', 'param.user.email'],
     'info'                 => ['param.list'],
     'install_pending_list' => ['param.user.email'],
@@ -17150,6 +17152,109 @@ sub do_auth {
     }
 
     return $default_home;
+}
+
+sub do_delete_account {
+    wwslog('info', sprintf('Account deletion: %s asked for its account to be deleted', $param->{'user'}->{'email'}));
+
+    # Show form if HTTP POST method not used.
+    return 1 unless $ENV{'REQUEST_METHOD'} eq 'POST';
+
+    my $email  = Sympa::Tools::Text::canonic_email($param->{'user'}->{'email'});
+    my $passwd = delete $in{'passwd'};                         # Clear it.
+
+    unless ($email) {
+        Sympa::WWW::Report::reject_report_web('user', 'no_email', {},
+            $param->{'action'});
+        wwslog('info', 'No email');
+        web_db_log(
+            {   'parameters'   => $email,
+                'target_email' => $email,
+                'status'       => 'error',
+                'error_type'   => "no_email"
+            }
+        );
+        return 'pref';
+    }
+
+    unless ($passwd) {
+        Sympa::WWW::Report::reject_report_web('user', 'missing_arg',
+            {'argument' => 'passwd'},
+            $param->{'action'});
+        wwslog('info', 'Missing parameter passwd');
+        web_db_log(
+            {   'parameters'   => $email,
+                'target_email' => $email,
+                'status'       => 'error',
+                'error_type'   => "missing_parameter"
+            }
+        );
+        return 'pref';
+    }
+
+    my $data;
+
+    unless ($data = Sympa::WWW::Auth::check_auth($robot, $email, $passwd)) {
+        $log->syslog('notice', 'Authentication failed');
+        web_db_log(
+            {   'parameters'   => $email,
+                'target_email' => $email,
+                'status'       => 'error',
+                'error_type'   => 'authentication'
+            }
+        );
+        return 'pref';
+    }
+
+    $param->{'email'} = $email;
+    $param->{'user'}  = $data->{'user'};
+
+    _set_my_lists_info();
+
+    my @only_owner;
+    for my $list (sort keys %{$param->{'which'}}) {
+        my $l = Sympa::List->new($list, $robot);
+        # Unsubscribe
+        $l->delete_list_member('users' => [$email]) if $param->{'which'}->{$list}->{'is_subscriber'};
+        # Remove from the editors
+        $l->delete_list_admin('editor', $email) if $param->{'which'}->{$list}->{'is_editor'};
+        # Remove from the owners
+        if ($param->{'which'}->{$list}->{'is_owner'}) {
+            my @admins = $l->get_admins('owner');
+            if (scalar(@admins) > 1) {
+                $l->delete_list_admin('owner', $email);
+
+                # Don't let a list without a privileged admin
+                my @privileged_admins = $l->get_admins('privileged_owner');
+                unless (scalar(@privileged_admins)) {
+                    @admins = $l->get_admins('owner');
+                    for my $admin (@admins) {
+                        $l->update_list_admin($admin->{email}, 'owner', {profile => 'privileged'});
+                    }
+                }
+            } else {
+                wwslog('info', sprintf('Account deletion: %s is the only owner of %s. The account will not be deleted.', $email, $list));
+                push @only_owner, $list;
+            }
+        }
+    }
+
+
+    if (@only_owner) {
+        Sympa::WWW::Report::reject_report_web('user', 'still_owner',
+            { lists => join(', ', @only_owner) },
+            $param->{'action'});
+        return 'pref';
+    }
+
+    my $user = Sympa::User->new($email);
+    $user->expire;
+
+    wwslog('info', sprintf('Account deletion: the account of %s has been deleted', $email));
+
+    Sympa::WWW::Report::notice_report_web('account_deleted', {}, $param->{'action'});
+
+    do_logout();
 }
 
 sub prevent_visibility_bypass {

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -2151,6 +2151,15 @@ our @params = (
         'file'     => 'sympa.conf',
         'optional' => 1,
     },
+    {   'name' => 'allow_account_deletion',
+        'gettext_id' =>
+            'EXPERIMENTAL! Allow users to delete their account. If enabled, shows a "delete my account" form in user\'s preferences page.',
+        'gettext_comment' =>
+            'Account deletion usubscribe the users from his/her lists and remove him/her from lists ownership. Only usable by users using internal authentication (i.e. no LDAP, no SSO…). See https://github.com/sympa-community/sympa/issues/300 for details',
+        'default'  => '0',
+        'file'     => 'sympa.conf',
+        'optional' => 1,
+    },
 
 ## Not implemented yet.
 ##    {

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -6423,10 +6423,11 @@ sub _load_include_admin_user_file {
                 unless (defined $hash{$k}) {
                     if (defined $pinfo->{$pname}{'file_format'}{$k}{'default'}
                     ) {
-                        $hash{$k} =
-                            $self->_load_list_param($k,
+                        $hash{$k} = $self->_load_list_param(
+                            $k,
                             $pinfo->{$pname}{'file_format'}{$k}{'default'},
-                            $pinfo->{$pname}{'file_format'}{$k});
+                            $pinfo->{$pname}{'file_format'}{$k}
+                        );
                     }
                 }
                 ## Required fields
@@ -8156,7 +8157,7 @@ sub _load_list_param {
 
     # Empty value.
     unless (defined $value and $value =~ /\S/) {
-        return undef;   #FIXME
+        return undef;    #FIXME
     }
 
     ## Search configuration file
@@ -8432,10 +8433,11 @@ sub _load_list_config_file {
                 unless (defined $hash{$k}) {
                     if (defined $pinfo->{$pname}{'file_format'}{$k}{'default'}
                     ) {
-                        $hash{$k} =
-                            $self->_load_list_param($k,
+                        $hash{$k} = $self->_load_list_param(
+                            $k,
                             $pinfo->{$pname}{'file_format'}{$k}{'default'},
-                            $pinfo->{$pname}{'file_format'}{$k});
+                            $pinfo->{$pname}{'file_format'}{$k}
+                        );
                     }
                 }
 

--- a/src/lib/Sympa/Robot.pm
+++ b/src/lib/Sympa/Robot.pm
@@ -265,8 +265,8 @@ sub load_topics {
                 $list_of_topics{$robot}{$tree[0]}{'order'} =
                     $topic->{'order'};
             } else {
-                my $subtopic   = join('/', @tree[1 .. $#tree]);
-                my $title      = _load_topics_get_title($topic);
+                my $subtopic = join('/', @tree[1 .. $#tree]);
+                my $title = _load_topics_get_title($topic);
                 my $visibility =
                     $topic->{'visibility'} || $default_topics_visibility;
                 $list_of_topics{$robot}{$tree[0]}{'sub'}{$subtopic} =


### PR DESCRIPTION
Only from web interface for now.

- add a form on pref page to delete the account
- checks the password of the user
- if it's good:
  - unsubscribe the user from all its lists
  - remove the user from the editor role of all its lists
  - remove the user from owner role of all its lists *only* if he/she
    is not the only owner (=> don't delete the account and give an error message)
  - if he/she was the only privileged owner of a list, give privileged
    profile to all unprivileged owners