### PR TITLE
sympa_test_ldap.pl misses bind password

### DIFF
--- a/src/bin/sympa_test_ldap.pl.in
+++ b/src/bin/sympa_test_ldap.pl.in
@@ -67,17 +67,6 @@ if ($options{use_start_tls}) {
 delete $options{use_start_tls};
 delete $options{use_ssl};
 
-my $db = Sympa::Database->new('LDAP', %options);
-unless ($db
-    and defined $options{'suffix'}
-    and defined $options{'filter'}) {
-    pod2usage(-exitval => 1, -output => \*STDERR);
-}
-
-print join ' ',
-    map { sprintf '%s=%s', $_, $options{$_} } qw(host suffix filter);
-print "\n";
-
 if ($options{'bind_dn'} and not $options{'bind_password'}) {
     local $SIG{TERM} = sub { system qw(stty echo) };
     system qw(stty -echo);
@@ -89,6 +78,17 @@ if ($options{'bind_dn'} and not $options{'bind_password'}) {
 
     $options{'bind_password'} = $password;
 }
+
+my $db = Sympa::Database->new('LDAP', %options);
+unless ($db
+    and defined $options{'suffix'}
+    and defined $options{'filter'}) {
+    pod2usage(-exitval => 1, -output => \*STDERR);
+}
+
+print join ' ',
+    map { sprintf '%s=%s', $_, $options{$_} } qw(host suffix filter);
+print "\n";
 
 my ($mesg, $res);
 


### PR DESCRIPTION
sympa_test_ldap: If `--bind_dn` was given but not `--bind_password`, password prompt is shown. However, input password was ignored.