### PR TITLE
Revert "Invalid default scenarios"

### DIFF
--- a/default/Makefile.am
+++ b/default/Makefile.am
@@ -410,6 +410,23 @@ EXTRA_DIST = $(nobase_default_DATA) \
 
 CLEANFILES = list_aliases.tt2
 
+DEFAULT_SCENARIOS = \
+	add.owner \
+	archive_mail_access.closed \
+	d_edit.owner \
+	d_read.private \
+	del.owner \
+	info.open \
+	invite.private \
+	remind.owner \
+	review.owner \
+	send.private \
+	subscribe.open \
+	topics_visibility.noconceal \
+	tracking.owner \
+	unsubscribe.open \
+	visibility.conceal
+
 list_aliases.tt2: Makefile list_aliases.tt2.in
 	@rm -f $@
 	$(AM_V_GEN)$(SED) \
@@ -417,6 +434,10 @@ list_aliases.tt2: Makefile list_aliases.tt2.in
 		< $(srcdir)/$@.in > $@
 
 install-data-hook:
+	cd  $(DESTDIR)$(defaultdir)/scenari; \
+	for file in $(DEFAULT_SCENARIOS); do \
+		$(LN_S) -f $$file `echo $$file | $(SED) -e 's/\.[^.]*$$/.default/'`; \
+	done
 	cd $(DESTDIR)$(defaultdir)/web_tt2; \
 	rm -f ja_JP/css.tt2 ko_KR/css.tt2 zh_CN/css.tt2 zh_TW/css.tt2; \
 	$(LN_S) -f review.tt2 search.tt2; \

--- a/default/web_tt2/config_common.tt2
+++ b/default/web_tt2/config_common.tt2
@@ -151,11 +151,13 @@
     <select name="single_param.[% ppaths.join('.') %].name"
      id="param.[% ppaths.join('.') %]">
     [% FOREACH scenario = pitem.format ~%]
-      <option value="[% scenario.value.name %]"
-       [%~ IF scenario.value.name == val.name %] selected="selected"[% END %]>
-      [%~ scenario.value.title %]
-      [%~ IF is_listmaster %] ([% scenario.value.name %])[% END ~%]
-      </option>
+      [% UNLESS scenario.value.name == 'default' ~%]
+        <option value="[% scenario.value.name %]"
+         [%~ IF scenario.value.name == val.name %] selected="selected"[% END %]>
+        [%~ scenario.value.title %]
+        [%~ IF is_listmaster %] ([% scenario.value.name %])[% END ~%]
+        </option>
+      [%~ END %]
     [% END %]
     </select>
   [%~ ELSE ~%]

