### PR TITLE
Fix #601 — Add a configure option for sympa.conf-dist location

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -137,11 +137,11 @@ installconfig: installdir
 		chown $(USER) $(DESTDIR)$(confdir)/sympa.conf; \
 		chgrp $(GROUP) $(DESTDIR)$(confdir)/sympa.conf; \
 	fi
-	@echo "Installing configuration template ..."
-	-@echo "installing sympa.conf-dist"; \
-	$(INSTALL) -m 644 -T sympa.conf-dist $(DESTDIR)$(confdir)/sympa.conf-dist; \
-	chown $(USER) $(DESTDIR)$(confdir)/sympa.conf-dist; \
-	chgrp $(GROUP) $(DESTDIR)$(confdir)/sympa.conf-dist
+	@echo "Installing configuration template ..." \
+	echo "installing sympa.conf-dist"; \
+	$(INSTALL) -m 644 -T sympa.conf-dist $(DESTDIR)$(confdistdir)/sympa.conf-dist; \
+	chown $(USER) $(DESTDIR)$(confdistdir)/sympa.conf-dist; \
+	chgrp $(GROUP) $(DESTDIR)$(confdistdir)/sympa.conf-dist;
 	-@if [ ! -f $(DESTDIR)$(sysconfdir)/data_structure.version ]; then \
 		cd $(DESTDIR)$(sysconfdir); \
 		echo "# automatically created file" >> data_structure.version; \
@@ -185,7 +185,7 @@ nextstep:
 	@echo "#"
 	@echo "# ADDITIONAL SETTINGS:"
 	@echo "#    * You will find all available configuration settings in:"
-	@echo "#        $(confdir)/sympa.conf-dist"
+	@echo "#        $(confdistdir)/sympa.conf-dist"
 	@echo "#"
 	@echo "#    * Copy the configuration settings you want in:"
 	@echo "#        $(confdir)/sympa.conf"

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,7 @@ if test "$fhs" = "yes"; then
     arcdir=$localstatedir/lib/sympa/arc
     bouncedir=$localstatedir/lib/sympa/bounce
     confdir=$sysconfdir/sympa
+    confdistdir=$confdir
 else
     # redefine default values for some standard variables,
     # but only if no value was given
@@ -101,6 +102,7 @@ else
     arcdir=$prefix/arc
     bouncedir=$prefix/bounce
     confdir=/etc/sympa
+    confdistdir=$confdir
 fi
  
 # substitute custom variables
@@ -122,6 +124,7 @@ AC_SUBST(arcdir)
 AC_SUBST(bouncedir)
 AC_SUBST(localedir)
 AC_SUBST(confdir)
+AC_SUBST(confdistdir)
 AC_SUBST(docdir)
 
 # allow user to redefine some of them
@@ -133,6 +136,17 @@ AC_ARG_WITH(
     ),
     [
 	confdir="$withval"
+    ]
+)
+
+AC_ARG_WITH(
+    confdistdir,
+    AS_HELP_STRING(
+	[--with-confdistdir=DIR],
+    [Directory of Sympa configuration example file (sympa.conf-dist) @<:@SYSCONFDIR/sympa@:>@]
+    ),
+    [
+	confdistdir="$withval"
     ]
 )
 


### PR DESCRIPTION
I’m not sure about the `confdistdir` name of the option, feel free to propose something else.