### PR TITLE
Add sympa.conf-dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Makefile
 /po/sympa/POTFILES
 /po/web_help/POTFILES
 /sympa.conf
+/sympa.conf-dist
 
 # make
 
@@ -30,6 +31,7 @@ Makefile
 *.o
 *.po~
 /previous_sympa_version
+/mk-sympa-dist.pl
 /src/bin/*.pl
 /src/cgi/*.fcgi
 /src/libexec/*.pl

--- a/Makefile.am
+++ b/Makefile.am
@@ -139,9 +139,9 @@ installconfig: installdir
 	fi
 	@echo "Installing configuration template ..." \
 	echo "installing sympa.conf-dist"; \
-	$(INSTALL) -m 644 -T sympa.conf-dist $(DESTDIR)$(sysconfdir)/sympa.conf-dist; \
-	chown $(USER) $(DESTDIR)$(sysconfdir)/sympa.conf-dist; \
-	chgrp $(GROUP) $(DESTDIR)$(sysconfdir)/sympa.conf-dist;
+	$(INSTALL) -m 644 -T sympa.conf-dist $(DESTDIR)$(confdir)/sympa.conf-dist; \
+	chown $(USER) $(DESTDIR)$(confdir)/sympa.conf-dist; \
+	chgrp $(GROUP) $(DESTDIR)$(confdir)/sympa.conf-dist;
 	-@if [ ! -f $(DESTDIR)$(sysconfdir)/data_structure.version ]; then \
 		cd $(DESTDIR)$(sysconfdir); \
 		echo "# automatically created file" >> data_structure.version; \
@@ -185,7 +185,7 @@ nextstep:
 	@echo "#"
 	@echo "# ADDITIONAL SETTINGS:"
 	@echo "#    * You will find all available configuration settings in:"
-	@echo "#        $(sysconfdir)/sympa.conf-dist"
+	@echo "#        $(confdir)/sympa.conf-dist"
 	@echo "#"
 	@echo "#    * Copy the configuration settings you want in:"
 	@echo "#        $(confdir)/sympa.conf"
@@ -215,13 +215,6 @@ tidyall:
 
 all-local: sympa.conf-dist
 
-sympa.conf-dist: mk-sympa-dist.pl
-	@./mk-sympa-dist.pl
+sympa.conf-dist:
+	@$(PERL) mk-sympa-dist.pl
 
-mk-sympa-dist.pl:
-	@rm -f $@
-	$(AM_V_GEN)$(SED) \
-		-e 's|--PERL--|$(PERL)|' \
-		-e 's|--srcdir--|$(srcdir)|' \
-		< $(srcdir)/$@.in > $@
-	@chmod +x $@

--- a/Makefile.am
+++ b/Makefile.am
@@ -137,6 +137,11 @@ installconfig: installdir
 		chown $(USER) $(DESTDIR)$(confdir)/sympa.conf; \
 		chgrp $(GROUP) $(DESTDIR)$(confdir)/sympa.conf; \
 	fi
+	@echo "Installing configuration template ..." \
+	echo "installing sympa.conf-dist"; \
+	$(INSTALL) -m 644 -T sympa.conf-dist $(DESTDIR)$(sysconfdir)/sympa.conf-dist; \
+	chown $(USER) $(DESTDIR)$(sysconfdir)/sympa.conf-dist; \
+	chgrp $(GROUP) $(DESTDIR)$(sysconfdir)/sympa.conf-dist;
 	-@if [ ! -f $(DESTDIR)$(sysconfdir)/data_structure.version ]; then \
 		cd $(DESTDIR)$(sysconfdir); \
 		echo "# automatically created file" >> data_structure.version; \
@@ -178,6 +183,13 @@ nextstep:
 	@echo "#    * Edit this file to define initial configuration:"
 	@echo "#        $(confdir)/sympa.conf"
 	@echo "#"
+	@echo "# ADDITIONAL SETTINGS:"
+	@echo "#    * You will find all available configuration settings in:"
+	@echo "#        $(sysconfdir)/sympa.conf-dist"
+	@echo "#"
+	@echo "#    * Copy the configuration settings you want in:"
+	@echo "#        $(confdir)/sympa.conf"
+	@echo "#"
 	@echo "# UPGRADING"
 	@echo "#    * Run this script to upgrade your data structures:"
 	@echo "#        $(sbindir)/sympa.pl --upgrade"
@@ -200,3 +212,16 @@ distcheck-hook:
 
 tidyall:
 	tidyall --conf-file doc/dot.tidyallrc --root-dir . -r src t xt
+
+all-local: sympa.conf-dist
+
+sympa.conf-dist: mk-sympa-dist.pl
+	@./mk-sympa-dist.pl
+
+mk-sympa-dist.pl:
+	@rm -f $@
+	$(AM_V_GEN)$(SED) \
+		-e 's|--PERL--|$(PERL)|' \
+		-e 's|--srcdir--|$(srcdir)|' \
+		< $(srcdir)/$@.in > $@
+	@chmod +x $@

--- a/configure.ac
+++ b/configure.ac
@@ -610,6 +610,7 @@ AC_SUBST(POSTMAP_ARG)
 AC_CONFIG_FILES([
     Makefile
     sympa.conf
+    mk-sympa-dist.pl
     default/Makefile
     doc/Makefile
     po/Makefile

--- a/mk-sympa-dist.pl.in
+++ b/mk-sympa-dist.pl.in
@@ -1,0 +1,134 @@
+#!--PERL--
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+# $Id$
+
+# Sympa - SYsteme de Multi-Postage Automatique
+#
+# Copyright (c) 1997, 1998, 1999 Institut Pasteur & Christophe Wolfhugel
+# Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
+# 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
+# Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
+# Copyright 2018 The Sympa Community. See the AUTHORS.md file at the
+# top-level directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use lib '--srcdir--/src/lib/';
+use strict;
+use warnings;
+use English qw(-no_match_vars);
+use Pod::Usage;
+
+use Sympa::ConfDef;
+use Sympa::Constants;
+
+my $modfail;      # any of required modules are not installed.
+
+BEGIN {
+    $modfail = !eval {
+        require Conf;
+        require Sympa::Language;
+        require Sympa::Tools::Text;
+    };
+}
+
+# Set language context if possible.
+if ($modfail) {
+    no warnings;
+
+    *gettext = sub { $_[1] ? sprintf('%*s', $_[1], $_[0]) : $_[0] };
+
+    eval { require Text::Wrap; };
+    if ($EVAL_ERROR) {
+        *Sympa::Tools::Text::wrap_text = sub {"$_[1]$_[0]\n"};
+    } else {
+        $Text::Wrap::columns = 78;
+        *Sympa::Tools::Text::wrap_text =
+            sub { Text::Wrap::wrap($_[1], $_[2], $_[0]) . "\n"; };
+    }
+} else {
+    no warnings;
+
+    my $language = Sympa::Language->instance;
+    *gettext = sub {
+        $_[1]
+            ? Sympa::Tools::Text::pad($language->gettext($_[0]), $_[1])
+            : $language->gettext($_[0]);
+    };
+
+    my $lang = $ENV{'LANGUAGE'} || $ENV{'LC_ALL'} || $ENV{'LANG'};
+    $lang =~ s/\..*// if $lang;
+    $language->set_lang($lang, 'en-US', 'en');
+}
+
+## sympa dist configuration file
+my $dist_conf = 'sympa.conf-dist';
+
+my $umask = umask 037;
+unless (open NEWF, '>', $dist_conf) {
+    umask $umask;
+    die "$0: "
+        . sprintf(gettext("Unable to open %s : %s"), $dist_conf, $ERRNO)
+        . "\n";
+}
+umask $umask;
+
+my $title;
+foreach my $param (@Sympa::ConfDef::params) {
+    unless ($param->{'name'}) {
+        $title = gettext($param->{'gettext_id'})
+            if $param->{'gettext_id'};
+        next;
+    }
+
+    next unless $param->{'file'};
+
+    if ($title) {
+        printf NEWF "###\\\\\\\\ %s ////###\n\n", $title;
+        undef $title;
+    }
+
+    printf NEWF "## %s\n", $param->{'name'};
+
+    if ($param->{'gettext_id'}) {
+        print NEWF Sympa::Tools::Text::wrap_text(
+            gettext($param->{'gettext_id'}),
+            '## ', '## ');
+    }
+
+    print NEWF Sympa::Tools::Text::wrap_text(
+        gettext($param->{'gettext_comment'}),
+        '## ', '## ')
+        if $param->{'gettext_comment'};
+
+    if (defined $param->{'sample'}) {
+        printf NEWF '## ' . gettext('Example: ') . "%s\t%s\n",
+            $param->{'name'}, $param->{'sample'};
+    }
+
+    if (defined $param->{'default'}) {
+        printf NEWF "#%s\t%s\n", $param->{'name'}, $param->{'default'};
+    } elsif ($param->{'optional'}) {
+        printf NEWF "#%s\t\n", $param->{'name'};
+    } else {
+        printf NEWF "#%s\t%s\n", $param->{'name'},
+            gettext("(You must define this parameter)");
+    }
+    print NEWF "\n";
+}
+
+close NEWF;
+print STDERR "$dist_conf file has been created\n";

