### PR TITLE
Fix #624 — Correctly rename archive folder when renaming list

### DIFF
--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -184,7 +184,7 @@ sub _move {
     my $new_dir = shift;
 
     my $robot_id     = $request->{context};
-    my $listname     = lc($request->{listname} || );
+    my $listname     = lc($request->{listname} || '');
     my $current_list = $request->{current_list};
     my $sender       = $request->{sender};
     my $pending      = $request->{pending};
@@ -456,7 +456,7 @@ sub _copy {
     my $new_dir = shift;
 
     my $robot_id     = $request->{context};
-    my $listname     = lc($request->{listname} || );
+    my $listname     = lc($request->{listname} || '');
     my $current_list = $request->{current_list};
     my $sender       = $request->{sender};
     my $pending      = $request->{pending};

--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -184,7 +184,7 @@ sub _move {
     my $new_dir = shift;
 
     my $robot_id     = $request->{context};
-    my $listname     = $request->{listname};
+    my $listname     = lc($request->{listname} || );
     my $current_list = $request->{current_list};
     my $sender       = $request->{sender};
     my $pending      = $request->{pending};
@@ -456,7 +456,7 @@ sub _copy {
     my $new_dir = shift;
 
     my $robot_id     = $request->{context};
-    my $listname     = $request->{listname};
+    my $listname     = lc($request->{listname} || );
     my $current_list = $request->{current_list};
     my $sender       = $request->{sender};
     my $pending      = $request->{pending};


### PR DESCRIPTION
This may fix #624.