### PR TITLE
Make it clear on web interface that a list is being moderated

### DIFF
--- a/default/web_tt2/main.tt2
+++ b/default/web_tt2/main.tt2
@@ -84,6 +84,11 @@
                             [% END %]
                         </p>
                     [% END %]
+                    [% IF list_status == 'pending' %]
+                        <p class="alert-box warning text-center">
+                            [%|loc%]List not activated yet. Please wait until a listmaster activated it to be able to use it.[%END%]
+                        </p>
+                    [% END %]
                 [% END %]
 
                 [% PROCESS nav.tt2 %]


### PR DESCRIPTION
Fix #636

Adds an alert-box with the text "List not activated yet. Please wait until a listmaster activated it to be able to use it." below list subject.