--- a/mk-sympa-dist.pl.in
+++ b/mk-sympa-dist.pl.in
@@ -1,15 +1,10 @@
-#!--PERL--
 # -*- indent-tabs-mode: nil; -*-
 # vim:ft=perl:et:sw=4
 # $Id$
 
 # Sympa - SYsteme de Multi-Postage Automatique
 #
-# Copyright (c) 1997, 1998, 1999 Institut Pasteur & Christophe Wolfhugel
-# Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
-# 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
-# Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2018 The Sympa Community. See the AUTHORS.md file at the
+# Copyright 2019 The Sympa Community. See the AUTHORS.md file at the
 # top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
@@ -26,7 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use lib '--srcdir--/src/lib/';
+use lib 'src/lib/';
 use strict;
 use warnings;
 use English qw(-no_match_vars);
@@ -78,7 +73,8 @@ if ($modfail) {
 my $dist_conf = 'sympa.conf-dist';
 
 my $umask = umask 037;
-unless (open NEWF, '>', $dist_conf) {
+my $fh;
+unless (open $fh, '>', $dist_conf) {
     umask $umask;
     die "$0: "
         . sprintf(gettext("Unable to open %s : %s"), $dist_conf, $ERRNO)
@@ -97,38 +93,38 @@ foreach my $param (@Sympa::ConfDef::params) {
     next unless $param->{'file'};
 
     if ($title) {
-        printf NEWF "###\\\\\\\\ %s ////###\n\n", $title;
+        printf $fh "###\\\\\\\\ %s ////###\n\n", $title;
         undef $title;
     }
 
-    printf NEWF "## %s\n", $param->{'name'};
+    printf $fh "## %s\n", $param->{'name'};
 
     if ($param->{'gettext_id'}) {
-        print NEWF Sympa::Tools::Text::wrap_text(
+        print $fh Sympa::Tools::Text::wrap_text(
             gettext($param->{'gettext_id'}),
             '## ', '## ');
     }
 
-    print NEWF Sympa::Tools::Text::wrap_text(
+    print $fh Sympa::Tools::Text::wrap_text(
         gettext($param->{'gettext_comment'}),
         '## ', '## ')
         if $param->{'gettext_comment'};
 
     if (defined $param->{'sample'}) {
-        printf NEWF '## ' . gettext('Example: ') . "%s\t%s\n",
+        printf $fh '## ' . gettext('Example: ') . "%s\t%s\n",
             $param->{'name'}, $param->{'sample'};
     }
 
     if (defined $param->{'default'}) {
-        printf NEWF "#%s\t%s\n", $param->{'name'}, $param->{'default'};
+        printf $fh "#%s\t%s\n", $param->{'name'}, $param->{'default'};
     } elsif ($param->{'optional'}) {
-        printf NEWF "#%s\t\n", $param->{'name'};
+        printf $fh "#%s\t\n", $param->{'name'};
     } else {
-        printf NEWF "#%s\t%s\n", $param->{'name'},
+        printf $fh "#%s\t%s\n", $param->{'name'},
             gettext("(You must define this parameter)");
     }
-    print NEWF "\n";
+    print $fh "\n";
 }
 
-close NEWF;
+close $fh;
 print STDERR "$dist_conf file has been created\n";

--- a/mk-sympa-dist.pl.in
+++ b/mk-sympa-dist.pl.in
@@ -35,16 +35,15 @@ my $modfail;      # any of required modules are not installed.
 BEGIN {
     $modfail = !eval {
         require Conf;
-        require Sympa::Language;
         require Sympa::Tools::Text;
     };
 }
 
 # Set language context if possible.
+*gettext = sub { $_[1] ? sprintf('%*s', $_[1], $_[0]) : $_[0] };
 if ($modfail) {
     no warnings;
 
-    *gettext = sub { $_[1] ? sprintf('%*s', $_[1], $_[0]) : $_[0] };
 
     eval { require Text::Wrap; };
     if ($EVAL_ERROR) {
@@ -54,19 +53,6 @@ if ($modfail) {
         *Sympa::Tools::Text::wrap_text =
             sub { Text::Wrap::wrap($_[1], $_[2], $_[0]) . "\n"; };
     }
-} else {
-    no warnings;
-
-    my $language = Sympa::Language->instance;
-    *gettext = sub {
-        $_[1]
-            ? Sympa::Tools::Text::pad($language->gettext($_[0]), $_[1])
-            : $language->gettext($_[0]);
-    };
-
-    my $lang = $ENV{'LANGUAGE'} || $ENV{'LC_ALL'} || $ENV{'LANG'};
-    $lang =~ s/\..*// if $lang;
-    $language->set_lang($lang, 'en-US', 'en');
 }
 
 ## sympa dist configuration file


### PR DESCRIPTION
- `sympa.conf-dist` always contains all available configuration settings, letting admins copy those they want in `sympa.conf`;
- it’s generated at `make`, getting the settings from `Sympa::ConfDef` module;
- it’s installed in `$sysconfdir` at `make install`.