### PR TITLE
`bounce_email_prefix` parameter was not considered to prevent reserved addrresses for list name (PR#455)

### DIFF
--- a/src/lib/Sympa/Aliases.pm
+++ b/src/lib/Sympa/Aliases.pm
@@ -122,8 +122,12 @@ sub check_new_listname {
     # Avoid "sympa", "listmaster", "bounce" and "bounce+XXX".
     if (   $listname eq Conf::get_robot_conf($robot_id, 'email')
         or $listname eq Conf::get_robot_conf($robot_id, 'listmaster_email')
-        or $listname eq 'bounce'
-        or 0 == index($listname, 'bounce+')) {
+        or $listname eq Conf::get_robot_conf($robot_id, 'bounce_email_prefix')
+        or 0 == index(
+            $listname,
+            Conf::get_robot_conf($robot_id, 'bounce_email_prefix') . '+'
+        )
+    ) {
         $log->syslog('err',
             'Incorrect listname %s matches one of service aliases',
             $listname);

--- a/src/lib/Sympa/Family.pm
+++ b/src/lib/Sympa/Family.pm
@@ -47,7 +47,6 @@ use Term::ProgressBar;
 use XML::LibXML;
 
 use Sympa;
-use Sympa::Aliases;
 use Conf;
 use Sympa::Config_XML;
 use Sympa::DatabaseManager;


### PR DESCRIPTION
To prevent creation of list with reserved addresses, only sticked names `bounce@...` and `bounce+...@...` were prevented: `bounce_email_prefix` parameter was not considered.
