### PR TITLE
Inconsistent location of messge footer/header files #507

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -8480,16 +8480,22 @@ sub do_savefile {
             if ($in{'file'} eq 'list_aliases.tt2') {
                 $param->{'filepath'} =
                     "$Conf::Conf{'etc'}/$robot/$in{'file'}";
-            } else {
+            } elsif ($in{'file'} =~ /\.tt2$/) {
                 $param->{'filepath'} =
                     "$Conf::Conf{'etc'}/$robot/mail_tt2/$in{'file'}";
+            } else {
+                $param->{'filepath'} =
+                    "$Conf::Conf{'etc'}/$robot/$in{'file'}";
             }
         } else {
             if ($in{'file'} eq 'list_aliases.tt2') {
                 $param->{'filepath'} = "$Conf::Conf{'etc'}/$in{'file'}";
-            } else {
+            } elsif ($in{'file'} =~ /\.tt2$/) {
                 $param->{'filepath'} =
                     "$Conf::Conf{'etc'}/mail_tt2/$in{'file'}";
+            } else {
+                $param->{'filepath'} =
+                    "$Conf::Conf{'etc'}/$in{'file'}";
             }
         }
     }

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -6104,29 +6104,6 @@ sub do_setpasswd {
 sub do_admin {
     wwslog('info', '');
 
-    ## Messages edition
-    #FIXME: No longer used: Kept for backward compatibility.
-    foreach my $f (
-        'info',           'homepage',
-        'welcome.tt2',    'bye.tt2',
-        'removed.tt2',    'message.footer',
-        'message.header', 'remind.tt2',
-        'invite.tt2',     'reject.tt2'
-    ) {
-        my ($role, $right) =
-            $list->may_edit($f, $param->{'user'}{'email'}, file => 1);
-        next unless $right eq 'write';
-        if ($Sympa::WWW::Tools::filenames{$f}{'gettext_id'}) {
-            $param->{'files'}{$f}{'complete'} =
-                $language->gettext(
-                $Sympa::WWW::Tools::filenames{$f}{'gettext_id'});
-        } else {
-            $param->{'files'}{$f}{'complete'} = $f;
-        }
-        $param->{'files'}{$f}{'selected'} = '';
-    }
-    $param->{'files'}{'info'}{'selected'} = 'selected="selected"';
-
     return 1;
 }
 
@@ -6139,8 +6116,8 @@ sub do_serveradmin {
     ## Lists Default files
     foreach my $f (
         'welcome.tt2',    'bye.tt2',
-        'removed.tt2',    'message.footer',
-        'message.header', 'remind.tt2',
+        'removed.tt2',    'message_header',
+        'message_footer', 'remind.tt2',
         'invite.tt2',     'reject.tt2',
         'your_infected_msg.tt2'
     ) {
@@ -8243,16 +8220,16 @@ sub do_editfile {
         description_templates => ['info', 'homepage'],
         message_templates     => [
             'welcome.tt2',    'bye.tt2',
-            'removed.tt2',    'message.footer',
-            'message.header', 'remind.tt2',
+            'removed.tt2',    'message_header',
+            'message_footer', 'remind.tt2',
             'invite.tt2',     'reject.tt2',
             'your_infected_msg.tt2'
         ],
         all_templates => [
             'info',           'homepage',
             'welcome.tt2',    'bye.tt2',
-            'removed.tt2',    'message.footer',
-            'message.header', 'remind.tt2',
+            'removed.tt2',    'message_header',
+            'message_footer', 'remind.tt2',
             'invite.tt2',     'reject.tt2',
             'your_infected_msg.tt2'
         ]

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -863,7 +863,7 @@ our @params = (
         'file'       => 'sympa.conf',
         'split_char' => ',',
         'default' =>
-            'message.footer,message.header,message.footer.mime,message.header.mime,info',
+            'message_header,message_header.mime,message_footer,message_footer.mime,info',
         'vhost' => '1',
     },
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -4176,7 +4176,11 @@ sub may_edit {
     ## What privilege does he/she has?
     my ($what, @order);
 
-    if ($parameter =~ /^(\w+)\.(\w+)$/ and $parameter !~ /\.tt2$/) {
+    if (    $parameter =~ /^(\w+)\.(\w+)$/
+        and $parameter !~ /\.tt2$/
+        and $parameter ne 'message_header.mime'
+        and $parameter ne 'message_footer.mime'
+        and $parameter ne 'message_global_footer.mime') {
         my $main_parameter = $1;
         @order = (
             $edit_list_conf->{$parameter}{$role},

--- a/src/lib/Sympa/Request/Handler/create_automatic_list.pm
+++ b/src/lib/Sympa/Request/Handler/create_automatic_list.pm
@@ -165,13 +165,23 @@ sub _twist {
 
     ## Create associated files if a template was given.
     my @files_to_parse;
-    foreach my $file (split ',',
+    foreach my $file (split /\s*,\s*/,
         Conf::get_robot_conf($robot_id, 'parsed_family_files')) {
-        $file =~ s{\s}{}g;
+        # Compat. <= 6.2.38: message.* were moved to message_*.
+        $file =~ s/\Amessage[.](header|footer)\b/message_$1/;
+
         push @files_to_parse, $file;
     }
     for my $file (@files_to_parse) {
-        my $template_file = Sympa::search_fullpath($family, $file . ".tt2");
+        # Compat. <= 6.2.38: message.* were obsoleted by message_*.
+        my $file_obs;
+        if ($file =~ /\Amessage_(header|footer)\b(.*)\z/) {
+            $file_obs = "message.$1$2";
+        }
+        my $template_file = Sympa::search_fullpath($family, $file . '.tt2');
+        $template_file = Sympa::search_fullpath($family, $file_obs . '.tt2')
+            if not $template_file and $file_obs;
+
         if (defined $template_file) {
             my $file_content;
             my $template =

--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -508,7 +508,7 @@ sub _copy {
         }
     }
     # copy optional files
-    foreach my $file ('message.footer', 'message.header', 'info', 'homepage')
+    foreach my $file ('message_header', 'message_footer', 'info', 'homepage')
     {
         if (-f $current_list->{'dir'} . '/' . $file) {
             unless (

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -1900,7 +1900,7 @@ sub upgrade {
         }
     }
 
-    if (lower_version($previous_version, '6.2.39b.1')) {
+    if (lower_version($previous_version, '6.2.41b.1')) {
         # The header/footer files were renamed.
         # Site-level files were moved.
         my %file_map = (

--- a/src/lib/Sympa/WWW/Tools.pm
+++ b/src/lib/Sympa/WWW/Tools.pm
@@ -61,13 +61,13 @@ our %cookie_period = (
     43200 => {'gettext_id' => "30 days"}
 );
 
-## Filenames with corresponding entry in NLS set 15
+# File names with corresponding entry in NLS set
 our %filenames = (
     'welcome.tt2'       => {'gettext_id' => "welcome message"},
     'bye.tt2'           => {'gettext_id' => "unsubscribe message"},
     'removed.tt2'       => {'gettext_id' => "deletion message"},
-    'message.footer'    => {'gettext_id' => "message footer"},
-    'message.header'    => {'gettext_id' => "message header"},
+    'message_header'    => {'gettext_id' => "message header"},
+    'message_footer'    => {'gettext_id' => "message footer"},
     'remind.tt2'        => {'gettext_id' => "remind message"},
     'reject.tt2'        => {'gettext_id' => "moderator rejection message"},
     'invite.tt2'        => {'gettext_id' => "subscribing invitation message"},


### PR DESCRIPTION
This may fix #507.

Fixes:

  - [bug] Message footer/header files of domain/site default are put in `mail_tt2` subdirectories while those of list config are not.
    Fixed by putting all of them in consistent location without intermediate directories (See also Notes below).
  - [bug] Entries for header/footer files in `edit_list.conf` were ignored.

Changes:

  - File names themselves of header/footer were changed:
    `message_header`, `message_header.mime` etc.
    This is due to consideration about conflict between files and directories with domain names (See also Notes below).
  - [change] Header/footer files with `.mime` extension:
    Previously, files with this extension were always preferred, then if they were not found, files without extension were used.  This behavior has not been documented.
    Now files with extension will be searched only in case that `footer_type` list parameter is set to `mime`.  Files without extension will be searched in both cases.

Notes:

  - Files with older names/paths in list/domain/site config directories will be copied to new location during upgrading process.
  - Template files with old names in families (`message.header.tt2` etc.) will be used as before and will be copied to new location during instantiation. If files with new names (`message_header.tt2` etc.) are added by administrator, they will be used.

Known bug:

  - There are no web UI to edit global footer (`message_global_footer`).
