### PR TITLE
Prepare minimal sympa.conf at install time (cf. #508)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,12 @@ Makefile
 /config.status
 /po/sympa/POTFILES
 /po/web_help/POTFILES
+/sympa.conf
 
 # make
 
 *.1
+*.3Sympa
 *.5
 *.8
 *.gmo
@@ -50,7 +52,6 @@ Makefile
 
 /data_structure.version
 /sympa_wizard.pl.inst
-/src/lib/*.3Sympa
 
 # make dist
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,7 +81,7 @@ EXTRA_DIST = \
 	$(noinst_SCRIPTS) \
 	$(nobase_modules_DATA)
 
-CLEANFILES = sympa_wizard.pl.inst
+CLEANFILES =
 
 MSGFMT=@MSGFMT@
 .po.mo:
@@ -112,7 +112,7 @@ installdir:
 	done
 	@echo "Creating writable directories"
 	-@for dir in $(expldir) $(spooldir) $(bouncedir) $(arcdir) $(piddir) \
-		$(sysconfdir); do \
+		$(confdir) $(sysconfdir); do \
 		if [ ! -d $(DESTDIR)$$dir ] ; then \
 			echo "Creating $(DESTDIR)$$dir"; \
 			$(INSTALL) -d -m 755 $(DESTDIR)$$dir; \
@@ -129,25 +129,11 @@ installdir:
 		chgrp $(GROUP) $(DESTDIR)$(spooldir)/$$subdir; \
 	done
 
-sympa_wizard.pl.inst: $(top_srcdir)/src/sbin/sympa_wizard.pl.in Makefile
-	$(SED) \
-		-e 's|--PERL--|$(PERL)|' \
-		-e 's|--modulesdir--|$(top_srcdir)/src/lib|' \
-		< $(top_srcdir)/src/sbin/sympa_wizard.pl.in > $@
-
-installconfig: installdir sympa_wizard.pl.inst
+installconfig: installdir
 	@echo "Installing basic configuration ..."
-	-@export PERL5LIB=$(DESTDIR)$(modulesdir); \
-	if [ ! -f  $(DESTDIR)$(confdir)/sympa.conf ]; then \
-		echo "This looks like your first Sympa installation. The following wizard will assist you to create your first Sympa configuration.";\
-		if [ ! -d $(DESTDIR)$(confdir) ]; then \
-			$(INSTALL) -d -m 755 $(DESTDIR)$(confdir); \
-		fi; \
-		chown $(USER) $(DESTDIR)$(confdir); \
-		chgrp $(GROUP) $(DESTDIR)$(confdir); \
-		$(PERL) sympa_wizard.pl.inst \
-			--create sympa.conf \
-			--target $(DESTDIR)$(confdir)/sympa.conf; \
+	-@if [ ! -f  $(DESTDIR)$(confdir)/sympa.conf ]; then \
+		echo "installing sympa.conf"; \
+		$(INSTALL) -m 640 sympa.conf $(DESTDIR)$(confdir); \
 		chown $(USER) $(DESTDIR)$(confdir)/sympa.conf; \
 		chgrp $(GROUP) $(DESTDIR)$(confdir)/sympa.conf; \
 	fi
@@ -185,13 +171,12 @@ nextstep:
 	@echo ""
 	@echo "#########################################################"
 	@echo "# CHECK YOU HAVE ALL THE NEEDED MODULES:"
-	@echo "#    * Check the required perl modules are installed:"
-	@echo "#        $(sbindir)/sympa_wizard.pl --check"
+	@echo "#    * Install or upgrade required perl modules. If you have cpanminus:"
+	@echo "#        cpanm --installdeps --with-recommends ."
 	@echo "#"
 	@echo "# FIRST INSTALLATION:"
-	@echo "#    * Check the INSTALL.md file."
-	@echo "#    * Run the wizard to define some required parameters that can't be guessed."
-	@echo "#        $(sbindir)/sympa_wizard.pl"
+	@echo "#    * Edit this file to define initial configuration:"
+	@echo "#        $(confdir)/sympa.conf"
 	@echo "#"
 	@echo "# UPGRADING"
 	@echo "#    * Run this script to upgrade your data structures:"

--- a/configure.ac
+++ b/configure.ac
@@ -609,6 +609,7 @@ AC_SUBST(POSTMAP_ARG)
 
 AC_CONFIG_FILES([
     Makefile
+    sympa.conf
     default/Makefile
     doc/Makefile
     po/Makefile

--- a/sympa.conf.in
+++ b/sympa.conf.in
@@ -1,0 +1,64 @@
+########################################################################
+# Initial configuration
+# See https://sympa-community.github.io/manual/install/generate-initial-configuration.html
+########################################################################
+
+domain              (You must define this parameter)
+listmaster          (You must define this parameter)
+#lang                en-US
+
+########################################################################
+# Setup database
+# See https://sympa-community.github.io/manual/install/setup-database.html
+########################################################################
+
+db_type             (You must define this parameter)
+db_name             sympa
+#db_host
+#db_port
+#db_user             user_name
+#db_passwd           (secret)
+#db_env
+
+########################################################################
+# Configure system log
+# See https://sympa-community.github.io/manual/install/configure-system-log.html
+########################################################################
+
+#syslog              LOCAL1 
+#log_socket_type     unix
+
+########################################################################
+# Configure mail server
+# See https://sympa-community.github.io/manual/install/configure-mail-server.html
+########################################################################
+
+#sendmail_aliases    @SENDMAIL_ALIASES@
+#aliases_program     newaliases
+#aliases_db_type     hash
+#sendmail            /usr/sbin/sendmail
+#sendmail_args       (if you use sendmail(1), this need not change)
+
+########################################################################
+# Configure HTTP server
+# See https://sympa-community.github.io/manual/install/configure-http-server.html
+########################################################################
+
+#mhonarc             /usr/bin/mhonarc
+#log_facility        LOCAL1
+
+# If you chose single domain setting, you may have to define following
+# parameters in this sympa.conf file.  Otherwise, if you chose virtual
+# domain setting (recommended), you should define them in robot.conf by
+# each domain.
+
+#wwsympa_url         (You must define this parameter to enable web interface)
+
+########################################################################
+# Customizing Sympa
+# You can customize Sympa, its web interface and/or SOAP/HTTP service
+# defining more parameters in this file sympa.conf or robot.conf by each
+# domain.
+# For more details see https://sympa-community.github.io/manual/customize.html
+########################################################################
+


### PR DESCRIPTION
Preparing minimal sympa.conf at install time.  `sympa_wizard.pl` will no longer be used to create it.

See #508.
