### PR TITLE
Sympa::Scenario::new() was unable to load scenario filename including dots

### DIFF
--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -151,10 +151,10 @@ sub new {
     unless (
         defined $name
         and (  $function eq 'include' and $name =~ m{\A[^/]+\z}
-            or $name =~ /\A[-\w]+\z/)
+            or $name =~ /\A[-\w\.]+\z/)
     ) {
-        $log->syslog('err', 'Unknown or undefined scenario function "%s"',
-            $function);
+        $log->syslog('err', 'Unknown or undefined scenario function "%s", scenario name "%s"',
+            $function, $name);
         return undef;
     }
 
@@ -1617,6 +1617,8 @@ sub get_scenarios {
             my $scenario =
                 Sympa::Scenario->new($that, $function, name => $name);
             $seen{$name} = 1;
+			next unless (defined $scenario);
+
             push @scenarios, $scenario;
         }
     }


### PR DESCRIPTION
We are upgrading from Sympa 6.2.36 to 6.2.42.
After upgrading our test staging instance of Sympa we encountered an error while editing the liste config through the web interface: 
```
DIED: Can't call method "get_current_title" on unblessed reference at /usr/local/sympa/bin/wwsympa.fcgi line 10847.
 at /usr/local/sympa/bin/wwsympa.fcgi line 10847.
	main::_do_edit_list_request(Sympa::List::Config <test-sympa-2-2-42@listes.univ-rennes1.fr>, HASH(0x59b0758), ARRAY(0x5bbf7e0)) called at /usr/local/sympa/bin/wwsympa.fcgi line 10771
	main::do_edit_list_request() called at /usr/local/sympa/bin/wwsympa.fcgi line 1558
```
The log says:
```
Apr  8 10:35:40 vmperl-tsympa1 wwsympa[10736]: info main::do_edit_list_request(description) [robot listes.univ-rennes1.fr] [session 50683453466904] [client 129.20.126.26] [user odile.germes@univ-rennes1.fr] [list test-sympa-2-2-42]
Apr  8 10:35:40 vmperl-tsympa1 wwsympa[10736]: err main::#1558 > main::do_edit_list_request#10771 > main::_do_edit_list_request#10842 > Sympa::Scenario::get_scenarios#1617 > Sympa::Scenario::new#156 Unknown or undefined scenario function "visibility"
Apr  8 10:35:40 vmperl-tsympa1 wwsympa[10736]: err main::#1558 > main::do_edit_list_request#10771 > main::_do_edit_list_request#10842 > Sympa::Scenario::get_scenarios#1617 > Sympa::Scenario::new#156 Unknown or undefined scenario function "visibility"
Apr  8 10:35:40 vmperl-tsympa1 wwsympa[10736]: err main::#1558 > main::do_edit_list_request#10771 > main::_do_edit_list_request#10847 DIED: Can't call method "get_current_title" on unblessed reference at /usr/local/sympa/bin/wwsympa.fcgi line 10847.
```

Here is what happens:
1. `Sympa::Scenario->new()` fails to load a scenario named `visibility.igr.univ-rennes1.fr` because only `/\A[-\w]+\z/` if allowed for the scenario name,
2. `Sympa::Scenario::get_scenarios()` returns an array with some undefined values,
3. `wwsympa::_do_edit_list_request()` fails to interpret `$_->get_current_title` because `$_` is undefined.  

The bug was introduced in https://github.com/sympa-community/sympa/commit/c8aca8379294c9bfce724e4f73a7c984d6f085c0

The pull request fixes (1): 
1. allowing dots in scenario names,
2. providing more details in the error log,
3. preventing undefined entries to be returned by `Sympa::Scenario->new()`.

It would also make sense to:
1.  consolidate `wwsympa::_do_edit_list_request()` in case `Sympa::Scenario::get_scenarios()` returns undefined values.
2. add parenthesis to this condition https://github.com/sympa-community/sympa/blob/sympa-6.2/src/lib/Sympa/Scenario.pm#L153