### PR TITLE
Invalid default scenarios

### DIFF
--- a/default/Makefile.am
+++ b/default/Makefile.am
@@ -410,23 +410,6 @@ EXTRA_DIST = $(nobase_default_DATA) \
 
 CLEANFILES = list_aliases.tt2
 
-DEFAULT_SCENARIOS = \
-	add.owner \
-	archive_mail_access.closed \
-	d_edit.owner \
-	d_read.private \
-	del.owner \
-	info.open \
-	invite.private \
-	remind.owner \
-	review.owner \
-	send.private \
-	subscribe.open \
-	topics_visibility.noconceal \
-	tracking.owner \
-	unsubscribe.open \
-	visibility.conceal
-
 list_aliases.tt2: Makefile list_aliases.tt2.in
 	@rm -f $@
 	$(AM_V_GEN)$(SED) \
@@ -434,10 +417,6 @@ list_aliases.tt2: Makefile list_aliases.tt2.in
 		< $(srcdir)/$@.in > $@
 
 install-data-hook:
-	cd  $(DESTDIR)$(defaultdir)/scenari; \
-	for file in $(DEFAULT_SCENARIOS); do \
-		$(LN_S) -f $$file `echo $$file | $(SED) -e 's/\.[^.]*$$/.default/'`; \
-	done
 	cd $(DESTDIR)$(defaultdir)/web_tt2; \
 	rm -f ja_JP/css.tt2 ko_KR/css.tt2 zh_CN/css.tt2 zh_TW/css.tt2; \
 	$(LN_S) -f review.tt2 search.tt2; \

--- a/default/web_tt2/config_common.tt2
+++ b/default/web_tt2/config_common.tt2
@@ -151,13 +151,11 @@
     <select name="single_param.[% ppaths.join('.') %].name"
      id="param.[% ppaths.join('.') %]">
     [% FOREACH scenario = pitem.format ~%]
-      [% UNLESS scenario.value.name == 'default' ~%]
-        <option value="[% scenario.value.name %]"
-         [%~ IF scenario.value.name == val.name %] selected="selected"[% END %]>
-        [%~ scenario.value.title %]
-        [%~ IF is_listmaster %] ([% scenario.value.name %])[% END ~%]
-        </option>
-      [%~ END %]
+      <option value="[% scenario.value.name %]"
+       [%~ IF scenario.value.name == val.name %] selected="selected"[% END %]>
+      [%~ scenario.value.title %]
+      [%~ IF is_listmaster %] ([% scenario.value.name %])[% END ~%]
+      </option>
     [% END %]
     </select>
   [%~ ELSE ~%]

