### PR TITLE
WWSympa: TLS client authentication: Get email from certificate according to S/MIME

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1282,48 +1282,32 @@ while ($query = CGI::Fast->new) {
 
     ## RSS does not require user authentication
     unless ($rss) {
-        if (    $ENV{'SSL_CLIENT_VERIFY'} eq 'SUCCESS'
+        if (    $Crypt::OpenSSL::X509::VERSION
+            and $ENV{SSL_CLIENT_VERIFY}
+            and $ENV{SSL_CLIENT_VERIFY} eq 'SUCCESS'
             and $in{'action'} ne 'sso_login') {
-            # Do not check client certificate automatically if in sso_login
+            # Get rfc822Name in X.509v3 subjectAltName, otherwise
+            # emailAddress attribute in subject DN (the first one of either).
+            # Note: Earlier efforts getting attribute such as MAIL, Email in
+            # subject DN are no longer supported.
+            my $x509 = eval {
+                Crypt::OpenSSL::X509->new_from_string($ENV{SSL_CLIENT_CERT});
+            };
+            my $email = Sympa::Tools::Text::canonic_email($x509->email)
+                if $x509 and Sympa::Tools::Text::valid_email($x509->email);
 
-            $log->syslog(
-                'debug2',
-                'SSL verified, S_EMAIL = %s, " . " S_DN_Email = %s',
-                $ENV{'SSL_CLIENT_S_EMAIL'},
-                $ENV{'SSL_CLIENT_S_DN_Email'}
-            );
-            if (($ENV{'SSL_CLIENT_S_EMAIL'})) {
-                # this is the X509v3 SubjectAlternativeName, and requires
-                # a patch to mod_ssl -- cm@coretec.at
-                $param->{'user'}{'email'} = lc($ENV{'SSL_CLIENT_S_EMAIL'});
-            } elsif ($ENV{SSL_CLIENT_S_DN_Email}) {
-                $param->{'user'}{'email'} = lc($ENV{'SSL_CLIENT_S_DN_Email'});
-            } elsif ($ENV{'SSL_CLIENT_S_DN'} =~ /\+MAIL=([^\+\/]+)$/) {
-                ## Compatibility issue with old a-sign.at certs
-                $param->{'user'}{'email'} = lc($1);
-            } elsif ($Crypt::OpenSSL::X509::VERSION
-                and exists($ENV{SSL_CLIENT_CERT})) {
-                # this is the X509v3 SubjectAlternativeName, and does only
-                # require "SSLOptions +ExportCertData" without patching
-                # mod_ssl -- massar@unix-ag.uni-kl.de
-                $param->{'user'}{'email'} = lc(
-                    Crypt::OpenSSL::X509->new_from_string(
-                        $ENV{SSL_CLIENT_CERT}
-                    )->email()
-                );
-            }
-
-            if ($param->{user}{email}) {
-                $session->{'email'}          = $param->{user}{email};
+            if ($email) {
+                $param->{'user'}{'email'}    = $email;
+                $session->{'email'}          = $email;
                 $param->{'auth_method'}      = 'smime';
                 $session->{'auth'}           = 'x509';
-                $param->{'ssl_client_s_dn'}  = $ENV{'SSL_CLIENT_S_DN'};
-                $param->{'ssl_client_v_end'} = $ENV{'SSL_CLIENT_V_END'};
-                $param->{'ssl_client_i_dn'}  = $ENV{'SSL_CLIENT_I_DN'};
+                $param->{'ssl_client_s_dn'}  = $x509->subject;
+                $param->{'ssl_client_v_end'} = $x509->notAfter;
+                $param->{'ssl_client_i_dn'}  = $x509->issuer;
+                # Only with Apache+mod_ssl or lighttpd+mod_openssl.
                 $param->{'ssl_cipher_usekeysize'} =
-                    $ENV{'SSL_CIPHER_USEKEYSIZE'};
+                    $ENV{SSL_CIPHER_USEKEYSIZE};
             }
-
         } elsif (($session->{'email'}) && ($session->{'email'} ne 'nobody')) {
             $param->{'user'}{'email'} = $session->{'email'};
         } elsif ($in{'ticket'} =~ /(S|P)T\-/) {


### PR DESCRIPTION
Now it gets `rfc822Name` in X.509v3 `subjectAltName`, otherwise `emailAddress` attribute in subject DN (the first one of either), accroding to S/MIME (See [RFC 5750](https://tools.ietf.org/html/rfc5750), 3 and 4.4.3).

Note that earlier efforts getting attribute such as `MAIL`, `Email` in subject DN are no longer supported.
