### PR TITLE
Mail command unavailable in confirmation requests

### DIFF
--- a/default/mail_tt2/request_auth.tt2
+++ b/default/mail_tt2/request_auth.tt2
@@ -1,10 +1,8 @@
 [%# request_auth.tt2 ~%]
 To: [% to %]
-[% IF user_interfaces.size() == 1 and user_interfaces.0 == 'mail' -%]
-Subject: [% FILTER qencode %]AUTH [%keyauth%] [%cmd%][%END%]
-[%- ELSIF type == 'signoff' -%]
+[% IF conf.wwsympa_url && type == 'signoff' -%]
 Subject: [% FILTER qencode %][%|loc(conf.title,list.name)%]%1 / unsubscribing from %2[%END%][%END%]
-[%- ELSIF type == 'subscribe' -%]
+[%- ELSIF conf.wwsympa_url && type == 'subscribe' -%]
 Subject: [% FILTER qencode %][%|loc(conf.title,list.name)%]%1 / subscribing to %2[%END%][%END%]
 [%- ELSE -%]
 Subject: [% FILTER qencode %]AUTH [%keyauth%] [%cmd%][%END%]
@@ -33,9 +31,11 @@ Subject: [% FILTER qencode %]AUTH [%keyauth%] [%cmd%][%END%]
 
 [%- END -%]
 
-[% IF not conf.wwsympa_url -%]
-[% sympa = BLOCK %][% conf.email %]@[% domain %][%END -%]
-[%|loc(sympa,"AUTH ${keyauth} ${cmd}") %]If you want this action to be taken, please
+[% IF conf.wwsympa_url -%]
+[%|loc%]If you want this action to be taken, please hit the following link:[%END%]
+  [% 'auth' | url_abs([keyauth,type],{email=>to}) ~%]
+[%- ELSE -%]
+[%|loc("${conf.email}@${domain}","AUTH ${keyauth} ${cmd}") %]If you want this action to be taken, please
 
 - reply to this mail
 OR
@@ -43,10 +43,7 @@ OR
  %2
 OR
 - click on the following URL[% END %]
-  [% sympa | mailtourl({subject => "AUTH ${keyauth} ${cmd}"}) %]
-[%- ELSE -%]
-[%|loc%]If you want this action to be taken, please hit the following link:[%END%]
-  [% 'auth' | url_abs([keyauth,type],{email=>to}) ~%]
+  [% "${conf.email}@${domain}" | mailtourl({subject => "AUTH ${keyauth} ${cmd}"}) %]
 [%- END %]
 
 [%|loc-%]If you do not want this action to be taken, you can safely ignore this message.[% END %]


### PR DESCRIPTION
Even if web interface was disabled (wwsympa_url parameter was unset), mail URL link was not shown in confirmation requests for subscribe/unsubscribe actions.
Fixed by replacing test on an unassigned variable user_interfaces with test on conf.wwsympa_url.