--- a/src/lib/Sympa.pm
+++ b/src/lib/Sympa.pm
@@ -87,12 +87,6 @@ sub search_fullpath {
 
     my @result;
     foreach my $f (@try) {
-##        if (-l $f) {
-##            my $realpath = Cwd::abs_path($f);    # follow symlink
-##            next unless $realpath and -r $realpath;
-##        } elsif (!-r $f) {
-##            next;
-##        }
         next unless -r $f;
         $log->syslog('debug3', 'Name: %s; file %s', $name, $f);
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -4313,7 +4313,7 @@ sub load_scenario_list {
             next unless (/$action\.($scenario_regexp)$/);
             my $name = $1;
 
-            # Ignore default setting on <= 6.2.38, using symbolic link.
+            # Ignore default setting on <= 6.2.40, using symbolic link.
             next if $name eq 'default' and -l "$dir/$action.$name";
 
             next if (defined $list_of_scenario{$name});

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -4313,6 +4313,9 @@ sub load_scenario_list {
             next unless (/$action\.($scenario_regexp)$/);
             my $name = $1;
 
+            # Ignore default setting on <= 6.2.38, using symbolic link.
+            next if $name eq 'default' and -l "$dir/$action.$name";
+
             next if (defined $list_of_scenario{$name});
             next if (defined $skip_scenario{$name});
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -832,7 +832,8 @@ our %pinfo = (
             'web_access' => {
                 'order'      => 3,
                 'gettext_id' => "access right",
-                'scenario'   => 'archive_web_access'
+                'scenario'   => 'archive_web_access',
+                'default'    => 'closed',
             },
             'mail_access' => {
                 'order'      => 4,

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -70,7 +70,8 @@ our %pinfo = (
         'synonym'  => {
             'public'  => 'noconceal',
             'private' => 'conceal'
-        }
+        },
+        'default' => 'conceal',
     },
 
     'owner' => {
@@ -289,7 +290,8 @@ our %pinfo = (
         'gettext_id' => "Who can send messages",
         'gettext_comment' =>
             'This parameter specifies who can send messages to the list.',
-        'scenario' => 'send'
+        'scenario' => 'send',
+        'default'  => 'private',
     },
 
     'delivery_time' => {
@@ -639,7 +641,8 @@ our %pinfo = (
         order        => 30.01,
         'group'      => 'command',
         'gettext_id' => "Who can view list information",
-        'scenario'   => 'info'
+        'scenario'   => 'info',
+        'default'    => 'open',
     },
 
     'subscribe' => {
@@ -648,7 +651,8 @@ our %pinfo = (
         'gettext_id' => "Who can subscribe to the list",
         'gettext_comment' =>
             'The subscribe parameter defines the rules for subscribing to the list.',
-        'scenario' => 'subscribe'
+        'scenario' => 'subscribe',
+        'default'  => 'open',
     },
     'subscription' => {'obsolete' => 'subscribe'},
 
@@ -658,7 +662,8 @@ our %pinfo = (
         'gettext_id' => "Who can add subscribers",
         'gettext_comment' =>
             'Privilege for adding (ADD command) a subscriber to the list',
-        'scenario' => 'add'
+        'scenario' => 'add',
+        'default'  => 'owner',
     },
 
     'unsubscribe' => {
@@ -667,7 +672,8 @@ our %pinfo = (
         'gettext_id' => "Who can unsubscribe",
         'gettext_comment' =>
             'This parameter specifies the unsubscription method for the list. Use open_notify or auth_notify to allow owner notification of each unsubscribe command.',
-        'scenario' => 'unsubscribe'
+        'scenario' => 'unsubscribe',
+        'default'  => 'open',
     },
     'unsubscription' => {'obsolete' => 'unsubscribe'},
 
@@ -675,14 +681,16 @@ our %pinfo = (
         order        => 30.05,
         'group'      => 'command',
         'gettext_id' => "Who can delete subscribers",
-        'scenario'   => 'del'
+        'scenario'   => 'del',
+        'default'    => 'owner',
     },
 
     'invite' => {
         order        => 30.06,
         'group'      => 'command',
         'gettext_id' => "Who can invite people",
-        'scenario'   => 'invite'
+        'scenario'   => 'invite',
+        'default'    => 'private',
     },
 
     'remind' => {
@@ -691,7 +699,8 @@ our %pinfo = (
         'gettext_id' => "Who can start a remind process",
         'gettext_comment' =>
             'This parameter specifies who is authorized to use the remind command.',
-        'scenario' => 'remind'
+        'scenario' => 'remind',
+        'default'  => 'owner',
     },
 
     'review' => {
@@ -701,7 +710,8 @@ our %pinfo = (
         'gettext_comment' =>
             'This parameter specifies who can access the list of members. Since subscriber addresses can be abused by spammers, it is strongly recommended that you only authorize owners or subscribers to access the subscriber list. ',
         'scenario' => 'review',
-        'synonym'  => {'open' => 'public'}
+        'synonym'  => {'open' => 'public'},
+        'default'  => 'owner',
     },
 
     'owner_domain' => {
@@ -739,12 +749,14 @@ our %pinfo = (
             'd_read' => {
                 'order'      => 1,
                 'gettext_id' => "Who can view",
-                'scenario'   => 'd_read'
+                'scenario'   => 'd_read',
+                'default'    => 'private',
             },
             'd_edit' => {
                 'order'      => 2,
                 'gettext_id' => "Who can edit",
-                'scenario'   => 'd_edit'
+                'scenario'   => 'd_edit',
+                'default'    => 'owner',
             },
             'quota' => {
                 'order'        => 3,
@@ -826,7 +838,8 @@ our %pinfo = (
                 'order'      => 4,
                 'gettext_id' => "access right by mail commands",
                 'scenario'   => 'archive_mail_access',
-                'synonym' => {'open' => 'public'}    # Compat. with <=6.2b.3.
+                'synonym' => {'open' => 'public'},    # Compat. with <=6.2b.3.
+                'default' => 'closed',
             },
             'quota' => {
                 'order'        => 5,
@@ -1007,7 +1020,8 @@ our %pinfo = (
             'tracking' => {
                 'order'      => 3,
                 'gettext_id' => "who can view message tracking",
-                'scenario'   => 'tracking'
+                'scenario'   => 'tracking',
+                'default'    => 'owner',
             },
             'retention_period' => {
                 'order' => 4,
@@ -2756,7 +2770,7 @@ sub cleanup {
     } elsif ($v->{'scenario'}) {
         # Scenario format
         $v->{'format'}  = Sympa::Regexps::scenario();
-        $v->{'default'} = 'default';
+        #XXX$v->{'default'} = 'default';
     } elsif ($v->{'task'}) {
         # Task format
         $v->{'format'} = Sympa::Regexps::task();
@@ -2805,9 +2819,9 @@ sub cleanup {
             } elsif ($v->{'format'}{$k}{'scenario'}) {
                 # Scenario format
                 $v->{'format'}{$k}{'format'}  = Sympa::Regexps::scenario();
-                $v->{'format'}{$k}{'default'} = 'default'
-                    unless ($p eq 'web_archive' and $k eq 'access')
-                    or ($p eq 'archive' and $k eq 'web_access');
+                #XXX$v->{'format'}{$k}{'default'} = 'default'
+                #XXX    unless ($p eq 'web_archive' and $k eq 'access')
+                #XXX    or ($p eq 'archive' and $k eq 'web_access');
             } elsif ($v->{'format'}{$k}{'task'}) {
                 # Task format
                 $v->{'format'}{$k}{'format'} = Sympa::Regexps::task();

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -68,6 +68,7 @@ our %pinfo = (
             'This parameter indicates whether the list should feature in the output generated in response to a LISTS command or should be shown in the list overview of the web-interface.',
         'scenario' => 'visibility',
         'synonym'  => {
+            'default' => 'conceal',     # Compat. <= 6.2.40
             'public'  => 'noconceal',
             'private' => 'conceal'
         },
@@ -291,7 +292,10 @@ our %pinfo = (
         'gettext_comment' =>
             'This parameter specifies who can send messages to the list.',
         'scenario' => 'send',
-        'default'  => 'private',
+        'synonym'  => {
+            'default' => 'private',    # Compat. <= 6.2.40
+        },
+        'default' => 'private',
     },
 
     'delivery_time' => {
@@ -642,7 +646,10 @@ our %pinfo = (
         'group'      => 'command',
         'gettext_id' => "Who can view list information",
         'scenario'   => 'info',
-        'default'    => 'open',
+        'synonym'    => {
+            'default' => 'open',    # Compat. <= 6.2.40
+        },
+        'default' => 'open',
     },
 
     'subscribe' => {
@@ -652,7 +659,10 @@ our %pinfo = (
         'gettext_comment' =>
             'The subscribe parameter defines the rules for subscribing to the list.',
         'scenario' => 'subscribe',
-        'default'  => 'open',
+        'synonym'  => {
+            'default' => 'open',    # Compat. <= 6.2.40
+        },
+        'default' => 'open',
     },
     'subscription' => {'obsolete' => 'subscribe'},
 
@@ -663,7 +673,10 @@ our %pinfo = (
         'gettext_comment' =>
             'Privilege for adding (ADD command) a subscriber to the list',
         'scenario' => 'add',
-        'default'  => 'owner',
+        'synonym'  => {
+            'default' => 'owner',    # Compat. <= 6.2.40
+        },
+        'default' => 'owner',
     },
 
     'unsubscribe' => {
@@ -673,7 +686,10 @@ our %pinfo = (
         'gettext_comment' =>
             'This parameter specifies the unsubscription method for the list. Use open_notify or auth_notify to allow owner notification of each unsubscribe command.',
         'scenario' => 'unsubscribe',
-        'default'  => 'open',
+        'synonym'  => {
+            'default' => 'open',    # Compat. <= 6.2.40
+        },
+        'default' => 'open',
     },
     'unsubscription' => {'obsolete' => 'unsubscribe'},
 
@@ -682,7 +698,10 @@ our %pinfo = (
         'group'      => 'command',
         'gettext_id' => "Who can delete subscribers",
         'scenario'   => 'del',
-        'default'    => 'owner',
+        'synonym'    => {
+            'default' => 'owner',    # Compat. <= 6.2.40
+        },
+        'default' => 'owner',
     },
 
     'invite' => {
@@ -690,7 +709,10 @@ our %pinfo = (
         'group'      => 'command',
         'gettext_id' => "Who can invite people",
         'scenario'   => 'invite',
-        'default'    => 'private',
+        'synonym'    => {
+            'default' => 'private',    # Compat. <= 6.2.40
+        },
+        'default' => 'private',
     },
 
     'remind' => {
@@ -700,7 +722,10 @@ our %pinfo = (
         'gettext_comment' =>
             'This parameter specifies who is authorized to use the remind command.',
         'scenario' => 'remind',
-        'default'  => 'owner',
+        'synonym'  => {
+            'default' => 'owner',    # Compat. <= 6.2.40
+        },
+        'default' => 'owner',
     },
 
     'review' => {
@@ -710,8 +735,11 @@ our %pinfo = (
         'gettext_comment' =>
             'This parameter specifies who can access the list of members. Since subscriber addresses can be abused by spammers, it is strongly recommended that you only authorize owners or subscribers to access the subscriber list. ',
         'scenario' => 'review',
-        'synonym'  => {'open' => 'public'},
-        'default'  => 'owner',
+        'synonym'  => {
+            'default' => 'owner',    # Compat. <= 6.2.40
+            'open'    => 'public',
+        },
+        'default' => 'owner',
     },
 
     'owner_domain' => {
@@ -750,13 +778,19 @@ our %pinfo = (
                 'order'      => 1,
                 'gettext_id' => "Who can view",
                 'scenario'   => 'd_read',
-                'default'    => 'private',
+                'synonym'    => {
+                    'default' => 'private',    # Compat. <= 6.2.40
+                },
+                'default' => 'private',
             },
             'd_edit' => {
                 'order'      => 2,
                 'gettext_id' => "Who can edit",
                 'scenario'   => 'd_edit',
-                'default'    => 'owner',
+                'synonym'    => {
+                    'default' => 'owner',      # Compat. <= 6.2.40
+                },
+                'default' => 'owner',
             },
             'quota' => {
                 'order'        => 3,
@@ -839,7 +873,10 @@ our %pinfo = (
                 'order'      => 4,
                 'gettext_id' => "access right by mail commands",
                 'scenario'   => 'archive_mail_access',
-                'synonym' => {'open' => 'public'},    # Compat. with <=6.2b.3.
+                'synonym'    => {
+                    'default' => 'closed',    # Compat. <= 6.2.40
+                    'open'    => 'public',    # Compat. with <=6.2b.3.
+                },
                 'default' => 'closed',
             },
             'quota' => {
@@ -1022,7 +1059,10 @@ our %pinfo = (
                 'order'      => 3,
                 'gettext_id' => "who can view message tracking",
                 'scenario'   => 'tracking',
-                'default'    => 'owner',
+                'synonym'    => {
+                    'default' => 'owner',    # Compat. <= 6.2.40
+                },
+                'default' => 'owner',
             },
             'retention_period' => {
                 'order' => 4,
@@ -2770,7 +2810,7 @@ sub cleanup {
         $v->{format} = $format;
     } elsif ($v->{'scenario'}) {
         # Scenario format
-        $v->{'format'}  = Sympa::Regexps::scenario();
+        $v->{'format'} = Sympa::Regexps::scenario();
         #XXX$v->{'default'} = 'default';
     } elsif ($v->{'task'}) {
         # Task format
@@ -2819,7 +2859,7 @@ sub cleanup {
                 $v->{'format'}{$k}{format} = $format;
             } elsif ($v->{'format'}{$k}{'scenario'}) {
                 # Scenario format
-                $v->{'format'}{$k}{'format'}  = Sympa::Regexps::scenario();
+                $v->{'format'}{$k}{'format'} = Sympa::Regexps::scenario();
                 #XXX$v->{'format'}{$k}{'default'} = 'default'
                 #XXX    unless ($p eq 'web_archive' and $k eq 'access')
                 #XXX    or ($p eq 'archive' and $k eq 'web_access');

--- a/src/lib/Sympa/Robot.pm
+++ b/src/lib/Sympa/Robot.pm
@@ -175,6 +175,8 @@ sub update_email_netidmap_db {
     return 1;
 }
 
+my $default_topics_visibility = 'noconceal';
+
 # Loads the list of topics if updated.
 # The topic names "others" and "topicsless" are reserved words therefore
 # ignored.  Note: "other" is not reserved and may be used.
@@ -259,14 +261,14 @@ sub load_topics {
                 my $title = _load_topics_get_title($topic);
                 $list_of_topics{$robot}{$tree[0]}{'title'} = $title;
                 $list_of_topics{$robot}{$tree[0]}{'visibility'} =
-                    $topic->{'visibility'} || 'default';
-                #$list_of_topics{$robot}{$tree[0]}{'visibility'} = _load_scenario_file('topics_visibility', $robot,$topic->{'visibility'}||'default');
+                    $topic->{'visibility'} || $default_topics_visibility;
                 $list_of_topics{$robot}{$tree[0]}{'order'} =
                     $topic->{'order'};
             } else {
                 my $subtopic   = join('/', @tree[1 .. $#tree]);
                 my $title      = _load_topics_get_title($topic);
-                my $visibility = $topic->{'visibility'} || 'default';
+                my $visibility =
+                    $topic->{'visibility'} || $default_topics_visibility;
                 $list_of_topics{$robot}{$tree[0]}{'sub'}{$subtopic} =
                     _add_topic($subtopic, $title, $visibility);
             }
@@ -274,10 +276,6 @@ sub load_topics {
 
         ## Set undefined Topic (defined via subtopic)
         foreach my $t (keys %{$list_of_topics{$robot}}) {
-            unless (defined $list_of_topics{$robot}{$t}{'visibility'}) {
-                #$list_of_topics{$robot}{$t}{'visibility'} = _load_scenario_file('topics_visibility', $robot,'default');
-            }
-
             unless (defined $list_of_topics{$robot}{$t}{'title'}) {
                 $list_of_topics{$robot}{$t}{'title'} = {'default' => $t};
             }


### PR DESCRIPTION
Fixed bugs:

  - WWSympa: On list config page, default settings of list scenarios are ignored. And if user updated configuration, the first option in select box is saved.
    Fixed by assigning defaults in Sympa::ListDef.
  - `archive.web_access` list parameter did not have default value.

Change:
  - The feature making a symbolic link "*.default" to assign default values of scenarios is deprecated.
    It was hard to determine original option value linked to default.
