### PR TITLE
Fix #621 — Add a 'gecos' option to web_archive_spam_protection

### DIFF
--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -1829,7 +1829,7 @@ our @params = (
     {   'name'       => 'web_archive_spam_protection',
         'gettext_id' => 'Protect web archive against spam harvesters',
         'gettext_comment' =>
-            "The same as \"spam_protection\", but restricted to the web archive.\nIn addition to it:\ncookie: users must submit a small form in order to receive a cookie before browsing the web archive.",
+            "The same as \"spam_protection\", but restricted to the web archive.\nIn addition to it:\ncookie: users must submit a small form in order to receive a cookie before browsing the web archive.\ngecos: \nonly gecos is displayed.",
         'default' => 'cookie',
         'vhost'   => '1',
     },

--- a/src/lib/Sympa/HTMLDecorator.pm
+++ b/src/lib/Sympa/HTMLDecorator.pm
@@ -240,8 +240,9 @@ sub decorate_email_gecos {
     my $language  = Sympa::Language->instance;
     while (my $item = $self->_queue_shift) {
         if ($item->{event} eq 'text') {
-            my $dtext = Sympa::Tools::Text::decode_html($item->{text});
-            if ($dtext =~ s{<?\b($email_re)\b>?}{}g) {
+            my $dtext       = Sympa::Tools::Text::decode_html($item->{text});
+            my $replacement = $language->gettext('address@concealed');
+            if ($dtext =~ s{\b($email_re)\b}{$replacement}g) {
                 $decorated .= Sympa::Tools::Text::encode_html($dtext);
             } else {
                 $decorated .= $item->{text};

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -878,7 +878,7 @@ our %pinfo = (
         'gettext_id' => "email address protection method",
         'gettext_comment' =>
             'Idem spam_protection is provided but it can be used only for web archives. Access requires a cookie, and users must submit a small form in order to receive a cookie before browsing the archives. This blocks all robot, even google and co.',
-        'format'     => ['cookie', 'javascript', 'at', 'none'],
+        'format'     => ['cookie', 'javascript', 'at', 'gecos', 'none'],
         'occurrence' => '1',
         'default'    => {'conf' => 'web_archive_spam_protection'}
     },

--- a/src/lib/Sympa/ListOpt.pm
+++ b/src/lib/Sympa/ListOpt.pm
@@ -197,6 +197,7 @@ our %list_option = (
 
     # web_archive_spam_protection
     'cookie' => {'gettext_id' => 'use HTTP cookie'},
+    'gecos'  => {'gettext_id' => 'only show gecos'},
 
     # verp_rate
     '100%' => {'gettext_id' => '100% - always'},


### PR DESCRIPTION
This allows to make web archives public without fearing to leak users
email addresses. This has only effect when you display a mail. In the archive list, the behavior is the current one: display gecos if any, display first part of email address otherwise (i.e. `foo` if the address is `foo@bar.org`).

Please note that I adapted the code from `decorate_email_at` subroutine.

Also, I used 'No gecos' as message when the email address didn’t contain a gecos, but feel free to propose somethin more easier to understand.

May fix #621 