### PR TITLE
Don’t capture extra spaces at the end of line in topics.conf

### DIFF
--- a/src/lib/Sympa/Robot.pm
+++ b/src/lib/Sympa/Robot.pm
@@ -227,7 +227,7 @@ sub load_topics {
                     'name'  => lc($1),
                     'order' => $index
                 };
-            } elsif ($line =~ /^([\w\.]+)\s+(.+)\s*$/) {
+            } elsif ($line =~ /^([\w\.]+)\s+(.+\S)\s*$/) {
                 next unless defined $topic->{'name'};
 
                 $topic->{$1} = $2;


### PR DESCRIPTION
I didn’t have the same error described in #581 (`Unable to find scenario file "topics_visibility.conceal "`) but this one:

```
DIED: Can't call method "authz" on an undefined value at /home/sympa/bin/wwsympa.fcgi line 15627.
 at /home/sympa/bin/wwsympa.fcgi line 15627.
	main::export_topics('sympa.test.org') called at /home/sympa/bin/wwsympa.fcgi line 2755
	main::check_param_in() called at /home/sympa/bin/wwsympa.fcgi line 1501
```

My patch fixes it, so it should work for #581 