### PR TITLE
Fix #613 — Avoid MHonArc’s search warning flood

### DIFF
--- a/src/lib/Sympa/WWW/Marc/Search.pm
+++ b/src/lib/Sympa/WWW/Marc/Search.pm
@@ -304,6 +304,11 @@ sub search {
                 last if (/-->/);
             }
         }
+
+        # If $subj is undefined, <$fh> will be undefined thus going further
+        # is useless
+        next unless defined $subj;
+
         $subj =~ s/ *-->$//;
 
         ($from = <$fh>) =~ s/^<!--X-From-R13: (.*) -->/$1/;


### PR DESCRIPTION
I think it’s a good fix for #613