### PR TITLE
WWSympa: Owners/moderators in list panel aren't updated

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -2851,7 +2851,9 @@ sub check_param_out {
 
         # Owners and editors
         foreach my $role (qw(owner editor)) {
-            foreach my $u ($list->get_admins($role)) {
+            my @users =
+                grep {$_->{role} eq $role} @{$list->get_current_admins || []};
+            foreach my $u (@users) {
                 next unless $u->{'email'};
 
                 my ($local, $domain) = split /\@/, $u->{'email'};


### PR DESCRIPTION
WWSympa: Owners/moderators in list panel aren't updated after edition on review page.
Fixed by getting recent owners/moderators passing cache on memory.


This will be merged immediately.
