### PR TITLE
Add a button for full export of subscribers

### DIFF
--- a/default/web_tt2/review.tt2
+++ b/default/web_tt2/review.tt2
@@ -46,6 +46,9 @@
         <a class="actionMenuLinks" href="[% 'export_member' | url_rel([list,'light']) %]">
             [%|loc%]Dump[%END%]
         </a>
+        <a class="actionMenuLinks" href="[% 'export_member' | url_rel([list]) %]">
+            [%|loc%]Dump with names[%END%]
+        </a>
     [% END %]
     <a class="actionMenuLinks" href="[% 'show_exclude' | url_rel([list]) %]">
         [%|loc%]Exclude[%END%]

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -15923,7 +15923,7 @@ sub do_export_member {
             . "\n";
     } elsif ($format eq 'light') {
         ;
-    } else {
+    } elsif (defined($in{'filter'})) {
         printf "# Exported subscribers with search filter \"%s\"\n", $filter;
     }
     my $searchkey = Sympa::Tools::Text::foldcase($filter)


### PR DESCRIPTION
- Currently, only light export is available, thus export doesn’t contain
  the name of the subscribers. The button solves that.
- The full export always includes a header:
  \# Exported subscribers with search filter ""
  But it’s useless and maybe confusing when you use the full export from
  the button. I removed that header if no filter was sent
- I changed an "unless defined" assignment to "//", I don't know if it’s
  ok to do that.