### PR TITLE
Refactor Sympa::Scenario (cf. #520)

### DIFF
--- a/default/web_tt2/config_common.tt2
+++ b/default/web_tt2/config_common.tt2
@@ -17,7 +17,7 @@
 
   [% IF pitem.scenario && is_listmaster ~%]
     &nbsp;<a class="input"
-     href="[% 'dump_scenario' | url_rel([list,pitem.name]) %]"
+     href="[% 'dump_scenario' | url_rel([list,pitem.scenario]) %]"
      title="[%|loc%]scenario source[%END%]">[%|loc%]scenario source[%END~%]
     </a>
   [%~ END %]

--- a/default/web_tt2/d_control.tt2
+++ b/default/web_tt2/d_control.tt2
@@ -83,14 +83,18 @@
   <label for="read_access">[%|loc%]Read access[%END%]</label>
   <select id="read_access" name="read_access">
   [% FOREACH s = scenari_read %]
-    <option value='[% s.key %]' [% s.value.selected %]>[% s.value.web_title %]</option>
+    <option value="[% s.key %]"
+    [%~ IF s.value.selected %] selected="selected"[% END ~%]
+    >[% s.value.title %]</option>
   [% END %]
   </select>
 
   <label for="edit_access">[%|loc%]Edit access[%END%]</label>
   <select id="edit_access" name="edit_access">
   [% FOREACH s = scenari_edit %]
-    <option value='[% s.key %]' [% s.value.selected %]>[% s.value.web_title %]</option>
+    <option value="[% s.key %]"
+    [%~ IF s.value.selected %] selected="selected"[% END ~%]
+    >[% s.value.title %]</option>
   [% END %]
   </select>
    <input type="hidden" name="list" value="[% list %]" />

--- a/default/web_tt2/dump_scenario.tt2
+++ b/default/web_tt2/dump_scenario.tt2
@@ -13,7 +13,7 @@
 [% ELSE %]
 
 <div id="ActionHeader">
-  <h2 class='block'>[% pname %] [% scenario_name %] </h2>
+  <h2 class='block'>[% scenario_function %].[% scenario_name %] </h2>
   <span class="text_center">([%|loc%]path:[%END%] [% scenario_path %])</span>
 </div>
 <font size="-2">
@@ -22,7 +22,7 @@
 <fieldset>
 <textarea cols="80" rows="10" name="new_scenario_content">[% dumped_scenario %]</textarea><br />
 <input type="hidden" name="list" value="[% list %]" />
-<input type="hidden" name="pname" value="[% pname %]" />
+<input type="hidden" name="scenario_function" value="[% scenario_function %]" />
 
 <!-- template is ready for saving scenario with scope limited to the current list or to the current robot but wwsympa 
 [% IF is_listmaster %]

--- a/default/web_tt2/my.tt2
+++ b/default/web_tt2/my.tt2
@@ -44,7 +44,7 @@
               <li><a href="[% 'review' | url_rel([l.key]) %]"><i class="fa fa-users"></i> [%|loc%]Review members[%END%]</a></li>
             [% END %]
             
-            [% IF is_user_allowed_to('archive.web_access', l.key) %]
+            [% IF is_user_allowed_to('archive_web_access', l.key) %]
               <li><a href="[% 'arc' | url_rel([l.key]) %]"><i class="fa fa-archive"></i> [%|loc%]Archives[%END%]</a></li>
             [% END %]
           </ul>

--- a/default/web_tt2/suspend_request.tt2
+++ b/default/web_tt2/suspend_request.tt2
@@ -63,7 +63,7 @@
               <li><a href="[% 'review' | url_rel([l.key]) %]">[%|loc%]Review members[%END%]</a></li>
             [% END %]
             
-            [% IF is_user_allowed_to('archive.web_access', l.key) %]
+            [% IF is_user_allowed_to('archive_web_access', l.key) %]
               <li><a href="[% 'arc' | url_rel([l.key]) %]">[%|loc%]Archives[%END%]</a></li>
             [% END %]
           </ul>

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -10129,7 +10129,7 @@ sub do_scenario_test {
     wwslog('info', '');
 
     # List available scenarios.
-    # FIXME Use load_scenario_list().
+    # FIXME Use get_scenarios().
     my $dh;
     unless (opendir $dh, Sympa::Constants::DEFAULTDIR . '/scenari/') {
         Sympa::WWW::Report::reject_report_web(
@@ -10877,16 +10877,15 @@ sub _do_edit_list_request {
             if ref $pitem->{format} eq 'ARRAY';
 
         if ($pitem->{scenario}) {
-            my $scenarios = $list->load_scenario_list($pitem->{scenario});
-            my $list_of_scenario = {};
-            # Only get required scenario attributes.
-            foreach my $name (keys %{$scenarios}) {
-                $list_of_scenario->{$name} = {
-                    name  => $name,
-                    title => $scenarios->{$name}->get_current_title()
-                };
-            }
-            $pitem->{format} = $list_of_scenario;
+            my $scenarios =
+                Sympa::Scenario::get_scenarios($list, $pitem->{scenario});
+            $pitem->{format} = {
+                map {
+                    my $name  = $_->{name};
+                    my $title = $_->get_current_title;
+                    ($name => {name => $name, title => $title});
+                } @$scenarios
+            };
         } elsif ($pitem->{task}) {
             my $tasks = Sympa::Task::get_tasks($list, $pitem->{task});
             $pitem->{format} = {map { ($_->{name} => $_) } @$tasks};
@@ -13439,27 +13438,26 @@ sub do_d_control {
 
     my $lang = $param->{'lang'};
 
-    my ($tmp_list_of_scenario, $name);
-    ## Scenario list for READ
-    ## Only get required scenario attributes
-    $tmp_list_of_scenario = $list->load_scenario_list('d_read');
-    foreach $name (keys %{$tmp_list_of_scenario}) {
-        $param->{'scenari_read'}{$name} = {
-            'name'      => $name,
-            'web_title' => $tmp_list_of_scenario->{$name}->get_current_title
-        };
-    }
+    # Only get required scenario attributes.
+    # "web_title" is for compatibility to <= 6.2.38.
+    my $scenarios = Sympa::Scenario::get_scenarios($list, 'd_read');
+    $param->{'scenari_read'} = {
+        map {
+            my $name  = $_->{name};
+            my $title = $_->get_current_title;
+            ($name => {name => $name, title => $title, web_title => $title});
+        } @$scenarios
+    };
     $param->{'scenari_read'}{$read}{'selected'} = 'selected="selected"';
 
-    ## Scenario list for EDIT
-    ## Only get required scenario attributes
-    $tmp_list_of_scenario = $list->load_scenario_list('d_edit');
-    foreach $name (keys %{$tmp_list_of_scenario}) {
-        $param->{'scenari_edit'}{$name} = {
-            'name'      => $name,
-            'web_title' => $tmp_list_of_scenario->{$name}->get_current_title
-        };
-    }
+    $scenarios = Sympa::Scenario::get_scenarios($list, 'd_edit');
+    $param->{'scenari_edit'} = {
+        map {
+            my $name  = $_->{name};
+            my $title = $_->get_current_title;
+            ($name => {name => $name, title => $title, web_title => $title});
+        } @$scenarios
+    };
     $param->{'scenari_edit'}{$edit}{'selected'} = 'selected="selected"';
 
     $param->{'set_owner'} = 1;

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1633,10 +1633,6 @@ while ($query = CGI::Fast->new) {
             if $function eq 'subscribe'
             and $param->{'user'}{'email'}
             and $list->is_list_member($param->{'user'}{'email'});
-        return 0
-            if ($function eq 'archive_web_access'
-            or $function eq 'archive.web_access')
-            and not %{$list->{'admin'}{'archive'} || {}};
 
         my $result = Sympa::Scenario->new($list, $function)->authz(
             $param->{'auth_method'},
@@ -1646,7 +1642,7 @@ while ($query = CGI::Fast->new) {
             }
         );
         return 0 unless ref $result eq 'HASH';
-        return 0 if $result->{'action'} eq 'reject';
+        return 0 if $result->{action} =~ /\Areject\b/i;
         return 1;
     };
 

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1638,9 +1638,7 @@ while ($query = CGI::Fast->new) {
             or $function eq 'archive.web_access')
             and not %{$list->{'admin'}{'archive'} || {}};
 
-        my $result = Sympa::Scenario::request_action(
-            $list,
-            $function,
+        my $result = Sympa::Scenario->new($list, $function)->authz(
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
@@ -2608,8 +2606,7 @@ sub check_param_in {
                 $list->find_picture_url($param->{'user'}{'email'});
 
             ## Checks if the user can post in this list.
-            my $result = Sympa::Scenario::request_action(
-                $list, 'send',
+            my $result = Sympa::Scenario->new($list, 'send')->authz(
                 $param->{'auth_method'},
                 {   'sender'      => $param->{'user'}{'email'},
                     'remote_host' => $param->{'remote_host'},
@@ -2663,9 +2660,7 @@ sub check_param_in {
         }
 
         ## Check unsubscription authorization for the current user and list.
-        my $result = Sympa::Scenario::request_action(
-            $list,
-            'unsubscribe',
+        my $result = Sympa::Scenario->new($list, 'unsubscribe')->authz(
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
@@ -2685,9 +2680,7 @@ sub check_param_in {
         }
 
         ## Check subscription authorization for the current user and list.
-        $result = Sympa::Scenario::request_action(
-            $list,
-            'subscribe',
+        $result = Sympa::Scenario->new($list, 'subscribe')->authz(
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
@@ -2719,9 +2712,7 @@ sub check_param_in {
     }
 
     ## Check if the current user can create a list.
-    my $result = Sympa::Scenario::request_action(
-        $robot,
-        'create_list',
+    my $result = Sympa::Scenario->new($robot, 'create_list')->authz(
         $param->{'auth_method'},
         {   'sender'      => $param->{'user'}{'email'},
             'remote_host' => $param->{'remote_host'},
@@ -2751,16 +2742,16 @@ sub check_param_in {
         my $family = Sympa::Family->new($key, $robot);
         next unless $family;
 
-        my $result = Sympa::Scenario::request_action(
-            $family->{'robot'},
-            'automatic_list_creation',
+        my $result =
+            Sympa::Scenario->new($family->{'robot'},
+            'automatic_list_creation')->authz(
             $param->{'auth_method'},
             {   'sender'             => $param->{'user'}{'email'},
                 'message'            => undef,
                 'family'             => $family,
                 'automatic_listname' => '',
             }
-        );
+            );
         my $r_action = $result->{'action'} if ref $result eq 'HASH';
         $param->{'may_create_automatic_list'}{$key} = 1
             if $r_action and $r_action =~ /do_it/;
@@ -2865,8 +2856,7 @@ sub check_param_out {
                 || $param->{'is_editor'};
 
             #May post:
-            my $result = Sympa::Scenario::request_action(
-                $list, 'send',
+            my $result = Sympa::Scenario->new($list, 'send')->authz(
                 $param->{'auth_method'},
                 {   'sender'      => $param->{'user'}{'email'},
                     'remote_host' => $param->{'remote_host'},
@@ -2898,8 +2888,7 @@ sub check_param_out {
             if ($param->{'may_signoff'} || $param->{'may_subscribe'});
 
         ## May review
-        my $result = Sympa::Scenario::request_action(
-            $list, 'review',
+        my $result = Sympa::Scenario->new($list, 'review')->authz(
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
@@ -2915,9 +2904,7 @@ sub check_param_out {
         $param->{'list_status'}    = $list->{'admin'}{'status'};
 
         ## May signoff
-        $result = Sympa::Scenario::request_action(
-            $list,
-            'unsubscribe',
+        $result = Sympa::Scenario->new($list, 'unsubscribe')->authz(
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
@@ -2938,9 +2925,7 @@ sub check_param_out {
         }
 
         ## May Subscribe
-        $result = Sympa::Scenario::request_action(
-            $list,
-            'subscribe',
+        $result = Sympa::Scenario->new($list, 'subscribe')->authz(
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
@@ -2954,8 +2939,7 @@ sub check_param_out {
 
 # SJS START
         ## May Add or del subscribers
-        my $result = Sympa::Scenario::request_action(
-            $list, 'add',
+        my $result = Sympa::Scenario->new($list, 'add')->authz(
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
@@ -2964,8 +2948,7 @@ sub check_param_out {
         );
         $main::action = $result->{'action'} if (ref($result) eq 'HASH');
         $param->{'may_add'} = 1 if ($main::action =~ /do_it/);
-        my $result = Sympa::Scenario::request_action(
-            $list, 'del',
+        my $result = Sympa::Scenario->new($list, 'del')->authz(
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
@@ -2981,15 +2964,14 @@ sub check_param_out {
             $param->{'is_archived'} = 1;
 
             ## Check if the current user may access web archives
-            my $result = Sympa::Scenario::request_action(
-                $list,
-                'archive_web_access',
+            my $result =
+                Sympa::Scenario->new($list, 'archive_web_access')->authz(
                 $param->{'auth_method'},
                 {   'sender'      => $param->{'user'}{'email'},
                     'remote_host' => $param->{'remote_host'},
                     'remote_addr' => $param->{'remote_addr'}
                 }
-            );
+                );
             my $r_action;
             $r_action = $result->{'action'} if (ref($result) eq 'HASH');
 
@@ -3001,11 +2983,8 @@ sub check_param_out {
 
             ## Check if web archive is publically accessible (useful
             ## information for RSS)
-            $result = Sympa::Scenario::request_action(
-                $list, 'archive_web_access',
-                $param->{'auth_method'},
-                {'sender' => 'nobody'}
-            );
+            $result = Sympa::Scenario->new($list, 'archive_web_access')
+                ->authz($param->{'auth_method'}, {'sender' => 'nobody'});
             $r_action = $result->{'action'} if (ref($result) eq 'HASH');
 
             if ($r_action =~ /do_it/i) {
@@ -4272,16 +4251,15 @@ sub do_lists {
     foreach my $list (@$all_lists) {
         my $sender = $param->{'user'}{'email'} || 'nobody';
 
-        my $result = Sympa::Scenario::request_action(
-            $list,
-            'visibility',
+        my $result =
+            Sympa::Scenario->new($list, 'visibility',
+            dont_reload_scenario => 1)->authz(
             $param->{'auth_method'},
             {   'sender'      => $sender,
                 'remote_host' => $param->{'remote_host'},
                 'remote_addr' => $param->{'remote_addr'},
-            },
-            dont_reload_scenario => 1
-        );
+            }
+            );
 
         my $r_action;
         $r_action = $result->{'action'} if (ref($result) eq 'HASH');
@@ -4500,16 +4478,15 @@ sub do_including_lists {
         foreach my $l (@{$list->get_including_lists($role) || []}) {
             unless (exists $which{$l->get_id}) {
                 # Check visibility.
-                my $result = Sympa::Scenario::request_action(
-                    $l,
-                    'visibility',
+                my $result =
+                    Sympa::Scenario->new($l, 'visibility',
+                    dont_reload_scenario => 1)->authz(
                     $param->{'auth_method'},
                     {   'sender'      => $param->{'user'}{'email'},
                         'remote_host' => $param->{'remote_host'},
                         'remote_addr' => $param->{'remote_addr'},
-                    },
-                    dont_reload_scenario => 1
-                );
+                    }
+                    );
                 my $action = $result->{'action'} if ref $result eq 'HASH';
                 next unless $action;
 
@@ -8584,9 +8561,7 @@ sub do_arc {
     }
 
     # Check authorization for tracking.
-    my $result = Sympa::Scenario::request_action(
-        $list,
-        'tracking',
+    my $result = Sympa::Scenario->new($list, 'tracking')->authz(
         $param->{'auth_method'},
         {   'sender'      => $param->{'user'}{'email'},
             'remote_host' => $param->{'remote_host'},
@@ -9143,9 +9118,7 @@ sub do_tracking {
     }
 
     ## Access control
-    my $result = Sympa::Scenario::request_action(
-        $list,
-        'tracking',
+    my $result = Sympa::Scenario->new($list, 'tracking')->authz(
         $param->{'auth_method'},
         {   'sender'      => $param->{'user'}{'email'},
             'remote_host' => $param->{'remote_host'},
@@ -9833,9 +9806,7 @@ sub do_create_list {
 sub do_create_list_request {
     wwslog('info', '');
 
-    my $result = Sympa::Scenario::request_action(
-        $robot,
-        'create_list',
+    my $result = Sympa::Scenario->new($robot, 'create_list')->authz(
         $param->{'auth_method'},
         {   'sender'      => $param->{'user'}{'email'},
             'remote_host' => $param->{'remote_host'},
@@ -10177,9 +10148,7 @@ sub do_scenario_test {
         my $function = $in{'scenario'};
         wwslog('debug3', 'Perform scenario_test');
 
-        my $result = Sympa::Scenario::request_action(
-            $robot,
-            $function,
+        my $result = Sympa::Scenario->new($robot, $function)->authz(
             $in{'auth_method'},
             {   'listname'    => $in{'listname'},
                 'sender'      => $in{'sender'},
@@ -10445,9 +10414,7 @@ sub do_search_list {
         'filter' => ['%name%|%subject%' => $param->{'filter_list'}]);
     foreach my $list (@$all_lists) {
         my $is_admin = 0;
-        my $result   = Sympa::Scenario::request_action(
-            $list,
-            'visibility',
+        my $result = Sympa::Scenario->new($list, 'visibility')->authz(
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
@@ -10918,9 +10885,7 @@ sub _do_edit_list_request {
 sub do_rename_list_request {
     wwslog('info', '');
 
-    my $result = Sympa::Scenario::request_action(
-        $robot,
-        'create_list',
+    my $result = Sympa::Scenario->new($robot, 'create_list')->authz(
         $param->{'auth_method'},
         {   'sender'      => $param->{'user'}{'email'},
             'remote_host' => $param->{'remote_host'},
@@ -11517,15 +11482,15 @@ sub do_d_read {
         if ($child->{type} eq 'directory') {
             if ($child->{scenario}) {
                 # Check access permission for reading.
-                my $result = Sympa::Scenario::request_action(
-                    $list, 'd_read',
+                my $result =
+                    Sympa::Scenario->new($list, 'd_read',
+                    name => $child->{scenario}{read})->authz(
                     $param->{'auth_method'},
                     {   'sender'      => $param->{'user'}{'email'},
                         'remote_host' => $param->{'remote_host'},
                         'remote_addr' => $param->{'remote_addr'},
-                    },
-                    name => $child->{scenario}{read}
-                );
+                    }
+                    );
                 my $action;
                 $action = $result->{'action'} if ref $result eq 'HASH';
 
@@ -11536,15 +11501,15 @@ sub do_d_read {
                     # edit description files access.
                     # Only authenticated users can edit a file.
                     if ($param->{'user'}{'email'}) {
-                        my $result = Sympa::Scenario::request_action(
-                            $list, 'd_edit',
+                        my $result =
+                            Sympa::Scenario->new($list, 'd_edit',
+                            name => $child->{scenario}{edit})->authz(
                             $param->{'auth_method'},
                             {   'sender'      => $param->{'user'}{'email'},
                                 'remote_host' => $param->{'remote_host'},
                                 'remote_addr' => $param->{'remote_addr'},
-                            },
-                            name => $child->{scenario}{edit}
-                        );
+                            }
+                            );
                         my $action_edit;
                         $action_edit = $result->{'action'}
                             if ref $result eq 'HASH';
@@ -11605,15 +11570,15 @@ sub do_d_read {
                 # a desc file was found
                 $def_desc = 1;
 
-                my $result = Sympa::Scenario::request_action(
-                    $list, 'd_read',
+                my $result =
+                    Sympa::Scenario->new($list, 'd_read',
+                    name => $child->{scenario}{read})->authz(
                     $param->{'auth_method'},
                     {   'sender'      => $param->{'user'}{'email'},
                         'remote_host' => $param->{'remote_host'},
                         'remote_addr' => $param->{'remote_addr'},
-                    },
-                    name => $child->{scenario}{read}
-                );
+                    }
+                    );
                 my $action;
                 $action = $result->{'action'} if ref $result eq 'HASH';
                 unless ($user eq $child->{owner}
@@ -11636,15 +11601,15 @@ sub do_d_read {
                     # Only authenticated users can edit files.
 
                     if ($param->{'user'}{'email'}) {
-                        my $result = Sympa::Scenario::request_action(
-                            $list, 'd_edit',
+                        my $result =
+                            Sympa::Scenario->new($list, 'd_edit',
+                            name => $child->{scenario}{edit})->authz(
                             $param->{'auth_method'},
                             {   'sender'      => $param->{'user'}{'email'},
                                 'remote_host' => $param->{'remote_host'},
                                 'remote_addr' => $param->{'remote_addr'},
-                            },
-                            name => $child->{scenario}{edit}
-                        );
+                            }
+                            );
                         my $action_edit;
                         $action_edit = $result->{'action'}
                             if ref $result eq 'HASH';
@@ -11872,15 +11837,15 @@ sub _latest_d_read {
         if ($child->{type} eq 'directory') {
             if ($child->{scenario}) {
                 # Check access permission for reading.
-                my $result = Sympa::Scenario::request_action(
-                    $list, 'd_read',
+                my $result =
+                    Sympa::Scenario->new($list, 'd_read',
+                    name => $child->{scenario}{read})->authz(
                     $param->{'auth_method'},
                     {   'sender'      => $param->{'user'}{'email'},
                         'remote_host' => $param->{'remote_host'},
                         'remote_addr' => $param->{'remote_addr'},
-                    },
-                    name => $child->{scenario}{read}
-                );
+                    }
+                    );
                 my $action = $result->{'action'} if ref $result eq 'HASH';
                 $action ||= '';
 
@@ -11897,15 +11862,15 @@ sub _latest_d_read {
 
             my $may = 1;
             if ($child->{scenario}) {
-                my $result = Sympa::Scenario::request_action(
-                    $list, 'd_read',
+                my $result =
+                    Sympa::Scenario->new($list, 'd_read',
+                    name => $child->{scenario}{read})->authz(
                     $param->{'auth_method'},
                     {   'sender'      => $param->{'user'}{'email'},
                         'remote_host' => $param->{'remote_host'},
                         'remote_addr' => $param->{'remote_addr'},
-                    },
-                    name => $child->{scenario}{read}
-                );
+                    }
+                    );
                 my $action = $result->{'action'} if ref $result eq 'HASH';
                 $action ||= '';
 
@@ -13792,8 +13757,8 @@ sub do_remind {
     my $mail_command;
 
     ## Sympa will require a confirmation
-    my $result = Sympa::Scenario::request_action(
-        $list, 'remind', 'smtp',
+    my $result = Sympa::Scenario->new($list, 'remind')->authz(
+        'smtp',
         {   'sender'      => $param->{'user'}{'email'},
             'remote_host' => $param->{'remote_host'},
             'remote_addr' => $param->{'remote_addr'}
@@ -14180,9 +14145,7 @@ sub _set_my_lists_info {
         # Add lists information to 'which'
         foreach my $list (@{$get_which{member}}) {
             # Evaluate AuthZ scenario first
-            my $result = Sympa::Scenario::request_action(
-                $list,
-                'visibility',
+            my $result = Sympa::Scenario->new($list, 'visibility')->authz(
                 $param->{'auth_method'},
                 {   'sender'      => $param->{'user'}{'email'},
                     'remote_host' => $param->{'remote_host'},
@@ -15629,17 +15592,16 @@ sub _purge_subtopics {
         my @names = (keys %{$topic->{sub}});
 
         for my $name (@names) {
-            my $result = Sympa::Scenario::request_action(
-                $robot,
-                'topics_visibility',
+            my $result =
+                Sympa::Scenario->new($robot, 'topics_visibility',
+                name => $topic->{sub}{$name}->{visibility})->authz(
                 $param->{'auth_method'},
                 {   'topicname'   => join('/', $topic_name, $name),
                     'sender'      => $param->{'user'}{'email'},
                     'remote_host' => $param->{'remote_host'},
                     'remote_addr' => $param->{'remote_addr'}
-                },
-                name => $topic->{sub}{$name}->{visibility}
-            );
+                }
+                );
 
             my $action;
             $action = $result->{'action'} if (ref($result) eq 'HASH');
@@ -15676,17 +15638,16 @@ sub export_topics {
         sort { $topics{$a}{'order'} <=> $topics{$b}{'order'} }
         keys %topics
     ) {
-        my $result = Sympa::Scenario::request_action(
-            $robot,
-            'topics_visibility',
+        my $result =
+            Sympa::Scenario->new($robot, 'topics_visibility',
+            name => $topics{$t}->{visibility})->authz(
             $param->{'auth_method'},
             {   'topicname'   => $t,
                 'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
                 'remote_addr' => $param->{'remote_addr'}
-            },
-            name => $topics{$t}->{visibility}
-        );
+            }
+            );
         my $action;
         $action = $result->{'action'} if (ref($result) eq 'HASH');
         next unless ($action =~ /do_it/);
@@ -16442,9 +16403,7 @@ sub do_rss_request {
     wwslog('info', '');
 
     if (ref $list eq 'Sympa::List') {
-        my $result = Sympa::Scenario::request_action(
-            $list,
-            'visibility',
+        my $result = Sympa::Scenario->new($list, 'visibility')->authz(
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
@@ -16850,9 +16809,7 @@ sub _prepare_subscriber {
 sub check_authz {
     my ($subname, $function) = @_;
 
-    my $result = Sympa::Scenario::request_action(
-        $list,
-        $function,
+    my $result = Sympa::Scenario->new($list, $function)->authz(
         $param->{'auth_method'},
         {   'sender'      => $param->{'user'}{'email'} || 'nobody',
             'remote_host' => $param->{'remote_host'},
@@ -17296,9 +17253,7 @@ sub _is_action_disabled {
 sub prevent_visibility_bypass {
     wwslog('debug2', 'Starting');
     if (defined $list and ref $list eq 'Sympa::List') {
-        my $result = Sympa::Scenario::request_action(
-            $list,
-            'visibility',
+        my $result = Sympa::Scenario->new($list, 'visibility')->authz(
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -378,7 +378,7 @@ our %action_args = (
     'reject'           => ['list',            'id'],
     'distribute'       => ['list',            'id'],
     'add_frommod'      => ['list',            'id'],
-    'dump_scenario'    => ['list',            'pname'],
+    'dump_scenario'    => ['list',            'scenario_function'],
     'd_reject_shared'  => ['list',            'id'],
     'd_install_shared' => ['list',            'id'],
     'modindex'         => ['list'],
@@ -547,7 +547,7 @@ our %required_args = (
     'delete_pictures' => ['param.list', 'param.user.email'],
     'distribute'      => ['param.list', 'param.user.email', 'id|idspam'],
     'add_frommod'     => ['param.list', 'param.user.email', 'id'],
-    'dump_scenario'   => ['param.list', 'pname'],
+    'dump_scenario'   => ['param.list', 'scenario_function|pname'],
     'edit'            => ['param.list', 'param.user.email', 'role', 'email'],
     'edit_list'         => ['param.user.email', 'param.list'],
     'edit_list_request' => ['param.user.email', 'param.list'],
@@ -1622,31 +1622,33 @@ while ($query = CGI::Fast->new) {
     }
 
     $param->{'is_user_allowed_to'} = sub {
-        my $permission = shift;
-        my $list       = shift;
-        return 0 unless $permission and $list;
+        my $function = shift;
+        my $list     = shift;
+        return 0 unless $function and $list;
 
         $list = Sympa::List->new($list, $robot)
             unless ref $list eq 'Sympa::List';
+
+        return 0
+            if $function eq 'subscribe'
+            and $param->{'user'}{'email'}
+            and $list->is_list_member($param->{'user'}{'email'});
+        return 0
+            if ($function eq 'archive_web_access'
+            or $function eq 'archive.web_access')
+            and not %{$list->{'admin'}{'archive'} || {}};
+
         my $result = Sympa::Scenario::request_action(
             $list,
-            $permission,
+            $function,
             $param->{'auth_method'},
             {   'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
                 'remote_addr' => $param->{'remote_addr'}
             }
         );
-
-        return 0
-            unless ref($result) eq 'HASH'
-            and $result->{'action'} ne 'reject';
-        return 0
-            if $permission eq 'subscribe'
-            and $list->is_list_member($param->{'user'}{'email'});
-        return 0
-            if $permission eq 'archive.web_access'
-            and not defined $list->{'admin'}{'archive'};
+        return 0 unless ref $result eq 'HASH';
+        return 0 if $result->{'action'} eq 'reject';
         return 1;
     };
 
@@ -2981,7 +2983,7 @@ sub check_param_out {
             ## Check if the current user may access web archives
             my $result = Sympa::Scenario::request_action(
                 $list,
-                'archive.web_access',
+                'archive_web_access',
                 $param->{'auth_method'},
                 {   'sender'      => $param->{'user'}{'email'},
                     'remote_host' => $param->{'remote_host'},
@@ -3000,7 +3002,7 @@ sub check_param_out {
             ## Check if web archive is publically accessible (useful
             ## information for RSS)
             $result = Sympa::Scenario::request_action(
-                $list, 'archive.web_access',
+                $list, 'archive_web_access',
                 $param->{'auth_method'},
                 {'sender' => 'nobody'}
             );
@@ -4277,8 +4279,8 @@ sub do_lists {
             {   'sender'      => $sender,
                 'remote_host' => $param->{'remote_host'},
                 'remote_addr' => $param->{'remote_addr'},
-                'options'     => {'dont_reload_scenario' => 1}
-            }
+            },
+            dont_reload_scenario => 1
         );
 
         my $r_action;
@@ -4505,8 +4507,8 @@ sub do_including_lists {
                     {   'sender'      => $param->{'user'}{'email'},
                         'remote_host' => $param->{'remote_host'},
                         'remote_addr' => $param->{'remote_addr'},
-                        'options'     => {'dont_reload_scenario' => 1}
-                    }
+                    },
+                    dont_reload_scenario => 1
                 );
                 my $action = $result->{'action'} if ref $result eq 'HASH';
                 next unless $action;
@@ -4815,7 +4817,7 @@ sub _review_member {
     my %sources;
 
     ## Access control
-    return undef unless (defined check_authz('do_review', 'review'));
+    return undef unless defined check_authz('do_review', 'review');
 
     if ($in{'size'}) {
         $size = $in{'size'};
@@ -5104,7 +5106,7 @@ sub do_search {
     my @additional_fields = split ',',
         $Conf::Conf{'db_additional_subscriber_fields'};
     ## Access control
-    return undef unless (defined check_authz('do_search', 'review'));
+    return undef unless defined check_authz('do_search', 'review');
 
     # Search key.
     # GH #341: Keep search key in session store.
@@ -5616,7 +5618,8 @@ sub do_setpref {
 sub do_subscribe {
     wwslog('info', '(%s)', $in{'email'});
 
-    return undef if purely_closed('subscribe');    #FIXME: mv this to Scenario
+    my $scenario = Sympa::Scenario->new($list, 'subscribe') or return undef;
+    return $in{'previous_action'} || 'info' if $scenario->is_purely_closed;
 
     if (    $param->{'user'}{'email'}
         and $list->is_list_member($param->{'user'}{'email'})) {
@@ -5777,7 +5780,10 @@ sub do_auto_signoff {
     # user: this function is supposed to be used by clicking on autocreated
     # URL only.
     my $default_home = Conf::get_robot_conf($robot, 'default_home');
-    return $default_home if purely_closed('unsubscribe');    #FIXME
+
+    my $scenario = Sympa::Scenario->new($list, 'unsubscribe') or return undef;
+    return $default_home if $scenario->is_purely_closed;
+
     my $email = Sympa::Tools::Text::canonic_email($in{'email'});
     return $default_home
         unless $email and Sympa::Tools::Text::valid_email($email);
@@ -5878,7 +5884,8 @@ sub do_family_signoff {
 sub do_signoff {
     wwslog('info', '(%s)', $in{'email'});
 
-    return undef if purely_closed('unsubscribe');  #FIXME: mv this to Scenario
+    my $scenario = Sympa::Scenario->new($list, 'unsubscribe') or return undef;
+    return $in{'previous_action'} || 'info' if $scenario->is_purely_closed;
 
     if ($param->{'user'}{'email'}
         and not $list->is_list_member($param->{'user'}{'email'})) {
@@ -8570,7 +8577,7 @@ sub do_arc {
     }
 
     ## Access control
-    unless (defined check_authz('do_arc', 'archive.web_access')) {
+    unless (defined check_authz('do_arc', 'archive_web_access')) {
         $param->{'previous_action'} = 'arc';
         $param->{'previous_list'}   = $list->{'name'};
         return undef;
@@ -8579,7 +8586,7 @@ sub do_arc {
     # Check authorization for tracking.
     my $result = Sympa::Scenario::request_action(
         $list,
-        'tracking.tracking',
+        'tracking',
         $param->{'auth_method'},
         {   'sender'      => $param->{'user'}{'email'},
             'remote_host' => $param->{'remote_host'},
@@ -8778,7 +8785,7 @@ sub do_latest_arc {
 
     ## Access control
     return undef
-        unless (defined check_authz('do_latest_arc', 'archive.web_access'));
+        unless defined check_authz('do_latest_arc', 'archive_web_access');
 
     ## parameters of the query
     my $today = time;
@@ -9079,7 +9086,7 @@ sub do_view_source {
         $in{'list'}, $in{'yyyy'}, $in{'month'}, $in{'msgid'});
 
     ## Access control
-    unless (defined check_authz('do_arc', 'archive.web_access')) {
+    unless (defined check_authz('do_arc', 'archive_web_access')) {
         $param->{'previous_action'} = 'arc';
         $param->{'previous_list'}   = $list->{'name'};
         return undef;
@@ -9138,7 +9145,7 @@ sub do_tracking {
     ## Access control
     my $result = Sympa::Scenario::request_action(
         $list,
-        'tracking.tracking',
+        'tracking',
         $param->{'auth_method'},
         {   'sender'      => $param->{'user'}{'email'},
             'remote_host' => $param->{'remote_host'},
@@ -9225,8 +9232,7 @@ sub do_arcsearch_form {
 
     ## Access control
     return undef
-        unless (
-        defined check_authz('do_arcsearch_form', 'archive.web_access'));
+        unless defined check_authz('do_arcsearch_form', 'archive_web_access');
 
     my $archive = Sympa::Archive->new(context => $list);
     $param->{'yyyymm'}       = [reverse $archive->get_archives];
@@ -9242,7 +9248,7 @@ sub do_arcsearch {
 
     # Access control
     return undef
-        unless defined check_authz('do_arcsearch', 'archive.web_access');
+        unless defined check_authz('do_arcsearch', 'archive_web_access');
 
     my $search = Sympa::WWW::Marc::Search->new;
     my $archive = Sympa::Archive->new(context => $list);
@@ -9380,7 +9386,7 @@ sub do_arcsearch_id {
 
     # Access control
     return undef
-        unless defined check_authz('do_arcsearch_id', 'archive.web_access');
+        unless defined check_authz('do_arcsearch_id', 'archive_web_access');
 
     if (    ($session->{'archive_sniffer'} || '') ne 'false'
         and not $param->{'user'}{'email'}
@@ -10118,11 +10124,14 @@ sub do_viewbounce {
 }
 
 ## some help for listmaster and developpers
+#FIXME Works only under doamin context.
 sub do_scenario_test {
     wwslog('info', '');
 
-    ## List available scenarii
-    unless (opendir SCENARI, Sympa::Constants::DEFAULTDIR . '/scenari/') {
+    # List available scenarios.
+    # FIXME Use load_scenario_list().
+    my $dh;
+    unless (opendir $dh, Sympa::Constants::DEFAULTDIR . '/scenari/') {
         Sympa::WWW::Report::reject_report_web(
             'intern',
             'cannot_open_dir',
@@ -10136,13 +10145,13 @@ sub do_scenario_test {
             Sympa::Constants::DEFAULTDIR);
         return undef;
     }
-
-    foreach my $scfile (readdir SCENARI) {
-        if ($scfile =~ /^(\w+)\.(\w+)/) {
+    foreach my $scfile (readdir $dh) {
+        if ($scfile =~ /^([-\w]+)[.](\w+)/) {
             $param->{'scenario'}{$1}{'defined'} = 1;
         }
     }
-    closedir SCENARI;
+    closedir $dh;
+
     my $all_lists = Sympa::List::get_lists('*');
     foreach my $list (@$all_lists) {
         $param->{'listname'}{$list->{'name'}}{'defined'} = 1;
@@ -10165,12 +10174,12 @@ sub do_scenario_test {
     $param->{'email'} = $in{'email'};
 
     if ($in{'scenario'}) {
-        my $operation = $in{'scenario'};
+        my $function = $in{'scenario'};
         wwslog('debug3', 'Perform scenario_test');
 
         my $result = Sympa::Scenario::request_action(
             $robot,
-            $operation,
+            $function,
             $in{'auth_method'},
             {   'listname'    => $in{'listname'},
                 'sender'      => $in{'sender'},
@@ -10178,7 +10187,7 @@ sub do_scenario_test {
                 'remote_host' => $in{'remote_host'},
                 'remote_addr' => $in{'remote_addr'}
             },
-            'debug'
+            debug => 1
         );
         if (ref($result) eq 'HASH') {
             $param->{'scenario_action'}      = $result->{'action'};
@@ -10868,14 +10877,13 @@ sub _do_edit_list_request {
             if ref $pitem->{format} eq 'ARRAY';
 
         if ($pitem->{scenario}) {
-            my $scenarios =
-                $list->load_scenario_list($pitem->{scenario}, $robot);
+            my $scenarios = $list->load_scenario_list($pitem->{scenario});
             my $list_of_scenario = {};
             # Only get required scenario attributes.
-            foreach my $scenario (keys %{$scenarios}) {
-                $list_of_scenario->{$scenario} = {
-                    name  => $scenarios->{$scenario}{name},
-                    title => $scenarios->{$scenario}->get_current_title()
+            foreach my $name (keys %{$scenarios}) {
+                $list_of_scenario->{$name} = {
+                    name  => $name,
+                    title => $scenarios->{$name}->get_current_title()
                 };
             }
             $pitem->{format} = $list_of_scenario;
@@ -11511,14 +11519,13 @@ sub do_d_read {
             if ($child->{scenario}) {
                 # Check access permission for reading.
                 my $result = Sympa::Scenario::request_action(
-                    $list,
-                    'shared_doc.d_read',
+                    $list, 'd_read',
                     $param->{'auth_method'},
                     {   'sender'      => $param->{'user'}{'email'},
                         'remote_host' => $param->{'remote_host'},
                         'remote_addr' => $param->{'remote_addr'},
-                        'scenario'    => $child->{scenario}{read}
-                    }
+                    },
+                    name => $child->{scenario}{read}
                 );
                 my $action;
                 $action = $result->{'action'} if ref $result eq 'HASH';
@@ -11531,14 +11538,13 @@ sub do_d_read {
                     # Only authenticated users can edit a file.
                     if ($param->{'user'}{'email'}) {
                         my $result = Sympa::Scenario::request_action(
-                            $list,
-                            'shared_doc.d_edit',
+                            $list, 'd_edit',
                             $param->{'auth_method'},
                             {   'sender'      => $param->{'user'}{'email'},
                                 'remote_host' => $param->{'remote_host'},
                                 'remote_addr' => $param->{'remote_addr'},
-                                'scenario'    => $child->{scenario}{edit}
-                            }
+                            },
+                            name => $child->{scenario}{edit}
                         );
                         my $action_edit;
                         $action_edit = $result->{'action'}
@@ -11601,14 +11607,13 @@ sub do_d_read {
                 $def_desc = 1;
 
                 my $result = Sympa::Scenario::request_action(
-                    $list,
-                    'shared_doc.d_read',
+                    $list, 'd_read',
                     $param->{'auth_method'},
                     {   'sender'      => $param->{'user'}{'email'},
                         'remote_host' => $param->{'remote_host'},
                         'remote_addr' => $param->{'remote_addr'},
-                        'scenario'    => $child->{scenario}{read}
-                    }
+                    },
+                    name => $child->{scenario}{read}
                 );
                 my $action;
                 $action = $result->{'action'} if ref $result eq 'HASH';
@@ -11633,14 +11638,13 @@ sub do_d_read {
 
                     if ($param->{'user'}{'email'}) {
                         my $result = Sympa::Scenario::request_action(
-                            $list,
-                            'shared_doc.d_edit',
+                            $list, 'd_edit',
                             $param->{'auth_method'},
                             {   'sender'      => $param->{'user'}{'email'},
                                 'remote_host' => $param->{'remote_host'},
                                 'remote_addr' => $param->{'remote_addr'},
-                                'scenario'    => $child->{scenario}{edit}
-                            }
+                            },
+                            name => $child->{scenario}{edit}
                         );
                         my $action_edit;
                         $action_edit = $result->{'action'}
@@ -11870,14 +11874,13 @@ sub _latest_d_read {
             if ($child->{scenario}) {
                 # Check access permission for reading.
                 my $result = Sympa::Scenario::request_action(
-                    $list,
-                    'shared_doc.d_read',
+                    $list, 'd_read',
                     $param->{'auth_method'},
                     {   'sender'      => $param->{'user'}{'email'},
                         'remote_host' => $param->{'remote_host'},
                         'remote_addr' => $param->{'remote_addr'},
-                        'scenario'    => $child->{scenario}{read}
-                    }
+                    },
+                    name => $child->{scenario}{read}
                 );
                 my $action = $result->{'action'} if ref $result eq 'HASH';
                 $action ||= '';
@@ -11896,14 +11899,13 @@ sub _latest_d_read {
             my $may = 1;
             if ($child->{scenario}) {
                 my $result = Sympa::Scenario::request_action(
-                    $list,
-                    'shared_doc.d_read',
+                    $list, 'd_read',
                     $param->{'auth_method'},
                     {   'sender'      => $param->{'user'}{'email'},
                         'remote_host' => $param->{'remote_host'},
                         'remote_addr' => $param->{'remote_addr'},
-                        'scenario'    => $child->{scenario}{read}
-                    }
+                    },
+                    name => $child->{scenario}{read}
                 );
                 my $action = $result->{'action'} if ref $result eq 'HASH';
                 $action ||= '';
@@ -13437,30 +13439,25 @@ sub do_d_control {
 
     my $lang = $param->{'lang'};
 
+    my ($tmp_list_of_scenario, $name);
     ## Scenario list for READ
-
-    my $tmp_list_of_scenario = $list->load_scenario_list('d_read', $robot);
-
     ## Only get required scenario attributes
-    foreach my $scenario (keys %{$tmp_list_of_scenario}) {
-        $param->{'scenari_read'}{$scenario} = {
-            'name' => $tmp_list_of_scenario->{$scenario}{'name'},
-            'web_title' =>
-                $tmp_list_of_scenario->{$scenario}->get_current_title()
+    $tmp_list_of_scenario = $list->load_scenario_list('d_read');
+    foreach $name (keys %{$tmp_list_of_scenario}) {
+        $param->{'scenari_read'}{$name} = {
+            'name'      => $name,
+            'web_title' => $tmp_list_of_scenario->{$name}->get_current_title
         };
     }
-
     $param->{'scenari_read'}{$read}{'selected'} = 'selected="selected"';
 
     ## Scenario list for EDIT
-    $tmp_list_of_scenario = $list->load_scenario_list('d_edit', $robot);
-
     ## Only get required scenario attributes
-    foreach my $scenario (keys %{$tmp_list_of_scenario}) {
-        $param->{'scenari_edit'}{$scenario} = {
-            'name' => $tmp_list_of_scenario->{$scenario}{'name'},
-            'web_title' =>
-                $tmp_list_of_scenario->{$scenario}->get_current_title()
+    $tmp_list_of_scenario = $list->load_scenario_list('d_edit');
+    foreach $name (keys %{$tmp_list_of_scenario}) {
+        $param->{'scenari_edit'}{$name} = {
+            'name'      => $name,
+            'web_title' => $tmp_list_of_scenario->{$name}->get_current_title
         };
     }
     $param->{'scenari_edit'}{$edit}{'selected'} = 'selected="selected"';
@@ -13783,7 +13780,7 @@ sub do_remind {
     wwslog('info', '');
 
     ## Access control
-    return undef unless (defined check_authz('do_remind', 'remind'));
+    return undef unless defined check_authz('do_remind', 'remind');
 
     # Action confirmed?
     my $next_action = $session->confirm_action(
@@ -15377,7 +15374,7 @@ sub do_attach {
 
     ## Access control
     return undef
-        unless (defined check_authz('do_attach', 'archive.web_access'));
+        unless defined check_authz('do_attach', 'archive_web_access');
 
     # parameters for the template file
     # view a file
@@ -15642,7 +15639,8 @@ sub _purge_subtopics {
                     'sender'      => $param->{'user'}{'email'},
                     'remote_host' => $param->{'remote_host'},
                     'remote_addr' => $param->{'remote_addr'}
-                }
+                },
+                name => $topic->{sub}{$name}->{visibility}
             );
 
             my $action;
@@ -15688,7 +15686,8 @@ sub export_topics {
                 'sender'      => $param->{'user'}{'email'},
                 'remote_host' => $param->{'remote_host'},
                 'remote_addr' => $param->{'remote_addr'}
-            }
+            },
+            name => $topics{$t}->{visibility}
         );
         my $action;
         $action = $result->{'action'} if (ref($result) eq 'HASH');
@@ -15886,37 +15885,38 @@ sub do_blacklist {
 
 # output in text/plain format a scenario
 sub do_dump_scenario {
-    wwslog('info', '(%s, %s)', $param->{'list'}, $in{'pname'});
+    wwslog('info', '(%s, %s)', $param->{'list'}, $in{'scenario_function'});
 
-    my $scenario = Sympa::Scenario->new(
-        'function'  => $in{'pname'},
-        'robot'     => $robot,
-        'name'      => $list->{'admin'}{$in{'pname'}}{'name'},
-        'directory' => $list->{'dir'}
-    );
-    unless (defined $scenario) {
+    $in{'scenario_function'} ||= $in{'pname'};    # Compat. <= 6.2.38
+
+    my $scenario = Sympa::Scenario->new($list, $in{'scenario_function'});
+    unless ($scenario) {
         Sympa::WWW::Report::reject_report_web('intern', 'cannot_open_file',
             {}, $param->{'action'}, $list);
         wwslog('info', 'Failed to load scenario');
         return undef;
     }
-    ($param->{'dumped_scenario'}, $param->{'scenario_path'}) =
-        ($scenario->{'data'}, $scenario->{'file_path'});
-    $param->{'pname'}         = $in{'pname'};
-    $param->{'scenario_name'} = $list->{'admin'}{$in{'pname'}}{'name'};
+    $param->{'dumped_scenario'}   = $scenario->to_string;
+    $param->{'scenario_path'}     = $scenario->{file_path};
+    $param->{'scenario_function'} = $scenario->{function};
+    $param->{'scenario_name'}     = $scenario->{name};
+
+    $param->{'pname'} = $scenario->{function};    # Compat. <= 6.2.38
 
     if ($in{'new_scenario_name'}) {
         # in this case it's a submit.
-        my $scenario_dir = $list->{'dir'} . '/scenari/';
+        my $scenario_dir = $list->{'dir'} . '/scenari';
         my $scenario_file =
-            $scenario_dir . $in{'pname'} . '.' . $in{'new_scenario_name'};
+              $scenario_dir . '/'
+            . $in{'scenario_function'} . '.'
+            . $in{'new_scenario_name'};
         if ($param->{'dumped_scenario'} eq $in{'new_scenario_content'}) {
             wwslog('info', 'Scenario unchanged');
             $param->{'result'} = 'unchanged';
             return 1;
         }
         unless (-d $scenario_dir) {
-            unless (mkdir($scenario_dir, 0777)) {
+            unless (mkdir $scenario_dir, 0775) {
                 wwslog('err', '%s: %s', $scenario_dir, $ERRNO);
                 Sympa::WWW::Report::reject_report_web(
                     'intern',
@@ -15929,7 +15929,8 @@ sub do_dump_scenario {
                 return undef;
             }
         }
-        unless (open SCENARIO, ">$scenario_file") {
+        my $ofh;
+        unless (open $ofh, '>', $scenario_file) {
             wwslog('info', '%s', $scenario_file);
             Sympa::WWW::Report::reject_report_web(
                 'intern',
@@ -15941,8 +15942,8 @@ sub do_dump_scenario {
             );
             return undef;
         }
-        print SCENARIO $in{'new_scenario_content'};
-        close SCENARIO;
+        print $ofh $in{'new_scenario_content'};
+        close $ofh;
         # load the new scenario in the list config.
         if ($in{'new_scenario_name'} eq $in{'scenario_name'}) {
             $param->{'result'} = 'success';
@@ -15960,9 +15961,7 @@ sub do_export_member {
         $in{'filter'});
 
     # Access control
-    unless (defined check_authz('do_export_member', 'review')) {
-        return undef;
-    }
+    return undef unless defined check_authz('do_export_member', 'review');
 
     my $format = $in{'format'} || 'full';
     my $filter = $in{'filter'};
@@ -16151,8 +16150,7 @@ sub do_arc_manage {
     wwslog('info', '(%s)', $in{'list'});
 
     # Access control
-    return undef
-        unless defined check_authz('do_arc', 'archive.web_access');
+    return undef unless defined check_authz('do_arc', 'archive_web_access');
 
     my $archive = Sympa::Archive->new(context => $list);
     $param->{'yyyymm'} = [reverse $archive->get_archives];
@@ -16166,9 +16164,7 @@ sub do_arc_download {
     wwslog('info', '(%s)', $in{'list'});
 
     ## Access control
-    unless (defined check_authz('do_arc', 'archive.web_access')) {
-        return undef;
-    }
+    return undef unless defined check_authz('do_arc', 'archive_web_access');
 
     ##zip file name:listname_archives.zip
     my $zip_file_name = $in{'list'} . '_archives.zip';
@@ -16379,8 +16375,7 @@ sub do_arc_delete {
     wwslog('info', '(%s)', $in{'list'});
 
     # Access control
-    return undef
-        unless defined check_authz('do_arc', 'archive.web_access');
+    return undef unless defined check_authz('do_arc', 'archive_web_access');
 
     my @directories = sort split /\0/, ($in{'directories'} || '');
     unless (@directories) {
@@ -16855,10 +16850,11 @@ sub _prepare_subscriber {
 ## used in common cases where actions fails unless result is 'do_it'
 ## It does not apply to actions that can be moderated
 sub check_authz {
-    my ($subname, $action) = @_;
+    my ($subname, $function) = @_;
 
     my $result = Sympa::Scenario::request_action(
-        $list, $action,
+        $list,
+        $function,
         $param->{'auth_method'},
         {   'sender'      => $param->{'user'}{'email'} || 'nobody',
             'remote_host' => $param->{'remote_host'},
@@ -16867,7 +16863,7 @@ sub check_authz {
     );
     my $r_action;
     my $reason;
-    if (ref($result) eq 'HASH') {
+    if (ref $result eq 'HASH') {
         $r_action = $result->{'action'};
         $reason   = $result->{'reason'};
     }
@@ -17331,17 +17327,8 @@ sub prevent_visibility_bypass {
     return undef;
 }
 
-sub purely_closed {
-    my $action   = shift;
-    my $scenario = Sympa::Scenario->new(
-        'robot'     => $robot,
-        'directory' => $list->{'dir'},
-        'file_path' => $list->{'admin'}{$action}{'file_path'},
-        'options'   => undef
-    );
-
-    return $scenario->is_purely_closed;
-}
+# No longer used.
+#sub purely_closed;
 
 # Old name: tools::add_in_blacklist().
 sub _add_in_blacklist {

--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -1890,23 +1890,6 @@ sub _infer_server_specific_parameter_values {
         $param->{'config_hash'}{'blacklist'}{$action} = 1;
     }
 
-    foreach my $log_module (
-        split(/,/, $param->{'config_hash'}{'log_module'} || '')) {
-        $param->{'config_hash'}{'loging_for_module'}{$log_module} = 1;
-    }
-
-    foreach my $log_condition (
-        split(/,/, $param->{'config_hash'}{'log_condition'} || '')) {
-        chomp $log_condition;
-        if ($log_condition =~ /^\s*(ip|email)\s*\=\s*(.*)\s*$/i) {
-            $param->{'config_hash'}{'loging_condition'}{$1} = $2;
-        } else {
-            $log->syslog('err',
-                'Unrecognized log_condition token %s; ignored',
-                $log_condition);
-        }
-    }
-
     if ($param->{'config_hash'}{'ldap_export_name'}) {
         $param->{'config_hash'}{'ldap_export'} = {
             $param->{'config_hash'}{'ldap_export_name'} => {

--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -1885,8 +1885,22 @@ sub _infer_server_specific_parameter_values {
         }
     }
 
-    foreach my $action (split(/,/, $param->{'config_hash'}{'use_blacklist'}))
+    foreach
+        my $action (split /\s*,\s*/, $param->{'config_hash'}{'use_blacklist'})
     {
+        next unless $action =~ /\A[.\w]+\z/;
+        # Compat. <= 6.2.38
+        $action = {
+            'shared_doc.d_read'   => 'd_read',
+            'shared_doc.d_edit'   => 'd_edit',
+            'archive.access'      => 'archive_mail_access',    # obsoleted
+            'web_archive.access'  => 'archive_web_access',     # obsoleted
+            'archive.web_access'  => 'archive_web_access',
+            'archive.mail_access' => 'archive_mail_access',
+            'tracking.tracking'   => 'tracking',
+        }->{$action}
+            || $action;
+
         $param->{'config_hash'}{'blacklist'}{$action} = 1;
     }
 
@@ -1965,7 +1979,20 @@ sub _infer_robot_parameter_values {
         . $param->{'config_hash'}{'domain'};
 
     # split action list for blacklist usage
-    foreach my $action (split(/,/, $Conf{'use_blacklist'})) {
+    foreach my $action (split /\s*,\s*/, $Conf{'use_blacklist'}) {
+        next unless $action =~ /\A[.\w]+\z/;
+        # Compat. <= 6.2.38
+        $action = {
+            'shared_doc.d_read'   => 'd_read',
+            'shared_doc.d_edit'   => 'd_edit',
+            'archive.access'      => 'archive_mail_access',    # obsoleted
+            'web_archive.access'  => 'archive_web_access',     # obsoleted
+            'archive.web_access'  => 'archive_web_access',
+            'archive.mail_access' => 'archive_mail_access',
+            'tracking.tracking'   => 'tracking',
+        }->{$action}
+            || $action;
+
         $param->{'config_hash'}{'blacklist'}{$action} = 1;
     }
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -56,7 +56,6 @@ use Sympa::Log;
 use Sympa::Process;
 use Sympa::Regexps;
 use Sympa::Robot;
-use Sympa::Scenario;
 use Sympa::Spindle::ProcessTemplate;
 use Sympa::Spool::Auth;
 use Sympa::Template;
@@ -4285,50 +4284,8 @@ sub is_included {
 # Moved to Sympa::Spindle::ProcessDigest::_may_distribute_digest().
 #sub may_distribute_digest;
 
-## Loads all scenari for an action
-sub load_scenario_list {
-    $log->syslog('debug3', '(%s, %s)', @_);
-    my $self     = shift;
-    my $function = shift;
-
-    my %list_of_scenario;
-    my %skip_scenario;
-    my @list_of_scenario_dir =
-        @{Sympa::get_search_path($self, subdir => 'scenari')};
-    unshift @list_of_scenario_dir, $self->{'dir'} . '/scenari';    #FIXME
-
-    foreach my $dir (@list_of_scenario_dir) {
-        next unless -d $dir;
-
-        my $scenario_regexp = Sympa::Regexps::scenario();
-
-        while (<$dir/$function.*:ignore>) {
-            if (/$function\.($scenario_regexp):ignore$/) {
-                my $name = $1;
-                $skip_scenario{$name} = 1;
-            }
-        }
-
-        while (<$dir/$function.*>) {
-            next unless /$function\.($scenario_regexp)$/;
-            my $name = $1;
-
-            # Ignore default setting on <= 6.2.40, using symbolic link.
-            next if $name eq 'default' and -l "$dir/$action.$name";
-
-            next if $list_of_scenario{$name};
-            next if $skip_scenario{$name};
-
-            my $scenario =
-                Sympa::Scenario->new($self, $function, name => $name);
-            $list_of_scenario{$name} = $scenario;
-        }
-    }
-
-    ## Return a copy of the data to prevent unwanted changes in the central
-    ## scenario data structure
-    return Sympa::Tools::Data::dup_var(\%list_of_scenario);
-}
+# Moved: Use Sympa::Scenario::get_scenarios().
+#sub load_scenario_list;
 
 # Deprecated: Use Sympa::Task::get_tasks().
 #sub load_task_list;

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -4231,6 +4231,7 @@ sub is_moderated {
 }
 
 ## Is the list archived?
+#FIXME: Broken. Use scenario or is_archiving_enabled().
 sub is_archived {
     $log->syslog('debug', '');
     if (shift->{'admin'}{'archive'}{'web_access'}) {
@@ -4242,6 +4243,7 @@ sub is_archived {
 }
 
 ## Is the list web archived?
+#FIXME: Broken. Use scenario or is_archiving_enabled().
 sub is_web_archived {
     my $self = shift;
     return 1

--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -420,8 +420,8 @@ sub check_spam_status {
         : $self->{context};
 
     my $spam_status =
-        Sympa::Scenario::request_action($robot_id || $Conf::Conf{'domain'},
-        'spam_status', 'smtp', {'message' => $self});
+        Sympa::Scenario->new($robot_id, 'spam_status')
+        ->authz('smtp', {'message' => $self});
     if (defined $spam_status) {
         if (ref($spam_status) eq 'HASH') {
             $self->{'spam_status'} = $spam_status->{'action'};

--- a/src/lib/Sympa/Request/Handler/get.pm
+++ b/src/lib/Sympa/Request/Handler/get.pm
@@ -38,7 +38,7 @@ use base qw(Sympa::Request::Handler);
 my $language = Sympa::Language->instance;
 my $log      = Sympa::Log->instance;
 
-use constant _action_scenario => 'archive.mail_access';
+use constant _action_scenario => 'archive_mail_access';
 use constant _action_regexp   => qr'reject|do_it'i;
 use constant _context_class   => 'Sympa::List';
 

--- a/src/lib/Sympa/Request/Handler/global_remind.pm
+++ b/src/lib/Sympa/Request/Handler/global_remind.pm
@@ -76,8 +76,8 @@ sub _twist {
         do {
             my $email = lc($user->{'email'});
             my $result =
-                Sympa::Scenario::request_action($list, 'visibility',
-                $auth_method, $self->{scenario_context});
+                Sympa::Scenario->new($list, 'visibility')
+                ->authz($auth_method, $self->{scenario_context});
             my $action;
             $action = $result->{'action'} if ref $result eq 'HASH';
 

--- a/src/lib/Sympa/Request/Handler/global_set.pm
+++ b/src/lib/Sympa/Request/Handler/global_set.pm
@@ -58,8 +58,8 @@ sub _twist {
         Sympa::List::get_which($sender, $request->{context}, 'member')) {
         # Skip hidden lists.
         my $result =
-            Sympa::Scenario::request_action($list, 'visibility', $auth_method,
-            $self->{scenario_context});
+            Sympa::Scenario->new($list, 'visibility')
+            ->authz($auth_method, $self->{scenario_context});
         my $action = $result->{'action'} if ref $result eq 'HASH';
 
         unless ($action) {

--- a/src/lib/Sympa/Request/Handler/global_signoff.pm
+++ b/src/lib/Sympa/Request/Handler/global_signoff.pm
@@ -58,8 +58,8 @@ sub _twist {
         Sympa::List::get_which($email, $request->{context}, 'member')) {
         # Skip hidden lists.
         my $result =
-            Sympa::Scenario::request_action($list, 'visibility', $auth_method,
-            $self->{scenario_context});
+            Sympa::Scenario->new($list, 'visibility')
+            ->authz($auth_method, $self->{scenario_context});
         my $action = $result->{'action'} if ref $result eq 'HASH';
 
         unless ($action) {

--- a/src/lib/Sympa/Request/Handler/index.pm
+++ b/src/lib/Sympa/Request/Handler/index.pm
@@ -38,7 +38,7 @@ use base qw(Sympa::Request::Handler);
 my $language = Sympa::Language->instance;
 my $log      = Sympa::Log->instance;
 
-use constant _action_scenario => 'archive.mail_access';
+use constant _action_scenario => 'archive_mail_access';
 use constant _action_regexp   => qr'reject|do_it'i;
 use constant _context_class   => 'Sympa::List';
 

--- a/src/lib/Sympa/Request/Handler/info.pm
+++ b/src/lib/Sympa/Request/Handler/info.pm
@@ -62,12 +62,8 @@ sub _twist {
 
     ## Set title in the current language
     foreach my $p ('subscribe', 'unsubscribe', 'send', 'review') {
-        my $scenario = Sympa::Scenario->new(
-            'robot'     => $robot,
-            'directory' => $list->{'dir'},
-            'file_path' => $list->{'admin'}{$p}{'file_path'}
-        );
-        $data->{$p} = $scenario->get_current_title();
+        my $scenario = Sympa::Scenario->new($list, $p);
+        $data->{$p} = $scenario->get_current_title;
     }
 
     ## Digest

--- a/src/lib/Sympa/Request/Handler/invite.pm
+++ b/src/lib/Sympa/Request/Handler/invite.pm
@@ -78,8 +78,8 @@ sub _twist {
     # Is the guest user allowed to subscribe in this list?
     # Emulating subscription privilege of target user.
     my $result =
-        Sympa::Scenario::request_action($list, 'subscribe', 'md5',
-        {sender => $email});
+        Sympa::Scenario->new($list, 'subscribe')
+        ->authz('md5', {sender => $email});
     my $action;
     $action = $result->{'action'} if ref $result eq 'HASH';
 

--- a/src/lib/Sympa/Request/Handler/last.pm
+++ b/src/lib/Sympa/Request/Handler/last.pm
@@ -38,7 +38,7 @@ use base qw(Sympa::Request::Handler);
 my $language = Sympa::Language->instance;
 my $log      = Sympa::Log->instance;
 
-use constant _action_scenario => 'archive.mail_access';
+use constant _action_scenario => 'archive_mail_access';
 use constant _action_regexp   => qr'reject|do_it'i;
 use constant _context_class   => 'Sympa::List';
 

--- a/src/lib/Sympa/Request/Handler/lists.pm
+++ b/src/lib/Sympa/Request/Handler/lists.pm
@@ -61,8 +61,8 @@ sub _twist {
 
     foreach my $list (@{Sympa::List::get_lists($robot) || []}) {
         my $result =
-            Sympa::Scenario::request_action($list, 'visibility', $auth_method,
-            $self->{scenario_context});
+            Sympa::Scenario->new($list, 'visibility')
+            ->authz($auth_method, $self->{scenario_context});
         my $action;
         $action = $result->{'action'} if ref $result eq 'HASH';
 

--- a/src/lib/Sympa/Request/Handler/which.pm
+++ b/src/lib/Sympa/Request/Handler/which.pm
@@ -61,8 +61,8 @@ sub _twist {
         $listname = $list->{'name'};
 
         my $result =
-            Sympa::Scenario::request_action($list, 'visibility', $auth_method,
-            $self->{scenario_context});
+            Sympa::Scenario->new($list, 'visibility')
+            ->authz($auth_method, $self->{scenario_context});
         my $action;
         $action = $result->{'action'} if ref $result eq 'HASH';
 

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -147,7 +147,12 @@ sub new {
     } else {
         $name = Conf::get_robot_conf($that, $ppath);
     }
-    unless (defined $name and $name =~ /\A[-\w]+\z/) {
+
+    unless (
+        defined $name
+        and (  $function eq 'include' and $name =~ m{\A[^/]+\z}
+            or $name =~ /\A[-\w]+\z/)
+    ) {
         $log->syslog('err', 'Unknown or undefined scenario function "%s"',
             $function);
         return undef;

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -483,7 +483,7 @@ sub request_action {
     my %param = (
         'function' => 'include',
         'robot'    => $robot_id,
-        'name'     => $operation . '.header',
+        'name'     => $scenario->{'function'} . '.header',
         'options'  => $context->{'options'}
     );
     $param{'directory'} = $list->{'dir'} if $list;

--- a/src/lib/Sympa/Spindle/AuthorizeMessage.pm
+++ b/src/lib/Sympa/Spindle/AuthorizeMessage.pm
@@ -98,8 +98,8 @@ sub _twist {
         : $message->{'dkim_pass'}    ? 'dkim'
         :                              'smtp';
 
-    $result = Sympa::Scenario::request_action($list, 'send', $auth_method,
-        $context);
+    $result =
+        Sympa::Scenario->new($list, 'send')->authz($auth_method, $context);
     $action = $result->{'action'} if (ref($result) eq 'HASH');
 
     unless (defined $action) {

--- a/src/lib/Sympa/Spindle/AuthorizeRequest.pm
+++ b/src/lib/Sympa/Spindle/AuthorizeRequest.pm
@@ -84,8 +84,8 @@ sub _twist {
         : $request->{dkim_pass}    ? 'dkim'
         :                            'smtp';
 
-    $result = Sympa::Scenario::request_action($that, $scenario, $auth_method,
-        $context);
+    $result =
+        Sympa::Scenario->new($that, $scenario)->authz($auth_method, $context);
     $action = $result->{'action'} if ref $result eq 'HASH';
 
     unless (defined $action and $action =~ /\A(?:$action_regexp)\b/) {

--- a/src/lib/Sympa/Spindle/ProcessBounce.pm
+++ b/src/lib/Sympa/Spindle/ProcessBounce.pm
@@ -410,8 +410,8 @@ sub _twist {
                 # opt-out-list are abandoned.
                 if ($feedback_type =~ /\babuse\b/) {
                     my $result =
-                        Sympa::Scenario::request_action($list, 'unsubscribe',
-                        'smtp', {'sender' => $original_rcpt});
+                        Sympa::Scenario->new($list, 'unsubscribe')
+                        ->authz('smtp', {'sender' => $original_rcpt});
                     my $action = $result->{'action'}
                         if ref $result eq 'HASH';
                     if ($action and $action =~ /do_it/i) {
@@ -491,8 +491,8 @@ sub _twist {
         $log->syslog('debug',
             "VERP for a service message, try to remove the subscriber");
 
-        my $result = Sympa::Scenario::request_action(
-            $list, 'del', 'smtp',
+        my $result = Sympa::Scenario->new($list, 'del')->authz(
+            'smtp',
             {   'sender' => $Conf::Conf{'listmaster'},    #FIXME
                 'email'  => $who
             }

--- a/src/lib/Sympa/Spindle/ProcessTask.pm
+++ b/src/lib/Sympa/Spindle/ProcessTask.pm
@@ -329,8 +329,8 @@ sub do_delete_subs {
 
     foreach my $email (keys %{$Rvars->{$var}}) {
         $log->syslog('notice', '%s', $email);
-        my $result = Sympa::Scenario::request_action(
-            $list, 'del', 'smime',
+        my $result = Sympa::Scenario->new($list, 'del')->authz(
+            'smime',
             {   'sender' => $Conf::Conf{'listmaster'},    #FIXME
                 'email'  => $email,
             }

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -46,7 +46,6 @@ use Sympa::LockedFile;
 use Sympa::Log;
 use Sympa::Message;
 use Sympa::Request;
-use Sympa::Scenario;
 use Sympa::Spool;
 use Sympa::Spool::Archive;
 use Sympa::Spool::Auth;
@@ -1290,19 +1289,9 @@ sub upgrade {
                 unless ref $list->{'admin'}{'archive'} eq 'HASH';
 
             if ($list->{'admin'}{'archive'}{'access'}) {
-                my $scenario = Sympa::Scenario->new(
-                    'function'  => 'archive_mail_access',
-                    'robot'     => $list->{domain},
-                    'name'      => $list->{'admin'}{'archive'}{'access'},
-                    'directory' => $list->{dir}
-                );
-                $list->{'admin'}{'archive'}{'mail_access'} = {
-                    'file_path' => $scenario->{'file_path'},
-                    'name'      => $scenario->{'name'}
-                };
-
+                $list->{'admin'}{'archive'}{'mail_access'} =
+                    {'name' => $list->{'admin'}{'archive'}{'access'}};
             }
-
             delete $list->{'admin'}{'archive'}{'access'};
 
             if (ref $list->{'admin'}{'web_archive'} eq 'HASH'

--- a/src/lib/Sympa/WWW/SOAP.pm
+++ b/src/lib/Sympa/WWW/SOAP.pm
@@ -104,9 +104,7 @@ sub lists {
         my $listname = $list->{'name'};
 
         my $result_item = {};
-        my $result      = Sympa::Scenario::request_action(
-            $list,
-            'visibility',
+        my $result = Sympa::Scenario->new($list, 'visibility')->authz(
             'md5',
             {   'sender'                  => $sender,
                 'remote_application_name' => $ENV{'remote_application_name'}
@@ -501,8 +499,8 @@ sub info {
             ->faultdetail("List $listname unknown");
     }
 
-    my $result = Sympa::Scenario::request_action(
-        $list, 'info', 'md5',
+    my $result = Sympa::Scenario->new($list, 'info')->authz(
+        'md5',
         {   'sender'                  => $sender,
             'remote_application_name' => $ENV{'remote_application_name'}
         }
@@ -956,8 +954,8 @@ sub review {
     # Part of the authorization code
     $user = Sympa::User::get_global_user($sender);
 
-    my $result = Sympa::Scenario::request_action(
-        $list, 'review', 'md5',
+    my $result = Sympa::Scenario->new($list, 'review')->authz(
+        'md5',
         {   'sender'                  => $sender,
             'remote_application_name' => $ENV{'remote_application_name'}
         }
@@ -1284,9 +1282,7 @@ sub which {
 
         my $result_item;
 
-        my $result = Sympa::Scenario::request_action(
-            $list,
-            'visibility',
+        my $result = Sympa::Scenario->new($list, 'visibility')->authz(
             'md5',
             {   'sender'                  => $sender,
                 'remote_application_name' => $ENV{'remote_application_name'}

--- a/src/lib/Sympa/WWW/SharedDocument.pm
+++ b/src/lib/Sympa/WWW/SharedDocument.pm
@@ -634,8 +634,7 @@ sub get_privileges {
 
     # if not privileged owner
     if ($mode_read) {
-        my $result =
-            Sympa::Scenario::request_action($list, 'shared_doc.d_read',
+        my $result = Sympa::Scenario::request_action($list, 'd_read',
             $auth_method, $scenario_context);
         my $action;
         if (ref($result) eq 'HASH') {
@@ -647,8 +646,7 @@ sub get_privileges {
     }
 
     if ($mode_edit) {
-        my $result =
-            Sympa::Scenario::request_action($list, 'shared_doc.d_edit',
+        my $result = Sympa::Scenario::request_action($list, 'd_edit',
             $auth_method, $scenario_context);
         my $action;
         if (ref($result) eq 'HASH') {
@@ -679,14 +677,10 @@ sub get_privileges {
     while ($current and @{$current->{paths}}) {
         if ($current->{scenario}) {
             if ($mode_read) {
-                my $result = Sympa::Scenario::request_action(
-                    $list,
-                    'shared_doc.d_read',
-                    $auth_method,
-                    {   %$scenario_context,
-                        scenario => $current->{scenario}{read}
-                    }
-                );
+                my $result =
+                    Sympa::Scenario::request_action($list, 'd_read',
+                    $auth_method, $scenario_context,
+                    name => $current->{scenario}{read});
                 my $action;
                 if (ref($result) eq 'HASH') {
                     $action       = $result->{'action'};
@@ -698,14 +692,10 @@ sub get_privileges {
             }
 
             if ($mode_edit) {
-                my $result = Sympa::Scenario::request_action(
-                    $list,
-                    'shared_doc.d_edit',
-                    $auth_method,
-                    {   %$scenario_context,
-                        scenario => $current->{scenario}{edit}
-                    }
-                );
+                my $result =
+                    Sympa::Scenario::request_action($list, 'd_edit',
+                    $auth_method, $scenario_context,
+                    name => $current->{scenario}{edit});
                 my $action_edit;
                 if (ref($result) eq 'HASH') {
                     $action_edit  = $result->{'action'};

--- a/src/lib/Sympa/WWW/SharedDocument.pm
+++ b/src/lib/Sympa/WWW/SharedDocument.pm
@@ -634,8 +634,8 @@ sub get_privileges {
 
     # if not privileged owner
     if ($mode_read) {
-        my $result = Sympa::Scenario::request_action($list, 'd_read',
-            $auth_method, $scenario_context);
+        my $result = Sympa::Scenario->new($list, 'd_read')
+            ->authz($auth_method, $scenario_context);
         my $action;
         if (ref($result) eq 'HASH') {
             $action       = $result->{'action'};
@@ -646,8 +646,8 @@ sub get_privileges {
     }
 
     if ($mode_edit) {
-        my $result = Sympa::Scenario::request_action($list, 'd_edit',
-            $auth_method, $scenario_context);
+        my $result = Sympa::Scenario->new($list, 'd_edit')
+            ->authz($auth_method, $scenario_context);
         my $action;
         if (ref($result) eq 'HASH') {
             $action       = $result->{'action'};
@@ -678,9 +678,9 @@ sub get_privileges {
         if ($current->{scenario}) {
             if ($mode_read) {
                 my $result =
-                    Sympa::Scenario::request_action($list, 'd_read',
-                    $auth_method, $scenario_context,
-                    name => $current->{scenario}{read});
+                    Sympa::Scenario->new($list, 'd_read',
+                    name => $current->{scenario}{read})
+                    ->authz($auth_method, $scenario_context);
                 my $action;
                 if (ref($result) eq 'HASH') {
                     $action       = $result->{'action'};
@@ -693,9 +693,9 @@ sub get_privileges {
 
             if ($mode_edit) {
                 my $result =
-                    Sympa::Scenario::request_action($list, 'd_edit',
-                    $auth_method, $scenario_context,
-                    name => $current->{scenario}{edit});
+                    Sympa::Scenario->new($list, 'd_edit',
+                    name => $current->{scenario}{edit})
+                    ->authz($auth_method, $scenario_context);
                 my $action_edit;
                 if (ref($result) eq 'HASH') {
                     $action_edit  = $result->{'action'};


### PR DESCRIPTION
Fixed bug:
  * Confusion between list parameter names and scenario function names. For example:
      - If a compound parameter (e.g. `shared_doc.d_read`) is given, corresponding scenario (`d_read.xxx`) mistakenly tries to include header file with parameter name (`include.shared_doc.d_read.header`) instead of that with scenario function name (`include.d_read.header`).  Fixed by assigning correct identifier.
      - `dump_scenario page` of wwsympa  doesn't work with scenarios corresponding to compound parameters (shared documents, archives, tracking).

    This may fix #520.

Changes in code:
  * Sympa::Scenario::request_action() function was replaced with Sympa::Scenario::authz() method.

Changes in behavior:
  * `log_module` and `log_condition` parameters were deprecated.  They were not so useful.  Instead, `debug3` log level will be used for debug logs about scenarios.
