### PR TITLE
Upgrade: A typo breaks configuration (#578)

### DIFF
--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -1954,7 +1954,7 @@ sub upgrade {
                 open $ofh, '>>', $dir . '/robot.conf' or next;
             }
             print $ofh "\n\n";
-            print $ofh
+            printf $ofh
                 "# Following parameters were added during upgrade to %s\n\n",
                 $new_version;
             foreach my $scenario (@scenarios) {


### PR DESCRIPTION
This will fix #578.
