### PR TITLE
(review.tt2) Make column header for "delete" checkboxes visible in owner/moderator edit panel

### DIFF
--- a/default/web_tt2/review.tt2
+++ b/default/web_tt2/review.tt2
@@ -279,8 +279,8 @@
 
   [% IF pS.privilege == 'write' && is_privileged_owner ~%]
     <div class="small-2 medium-1 columns" role="columnheader">
-      <label title="[%|loc%]Delete[%END%]">
-        <i class="fa fa-user-times"></i>
+      <label>
+         [%|loc%]delete[%END%]
       </label>
     </div>
   [%~ END %]


### PR DESCRIPTION
When editing owners/moderators, the column for the "delete" checkboxes does not display a visible header like the other columns do.

This commit uses a simple ``<label>`` tag rather than an empty ``<i>``, which seems to be used elsewhere for hover-over labels.


