### PR TITLE
Owner page is empty

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -4150,11 +4150,10 @@ sub may_edit {
 
     # Load edit_list.conf: Track by file, not domain (file may come from
     # server, robot, family or list context).
-    my $edit_list_conf = $self->_cache_get('edit_list_conf');
-    unless ($edit_list_conf) {
-        $self->_cache_put('edit_list_conf', $self->_load_edit_list_conf);
-    }
-    $edit_list_conf ||= {};
+    my $edit_list_conf =
+           $self->_cache_get('edit_list_conf')
+        || $self->_cache_put('edit_list_conf', $self->_load_edit_list_conf)
+        || {};
 
     my $role;
 
@@ -9509,7 +9508,10 @@ sub _load_edit_list_conf {
 
     my $robot = $self->{'domain'};
 
-    my $pinfo = Sympa::Robot::list_params($self->{'domain'});
+    my $pinfo = {
+        %{Sympa::Robot::list_params($self->{'domain'})},
+        %Sympa::ListDef::user_info
+    };
 
     my $file;
     my $conf;


### PR DESCRIPTION
[bug] "Users" - "Owner" page is empty for a while after restart, as picture below.

![empty_review_owner](https://user-images.githubusercontent.com/5743546/51884808-2f936480-23cc-11e9-8a9f-5014a0d8d206.png)

Fixed by correcting typos not loading information soon.