--- a/src/lib/Sympa.pm
+++ b/src/lib/Sympa.pm
@@ -87,6 +87,12 @@ sub search_fullpath {
 
     my @result;
     foreach my $f (@try) {
+##        if (-l $f) {
+##            my $realpath = Cwd::abs_path($f);    # follow symlink
+##            next unless $realpath and -r $realpath;
+##        } elsif (!-r $f) {
+##            next;
+##        }
         next unless -r $f;
         $log->syslog('debug3', 'Name: %s; file %s', $name, $f);
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -4319,9 +4319,6 @@ sub load_scenario_list {
             next unless (/$action\.($scenario_regexp)$/);
             my $name = $1;
 
-            # Ignore default setting on <= 6.2.40, using symbolic link.
-            next if $name eq 'default' and -l "$dir/$action.$name";
-
             next if (defined $list_of_scenario{$name});
             next if (defined $skip_scenario{$name});
 

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -68,11 +68,9 @@ our %pinfo = (
             'This parameter indicates whether the list should feature in the output generated in response to a LISTS command or should be shown in the list overview of the web-interface.',
         'scenario' => 'visibility',
         'synonym'  => {
-            'default' => 'conceal',     # Compat. <= 6.2.40
             'public'  => 'noconceal',
             'private' => 'conceal'
-        },
-        'default' => 'conceal',
+        }
     },
 
     'owner' => {
@@ -291,11 +289,7 @@ our %pinfo = (
         'gettext_id' => "Who can send messages",
         'gettext_comment' =>
             'This parameter specifies who can send messages to the list.',
-        'scenario' => 'send',
-        'synonym'  => {
-            'default' => 'private',    # Compat. <= 6.2.40
-        },
-        'default' => 'private',
+        'scenario' => 'send'
     },
 
     'delivery_time' => {
@@ -645,11 +639,7 @@ our %pinfo = (
         order        => 30.01,
         'group'      => 'command',
         'gettext_id' => "Who can view list information",
-        'scenario'   => 'info',
-        'synonym'    => {
-            'default' => 'open',    # Compat. <= 6.2.40
-        },
-        'default' => 'open',
+        'scenario'   => 'info'
     },
 
     'subscribe' => {
@@ -658,11 +648,7 @@ our %pinfo = (
         'gettext_id' => "Who can subscribe to the list",
         'gettext_comment' =>
             'The subscribe parameter defines the rules for subscribing to the list.',
-        'scenario' => 'subscribe',
-        'synonym'  => {
-            'default' => 'open',    # Compat. <= 6.2.40
-        },
-        'default' => 'open',
+        'scenario' => 'subscribe'
     },
     'subscription' => {'obsolete' => 'subscribe'},
 
@@ -672,11 +658,7 @@ our %pinfo = (
         'gettext_id' => "Who can add subscribers",
         'gettext_comment' =>
             'Privilege for adding (ADD command) a subscriber to the list',
-        'scenario' => 'add',
-        'synonym'  => {
-            'default' => 'owner',    # Compat. <= 6.2.40
-        },
-        'default' => 'owner',
+        'scenario' => 'add'
     },
 
     'unsubscribe' => {
@@ -685,11 +667,7 @@ our %pinfo = (
         'gettext_id' => "Who can unsubscribe",
         'gettext_comment' =>
             'This parameter specifies the unsubscription method for the list. Use open_notify or auth_notify to allow owner notification of each unsubscribe command.',
-        'scenario' => 'unsubscribe',
-        'synonym'  => {
-            'default' => 'open',    # Compat. <= 6.2.40
-        },
-        'default' => 'open',
+        'scenario' => 'unsubscribe'
     },
     'unsubscription' => {'obsolete' => 'unsubscribe'},
 
@@ -697,22 +675,14 @@ our %pinfo = (
         order        => 30.05,
         'group'      => 'command',
         'gettext_id' => "Who can delete subscribers",
-        'scenario'   => 'del',
-        'synonym'    => {
-            'default' => 'owner',    # Compat. <= 6.2.40
-        },
-        'default' => 'owner',
+        'scenario'   => 'del'
     },
 
     'invite' => {
         order        => 30.06,
         'group'      => 'command',
         'gettext_id' => "Who can invite people",
-        'scenario'   => 'invite',
-        'synonym'    => {
-            'default' => 'private',    # Compat. <= 6.2.40
-        },
-        'default' => 'private',
+        'scenario'   => 'invite'
     },
 
     'remind' => {
@@ -721,11 +691,7 @@ our %pinfo = (
         'gettext_id' => "Who can start a remind process",
         'gettext_comment' =>
             'This parameter specifies who is authorized to use the remind command.',
-        'scenario' => 'remind',
-        'synonym'  => {
-            'default' => 'owner',    # Compat. <= 6.2.40
-        },
-        'default' => 'owner',
+        'scenario' => 'remind'
     },
 
     'review' => {
@@ -735,11 +701,7 @@ our %pinfo = (
         'gettext_comment' =>
             'This parameter specifies who can access the list of members. Since subscriber addresses can be abused by spammers, it is strongly recommended that you only authorize owners or subscribers to access the subscriber list. ',
         'scenario' => 'review',
-        'synonym'  => {
-            'default' => 'owner',    # Compat. <= 6.2.40
-            'open'    => 'public',
-        },
-        'default' => 'owner',
+        'synonym'  => {'open' => 'public'}
     },
 
     'owner_domain' => {
@@ -777,20 +739,12 @@ our %pinfo = (
             'd_read' => {
                 'order'      => 1,
                 'gettext_id' => "Who can view",
-                'scenario'   => 'd_read',
-                'synonym'    => {
-                    'default' => 'private',    # Compat. <= 6.2.40
-                },
-                'default' => 'private',
+                'scenario'   => 'd_read'
             },
             'd_edit' => {
                 'order'      => 2,
                 'gettext_id' => "Who can edit",
-                'scenario'   => 'd_edit',
-                'synonym'    => {
-                    'default' => 'owner',      # Compat. <= 6.2.40
-                },
-                'default' => 'owner',
+                'scenario'   => 'd_edit'
             },
             'quota' => {
                 'order'        => 3,
@@ -866,18 +820,13 @@ our %pinfo = (
             'web_access' => {
                 'order'      => 3,
                 'gettext_id' => "access right",
-                'scenario'   => 'archive_web_access',
-                'default'    => 'closed',
+                'scenario'   => 'archive_web_access'
             },
             'mail_access' => {
                 'order'      => 4,
                 'gettext_id' => "access right by mail commands",
                 'scenario'   => 'archive_mail_access',
-                'synonym'    => {
-                    'default' => 'closed',    # Compat. <= 6.2.40
-                    'open'    => 'public',    # Compat. with <=6.2b.3.
-                },
-                'default' => 'closed',
+                'synonym' => {'open' => 'public'}    # Compat. with <=6.2b.3.
             },
             'quota' => {
                 'order'        => 5,
@@ -1058,11 +1007,7 @@ our %pinfo = (
             'tracking' => {
                 'order'      => 3,
                 'gettext_id' => "who can view message tracking",
-                'scenario'   => 'tracking',
-                'synonym'    => {
-                    'default' => 'owner',    # Compat. <= 6.2.40
-                },
-                'default' => 'owner',
+                'scenario'   => 'tracking'
             },
             'retention_period' => {
                 'order' => 4,
@@ -2810,8 +2755,8 @@ sub cleanup {
         $v->{format} = $format;
     } elsif ($v->{'scenario'}) {
         # Scenario format
-        $v->{'format'} = Sympa::Regexps::scenario();
-        #XXX$v->{'default'} = 'default';
+        $v->{'format'}  = Sympa::Regexps::scenario();
+        $v->{'default'} = 'default';
     } elsif ($v->{'task'}) {
         # Task format
         $v->{'format'} = Sympa::Regexps::task();
@@ -2859,10 +2804,10 @@ sub cleanup {
                 $v->{'format'}{$k}{format} = $format;
             } elsif ($v->{'format'}{$k}{'scenario'}) {
                 # Scenario format
-                $v->{'format'}{$k}{'format'} = Sympa::Regexps::scenario();
-                #XXX$v->{'format'}{$k}{'default'} = 'default'
-                #XXX    unless ($p eq 'web_archive' and $k eq 'access')
-                #XXX    or ($p eq 'archive' and $k eq 'web_access');
+                $v->{'format'}{$k}{'format'}  = Sympa::Regexps::scenario();
+                $v->{'format'}{$k}{'default'} = 'default'
+                    unless ($p eq 'web_archive' and $k eq 'access')
+                    or ($p eq 'archive' and $k eq 'web_access');
             } elsif ($v->{'format'}{$k}{'task'}) {
                 # Task format
                 $v->{'format'}{$k}{'format'} = Sympa::Regexps::task();

--- a/src/lib/Sympa/Robot.pm
+++ b/src/lib/Sympa/Robot.pm
@@ -175,8 +175,6 @@ sub update_email_netidmap_db {
     return 1;
 }
 
-my $default_topics_visibility = 'noconceal';
-
 # Loads the list of topics if updated.
 # The topic names "others" and "topicsless" are reserved words therefore
 # ignored.  Note: "other" is not reserved and may be used.
@@ -261,14 +259,14 @@ sub load_topics {
                 my $title = _load_topics_get_title($topic);
                 $list_of_topics{$robot}{$tree[0]}{'title'} = $title;
                 $list_of_topics{$robot}{$tree[0]}{'visibility'} =
-                    $topic->{'visibility'} || $default_topics_visibility;
+                    $topic->{'visibility'} || 'default';
+                #$list_of_topics{$robot}{$tree[0]}{'visibility'} = _load_scenario_file('topics_visibility', $robot,$topic->{'visibility'}||'default');
                 $list_of_topics{$robot}{$tree[0]}{'order'} =
                     $topic->{'order'};
             } else {
                 my $subtopic   = join('/', @tree[1 .. $#tree]);
                 my $title      = _load_topics_get_title($topic);
-                my $visibility =
-                    $topic->{'visibility'} || $default_topics_visibility;
+                my $visibility = $topic->{'visibility'} || 'default';
                 $list_of_topics{$robot}{$tree[0]}{'sub'}{$subtopic} =
                     _add_topic($subtopic, $title, $visibility);
             }
@@ -276,6 +274,10 @@ sub load_topics {
 
         ## Set undefined Topic (defined via subtopic)
         foreach my $t (keys %{$list_of_topics{$robot}}) {
+            unless (defined $list_of_topics{$robot}{$t}{'visibility'}) {
+                #$list_of_topics{$robot}{$t}{'visibility'} = _load_scenario_file('topics_visibility', $robot,'default');
+            }
+
             unless (defined $list_of_topics{$robot}{$t}{'title'}) {
                 $list_of_topics{$robot}{$t}{'title'} = {'default' => $t};
             }


### PR DESCRIPTION
Reverts sympa-community/sympa#528
A lot of problems with this PR. Sorry I did not see them before.
The problem is: listmasters can't define default scenarios anymore. the only way to do so is in ListDef.pm
Consequently : all instances having defined default scenarios will have their customizations ignored when upgrading.
This PR is clearly a regression and should be removed.
