### PR TITLE
WWSympa: Features of archives and shared repository should be able to be disabled

### DIFF
--- a/default/web_tt2/admin.tt2
+++ b/default/web_tt2/admin.tt2
@@ -62,7 +62,7 @@
   [%~ END ~%]
 [% END %]
 
-[% IF is_listmaster || is_owner %]
+[% IF is_shared_allowed && (is_listmaster || is_owner) %]
 <form name="manage_shared_status" action="[% path_cgi %]" method="post">
 <div>
 [% IF shared == 'none' %]

--- a/default/web_tt2/list_menu.tt2
+++ b/default/web_tt2/list_menu.tt2
@@ -79,7 +79,7 @@
       [% IF action == 'modindex' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
       <li  class="[% class %]"><a href="[% 'modindex' | url_rel([list]) %]">[%|loc%]Message[%END%] ([% mod_message %]) </a></li>
       [% IF action == 'docindex' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
-      [% IF shared == 'exist' ~%]
+      [% IF is_shared_allowed && shared == 'exist' ~%]
       <li class="[% class %]"><a href="[% 'docindex' | url_rel([list]) %]">[%|loc%]Document[%END%] ([% mod_total_shared %])</a></li>
       [%~ END %]
     [% END %]
@@ -143,7 +143,7 @@
   <li class="[% class %]"><a href="[% 'rss_request' | url_rel([list]) %]" >[%|loc%]RSS[%END%]</a></li>
 [% END %]
 
-[% IF shared == 'exist' %]
+[% IF is_shared_allowed && shared == 'exist' %]
   [% IF may_d_read %]
     [% IF action == 'd_read' || action == 'd_edit' || action == 'd_properties' %][% SET class = 'active' %][% ELSE %][% SET class = '' %][% END %]
     <li class="[% class %]"><a href="[% 'd_read' | url_rel([list,'']) %]" >[%|loc%]Shared documents[%END%]</a></li>

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -2975,7 +2975,7 @@ sub check_param_out {
 # SJS END
 
         ## Archives Access control
-        if (defined $list->{'admin'}{'archive'}) {
+        if (defined $list->is_archiving_enabled) {
             $param->{'is_archived'} = 1;
 
             ## Check if the current user may access web archives

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1516,7 +1516,7 @@ while ($query = CGI::Fast->new) {
 
             check_param_in();
 
-            unless ($comm{$action}) {
+            if (not $comm{$action} or _is_action_disabled($action)) {
                 # Previously we searched the list using value of action here.
                 # To prevent sniffing lists, we no longer do.
                 Sympa::WWW::Report::reject_report_web('user',
@@ -17283,6 +17283,20 @@ sub do_delete_account {
                 $param->{'user'}->{'email'})
         );
     }
+}
+
+sub _is_action_disabled {
+    my $action = shift;
+
+    unless (Conf::get_robot_conf($robot, 'shared_feature') eq 'on') {
+        return 1
+            if grep { $action eq $_ }
+            qw(d_admin d_change_access d_control d_create_child d_delete
+               d_describe d_editfile d_install_shared d_properties d_read
+               d_reject_shared d_rename d_set_owner d_unzip d_update);
+    }
+
+    return undef;
 }
 
 sub prevent_visibility_bypass {

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -3011,6 +3011,9 @@ sub check_param_out {
             }
         }
 
+        if (Conf::get_robot_conf($robot, 'shared_feature') eq 'on') {
+            $param->{'is_shared_allowed'} = 1;
+
         # Shared documents access control.
         my $shared_doc = Sympa::WWW::SharedDocument->new($list);
         if ($shared_doc and $shared_doc->{status} eq 'exist') {
@@ -3023,6 +3026,7 @@ sub check_param_out {
                 scenario_context => {sender => 'nobody'}
             );
             $param->{'shared_public_access'} = $access{'may'}{'read'};
+        }
         }
 
         # List included in other list may not be closed nor renamed.

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -1688,7 +1688,7 @@ our @params = (
             'If set to "on", list owners can open shared repository.',
         'vhost'        => '1',
         'edit'         => '1',
-        'default'      => 'on',
+        'default'      => 'on',    # Enalbed by historical reason.
     },
 
     {   'name'         => 'default_shared_quota',

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -1688,7 +1688,7 @@ our @params = (
             'If set to "on", list owners can open shared repository.',
         'vhost'        => '1',
         'edit'         => '1',
-        'default'      => 'on',    # Enalbed by historical reason.
+        'default'      => 'off',
     },
 
     {   'name'         => 'default_shared_quota',

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -1682,6 +1682,15 @@ our @params = (
 
     # Shared document repository
 
+    {   'name'         => 'shared_feature',
+        'gettext_id'   => 'Enable shared repository',
+        'gettext_comment' =>
+            'If set to "on", list owners can open shared repository.',
+        'vhost'        => '1',
+        'edit'         => '1',
+        'default'      => 'on',
+    },
+
     {   'name'         => 'default_shared_quota',
         'optional'     => '1',
         'gettext_id'   => 'Default disk quota for shared repository',

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -2045,6 +2045,17 @@ sub upgrade {
         }
     }
 
+    # Previously shared repository could not be disabled.
+    if (lower_version($previous_version, '6.2.41b.2')) {
+        my $human_date = $language->gettext_strftime('%d %b %Y at %H:%M:%S',
+            localtime time);
+
+        open my $ofh, '>>', Conf::get_sympa_conf();
+        printf $ofh "\n\n# Upgrade from %s to %s\n# %s\nshared_feature on\n",
+            $previous_version, $new_version, $human_date;
+        close $ofh;
+    }
+
     return 1;
 }
 


### PR DESCRIPTION
  * Even if `process_archive` parameter was "off", items about archiving were shown in web interface.
  * Shared repository could not be disabled: List owners could freely install it.

This PR will fix those problems.

Especially on latter, a new parameter `shared_feature` in sympa.conf/robot.conf was introduced to enable/disable the feature of shared document repository.
