### PR TITLE
Weaken sympa and wwsympa/sympa soap link

### DIFF
--- a/src/etc/script/sympa-archive.servicein
+++ b/src/etc/script/sympa-archive.servicein
@@ -1,7 +1,7 @@
 [Unit]
 Description=Sympa mailing list manager (archiving)
 After=syslog.target
-BindTo=sympa.service
+BindsTo=sympa.service
  
 [Service]
 Type=forking

--- a/src/etc/script/sympa-bounce.servicein
+++ b/src/etc/script/sympa-bounce.servicein
@@ -1,7 +1,7 @@
 [Unit]
 Description=Sympa mailing list manager (bounce processing)
 After=syslog.target
-BindTo=sympa.service
+BindsTo=sympa.service
  
 [Service]
 Type=forking

--- a/src/etc/script/sympa-outgoing.servicein
+++ b/src/etc/script/sympa-outgoing.servicein
@@ -1,7 +1,7 @@
 [Unit]
 Description=Sympa mailing list manager (message distribution)
 After=syslog.target
-BindTo=sympa.service
+BindsTo=sympa.service
  
 [Service]
 Type=forking

--- a/src/etc/script/sympa-task.servicein
+++ b/src/etc/script/sympa-task.servicein
@@ -1,7 +1,7 @@
 [Unit]
 Description=Sympa mailing list manager (task management)
 After=syslog.target
-BindTo=sympa.service
+BindsTo=sympa.service
  
 [Service]
 Type=forking

--- a/src/etc/script/sympasoap.servicein
+++ b/src/etc/script/sympasoap.servicein
@@ -1,7 +1,6 @@
 [Unit]
 Description=SympaSOAP - SOAP interface for Sympa mailing list manager
-After=syslog.target
-BindsTo=sympa.service
+After=syslog.target sympa.service
  
 [Service]
 Type=forking

--- a/src/etc/script/sympasoap.servicein
+++ b/src/etc/script/sympasoap.servicein
@@ -1,7 +1,7 @@
 [Unit]
 Description=SympaSOAP - SOAP interface for Sympa mailing list manager
 After=syslog.target
-BindTo=sympa.service
+BindsTo=sympa.service
  
 [Service]
 Type=forking

--- a/src/etc/script/wwsympa.servicein
+++ b/src/etc/script/wwsympa.servicein
@@ -1,7 +1,6 @@
 [Unit]
 Description=WWSympa - Web interface for Sympa mailing list manager
-After=syslog.target
-BindsTo=sympa.service
+After=syslog.target sympa.service
  
 [Service]
 Type=forking

--- a/src/etc/script/wwsympa.servicein
+++ b/src/etc/script/wwsympa.servicein
@@ -1,7 +1,7 @@
 [Unit]
 Description=WWSympa - Web interface for Sympa mailing list manager
 After=syslog.target
-BindTo=sympa.service
+BindsTo=sympa.service
  
 [Service]
 Type=forking


### PR DESCRIPTION
wwsympa and sympasoap do not strictly require the other sympa services to be
useful. However, BindsTo enforces that in both systemd unit files, thus replace
with After.