### PR TITLE
A scalar parameter in list config without value is warned

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -6392,7 +6392,7 @@ sub _load_include_admin_user_file {
                 }
 
                 unless ($paragraph[$i] =~
-                    /^\s*$key\s+($pinfo->{$pname}{'file_format'}{$key}{'file_format'})\s*$/i
+                    /^\s*$key(?:\s+($pinfo->{$pname}{'file_format'}{$key}{'file_format'}))?\s*$/i
                 ) {
                     chomp($paragraph[$i]);
                     $log->syslog('info',
@@ -6415,7 +6415,8 @@ sub _load_include_admin_user_file {
                     if (defined $pinfo->{$pname}{'file_format'}{$k}{'default'}
                     ) {
                         $hash{$k} =
-                            $self->_load_list_param($k, 'default',
+                            $self->_load_list_param($k,
+                            $pinfo->{$pname}{'file_format'}{$k}{'default'},
                             $pinfo->{$pname}{'file_format'}{$k});
                     }
                 }
@@ -6448,7 +6449,7 @@ sub _load_include_admin_user_file {
             }
 
             unless ($paragraph[0] =~
-                /^\s*$pname\s+($pinfo->{$pname}{'file_format'})\s*$/i) {
+                /^\s*$pname(?:\s+($pinfo->{$pname}{'file_format'}))?\s*$/i) {
                 chomp($paragraph[0]);
                 $log->syslog('info', 'Bad entry "%s" in %s',
                     $paragraph[0], $file);
@@ -8144,14 +8145,9 @@ sub _load_list_param {
     my $robot     = $self->{'domain'};
     my $directory = $self->{'dir'};
 
-    ## Empty value
-    if ($value =~ /^\s*$/) {
-        return undef;
-    }
-
-    ## Default
-    if ($value eq 'default') {
-        $value = $p->{'default'};
+    # Empty value.
+    unless (defined $value and $value =~ /\S/) {
+        return undef;   #FIXME
     }
 
     ## Search configuration file
@@ -8400,7 +8396,7 @@ sub _load_list_config_file {
                 }
 
                 unless ($paragraph[$i] =~
-                    /^\s*$key\s+($pinfo->{$pname}{'file_format'}{$key}{'file_format'})\s*$/i
+                    /^\s*$key(?:\s+($pinfo->{$pname}{'file_format'}{$key}{'file_format'}))?\s*$/i
                 ) {
                     chomp($paragraph[$i]);
                     $log->syslog(
@@ -8464,7 +8460,7 @@ sub _load_list_config_file {
             }
 
             unless ($paragraph[0] =~
-                /^\s*$pname\s+($pinfo->{$pname}{'file_format'})\s*$/i) {
+                /^\s*$pname(?:\s+($pinfo->{$pname}{'file_format'}))?\s*$/i) {
                 chomp($paragraph[0]);
                 $log->syslog('info', 'Bad entry "%s" in %s',
                     $paragraph[0], $config_file);

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -8424,7 +8424,8 @@ sub _load_list_config_file {
                     if (defined $pinfo->{$pname}{'file_format'}{$k}{'default'}
                     ) {
                         $hash{$k} =
-                            $self->_load_list_param($k, 'default',
+                            $self->_load_list_param($k,
+                            $pinfo->{$pname}{'file_format'}{$k}{'default'},
                             $pinfo->{$pname}{'file_format'}{$k});
                     }
                 }


### PR DESCRIPTION
  - [-bug] A scalar parameter in list config without value and separator is warned.

See GH issue #468, Additional information.
