### PR TITLE
Fix #27 — Missing admin function to bulk unsubscribe

### DIFF
--- a/default/web_tt2/confirm_action.tt2
+++ b/default/web_tt2/confirm_action.tt2
@@ -119,6 +119,22 @@
             [%|loc%]Do you really want to unsubscribe ALL selected subscribers?[%END%]
         </strong>
     </p>
+[%~ ELSIF confirm_action == 'mass_del' ~%]
+    <h2>
+        <i class="fa fa-check-circle"></i>
+        [%|loc%]Delete email address from selected lists[%END%]
+    </h2>
+    <p>
+        <strong>
+            [% SET target = "&lt;${email}&gt;" ~%]
+            [%|loc(target)%]Do you really want to unsubscribe %1 from the following lists?[%END%]
+        </strong>
+    </p>
+    <ul>
+        [%~ FOREACH list = lists %]
+            <li>[% list %]</li>
+        [%~ END %]
+    </ul>
 [%~ ELSIF confirm_action == 'delete_account' ~%]
     <h2>
         <i class="fa fa-check-circle"></i>
@@ -391,6 +407,16 @@
         [% FOREACH e = email ~%]
             <input type="hidden" name="email" value="[% e %]" />
         [%~ END %]
+        <div>
+            <input type="checkbox" id="quiet" name="quiet" value="1"
+                   [% IF quiet %]checked="checked"[%END%] />
+            <label for="quiet">[%|loc%]Quiet (don't send deletion email)[%END%]</label>
+        </div>
+    [%~ ELSIF confirm_action == 'mass_del' ~%]
+        [% FOREACH list = lists ~%]
+            <input type="hidden" name="lists" value="[% list %]" />
+        [%~ END %]
+        <input type="hidden" name="email" value="[% email %]" />
         <div>
             <input type="checkbox" id="quiet" name="quiet" value="1"
                    [% IF quiet %]checked="checked"[%END%] />

--- a/default/web_tt2/confirm_action.tt2
+++ b/default/web_tt2/confirm_action.tt2
@@ -118,6 +118,11 @@
         <strong>
             [%|loc%]Do you really want to unsubscribe ALL selected subscribers?[%END%]
         </strong>
+        <ul>
+            [% FOREACH e = email ~%]
+                <li>[% e %]</li>
+            [%~ END %]
+        </ul>
     </p>
 [%~ ELSIF confirm_action == 'mass_del' ~%]
     <h2>

--- a/default/web_tt2/search_user.tt2
+++ b/default/web_tt2/search_user.tt2
@@ -3,9 +3,15 @@
     <h2><i class="fa fa-search"></i> [%|loc%]User search result:[%END%]</h2>
     <br />
     [% IF which %]
-        <table  class="responsive listOfItems">
+        <table  class="responsive listOfItems toggleContainer" data-toggle-selector="input[name='lists']">
             <caption>[%|loc(email)%]Lists which %1 is subscribed [%END%]</caption>
             <tr>
+                <th>
+                    <a href="#" data-tooltip aria-haspopup="true"
+                       title="[%|loc%]Toggle Selection[%END%]" class="toggleButton">
+                        <i class="fa fa-check-square-o"></i>
+                    </a>
+                </th>
                 <th>[%|loc%]list[%END%]</th>
                 <th>[%|loc%]role[%END%]</th>
                 <th>[%|loc%]reception[%END%]</th>
@@ -21,6 +27,11 @@
                     [% SET dark = 1 %]
                     <tr class="color0">
                 [% END %]
+                        <td>
+                            [% IF l.value.is_member %]
+                                <input type="checkbox" name="lists" value="[% l.key %]" form="mass_del"/>
+                            [% END %]
+                        </td>
                         <td>
                             <a href="[% 'info' | url_rel([l.key]) %]" >
                                 <strong>[%|obfuscate(conf.spam_protection) %][% l.key %]@[% domain %][% END %]</strong>
@@ -68,6 +79,21 @@
                     </tr>
             [% END %]
         </table>
+        <form action="[% path_cgi %]" method="post" id="mass_del">
+        </form>
+        <div>
+            <input class="MainMenuLinks disableUnlessChecked"
+                   data-selector="input[name='lists']" form="mass_del"
+                   type="submit" name="action_mass_del"
+                   value="[%|loc%]Delete selected email addresses[%END%]" />
+        </div>
+        <div>
+            <input type="checkbox" id="quiet" name="quiet" form="mass_del"/>
+            <label for="quiet">
+                [%|loc%]Quiet (don't send deletion email)[%END%]
+            </label>
+        </div>
+        <input type="hidden" name="email" value="[% email %]" form="mass_del"/>
     [% ELSE %]
         <p>[%|loc%]No mailing list available.[%END%]</p>
     [% END %]

--- a/default/web_tt2/search_user.tt2
+++ b/default/web_tt2/search_user.tt2
@@ -51,14 +51,14 @@
                         <td>
                             [% l.value.bounce %]
                         </td>
-                        [% IF l.value.subscribed %]
+                        [% IF l.value.is_member %]
                             <td>
                                 <form action="[% path_cgi %]" method="post">
                                     <fieldset>
                                         <input type="hidden" name="previous_action" value="search_user" />
                                         <input type="hidden" name="email" value="[% email %]" />
                                         <input type="hidden" name="list" value="[% l.key %]" />
-                                        <input class="MainMenuLinks" type="submit" name="action_del" value="[%|loc%]delete[%END%]" />
+                                        <input class="MainMenuLinks" type="submit" name="action_del" value="[%|loc%]Unsubscribe the User[%END%]" />
                                         <input id="quiet" type="checkbox" name="quiet" /> <label for="quiet">[%|loc%]quiet[%END%]</label>
                                     </fieldset>
                                 </form>

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -677,6 +677,7 @@ our %required_privileges = (
     'edit_config'              => ['listmaster'],
     'ls_templates'             => ['listmaster'],
     'manage_template'          => ['owner'],
+    'mass_del'                 => ['listmaster'],
     'rt_create'                => ['owner'],
     'rt_delete'                => ['owner'],
     'rt_edit'                  => ['owner'],
@@ -7319,9 +7320,7 @@ sub do_mass_del {
     wwslog('info', '(%s) (%s)', $in{'email'},
         join(', ', split /\0/, $in{'lists'}));
 
-    # Access control.
-    return undef
-        unless (Sympa::is_listmaster($robot, $param->{'user'}{'email'}));
+    # Access control is done by %required_privileges
 
     # Turn data into usable structures
     my @lists = split /\0/, $in{'lists'};

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -7326,7 +7326,8 @@ sub do_mass_del {
     my @lists = split /\0/, $in{'lists'};
     my $email = Sympa::Tools::Text::canonic_email($in{'email'});
 
-    return $in{'previous_action'} || 'serveradmin' unless $email;
+    return $in{'previous_action'} || 'serveradmin'
+        unless Sympa::Tools::Text::valid_email($email);
 
     # Action confirmed?
     $param->{'email'} = $email;
@@ -7343,6 +7344,7 @@ sub do_mass_del {
     for my $list (@lists) {
         return $in{'previous_action'} || 'serveradmin' unless $email;
 
+        next unless Sympa::List->new($list, $robot, {just_try => 1});
         $list = Sympa::List->new($list, $robot);
 
         my $stash     = [];

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -194,6 +194,7 @@ our %comm = (
     'auth_add'         => 'do_auth_add',
     'del'              => 'do_del',
     'auth_del'         => 'do_auth_del',
+    'mass_del'         => 'do_mass_del',
     'modindex'         => 'do_modindex',
     'docindex'         => 'do_docindex',
     'reject'           => 'do_reject',
@@ -7312,6 +7313,79 @@ sub do_auth_del {
     }
 
     return ($in{'previous_action'} || 'sigindex');
+}
+# Deletes user from lists (requested by listmaster)
+sub do_mass_del {
+    wwslog('info', '(%s) (%s)', $in{'email'},
+        join(', ', split /\0/, $in{'lists'}));
+
+    # Access control.
+    return undef
+        unless (Sympa::is_listmaster($robot, $param->{'user'}{'email'}));
+
+    # Turn data into usable structures
+    my @lists = split /\0/, $in{'lists'};
+    my $email = Sympa::Tools::Text::canonic_email($in{'email'});
+
+    return $in{'previous_action'} || 'serveradmin' unless $email;
+
+    # Action confirmed?
+    $param->{'email'} = $email;
+    $param->{'lists'} = \@lists;
+    $param->{'quiet'} = $in{'quiet'};
+
+    my $next_action = $session->confirm_action(
+        $in{'action'}, $in{'response_action'},
+        arg             => join(',', @lists),
+        previous_action => 'serveradmin'
+    );
+    return $next_action unless $next_action eq '1';
+
+    for my $list (@lists) {
+        return $in{'previous_action'} || 'serveradmin' unless $email;
+
+        $list = Sympa::List->new($list, $robot);
+
+        my $stash     = [];
+        my $processed = 0;
+        my $spindle   = Sympa::Spindle::ProcessRequest->new(
+            context          => $list,
+            action           => 'del',
+            email            => $email,
+            sender           => $param->{'user'}{'email'},
+            quiet            => $param->{'quiet'},
+            md5_check        => 1,
+            scenario_context => {
+                email       => $email,
+                sender      => $param->{'user'}{'email'},
+                remote_host => $param->{'remote_host'},
+                remote_addr => $param->{'remote_addr'}
+            },
+            stash => $stash,
+        );
+        $spindle and $processed += $spindle->spin;
+        unless ($processed) {
+            return $in{'previous_action'} || 'serveradmin';
+        }
+
+        foreach my $report (@$stash) {
+            if ($report->[1] eq 'notice') {
+                Sympa::WWW::Report::notice_report_web(@{$report}[2, 3],
+                    $param->{'action'});
+            } else {
+                Sympa::WWW::Report::reject_report_web(@{$report}[1 .. 3],
+                    $param->{action});
+            }
+        }
+        unless (@$stash) {
+            Sympa::WWW::Report::notice_report_web('performed', {},
+                $param->{'action'});
+        }
+
+        # Skip search because we don't have the expression anymore.
+        delete $in{'previous_action'} if $in{'previous_action'} eq 'search';
+    }
+    return $in{'previous_action'} || 'serveradmin';
 }
 
 ####################################################

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -3824,7 +3824,7 @@ sub add_list_member {
 
     my $current_list_members_count = 0;
     if ($self->{'admin'}{'max_list_members'} > 0) {
-        $current_list_members_count = $self->get_total;   # FIXME: high db load
+        $current_list_members_count = $self->get_total;  # FIXME: high db load
     }
 
     my $sdm = Sympa::DatabaseManager->instance;

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -2789,7 +2789,8 @@ sub cleanup {
                 $v->{'format'}{$k}{format} = $format;
             } elsif ($v->{'format'}{$k}{'scenario'}) {
                 # Scenario format
-                $v->{'format'}{$k}{'format'} = Sympa::Regexps::scenario_config();
+                $v->{'format'}{$k}{'format'} =
+                    Sympa::Regexps::scenario_config();
                 #XXX$v->{'format'}{$k}{'default'} = 'default'
                 #XXX    unless ($p eq 'web_archive' and $k eq 'access')
                 #XXX    or ($p eq 'archive' and $k eq 'web_access');

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -156,8 +156,12 @@ sub new {
         and (  $function eq 'include' and $name =~ m{\A[^/]+\z}
             or $name =~ /\A$scenario_name_re\z/)
     ) {
-        $log->syslog('err', 'Unknown or undefined scenario function "%s", scenario name "%s"',
-            $function, $name);
+        $log->syslog(
+            'err',
+            'Unknown or undefined scenario function "%s", scenario name "%s"',
+            $function,
+            $name
+        );
         return undef;
     }
 
@@ -1620,7 +1624,7 @@ sub get_scenarios {
             my $scenario =
                 Sympa::Scenario->new($that, $function, name => $name);
             $seen{$name} = 1;
-			next unless (defined $scenario);
+            next unless (defined $scenario);
 
             push @scenarios, $scenario;
         }


### PR DESCRIPTION
- Bulk unsubscribe is back (#27)
- Tidying some files
- The unsubscribe and edit buttons where not shown in search_user.tt2, they are back. I also change the name of the unsubscribe button that was "delete" and sounds confusing to "Unsubscribe the User" (already available in the translations)
- I added the list of users that will be bulk-unsubscribed from a list on the confirmation page (go to a list subscribers review page, select some of them, unsubscribe them => their addresses are listed on the confirmation page, as reminder).