### PR TITLE
Wrong file name for implicit inclusion of scenario #520

### DIFF
--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -516,7 +516,7 @@ sub request_action {
     my %param = (
         'function' => 'include',
         'robot'    => $robot_id,
-        'name'     => $operation . '.header',
+        'name'     => $scenario->{'function'} . '.header',
         'options'  => $context->{'options'}
     );
     $param{'directory'} = $list->{'dir'} if $list;


### PR DESCRIPTION
This may fix #520.

If a compound parameter (e.g. `shared_doc.d_read`) is given, corresponding scenario (`d_read.xxx`) mistakenly tries to include header file with parameter name (`include.shared_doc.d_read.header`) instead of that with scenario function name (`include.d_read.header`).

Fixed by assigning correct identifier.
