### PR TITLE
Remove 'confirm_action' from list of actions requiring the CSRF token

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -730,7 +730,6 @@ our %required_privileges = (
 
 our %require_csrftoken = (
     'add'            => 1,
-    'confirm_action' => 1,
     'del'            => 1,
     'move_user'      => 1,
     'savefile'       => 1,


### PR DESCRIPTION
The current CSRF code is configured to require the token for the `confirm_action` action. However #527 shows that there are legitimate Sympa functions such as unauthenticated archive views that invoke `confirm_action` as part of a GET request (i.e. the "I am not a spammer" click-through challenge for archives). 

This simple patch removes `confirm_action` from the `%require_csrftoken` list. That allows `confirm_action` to be invoked during GET requests, allowing unauthenticated archive views and other GET based confirmed actions to work as expected.

Thankfully, the input validation in `Sympa::WWW::Session::confirm_action()`  acts against CSRF on its own, so we are still covered there. The `confirm` submission must be the very next click in the user's Sympa session, otherwise the pending action is cancelled. Furthermore the action arguments must match a recorded hash before the action can proceed.  