### PR TITLE
Add trusted status to users, allowing to use "is_trusted" (new) in scenarii

### DIFF
--- a/default/Makefile.am
+++ b/default/Makefile.am
@@ -311,6 +311,7 @@ nobase_default_DATA = \
 	web_tt2/maintenance.tt2 \
 	web_tt2/main.tt2 \
 	web_tt2/manage_template.tt2 \
+	web_tt2/manage_trusted_users.tt2 \
 	web_tt2/modindex.tt2 \
 	web_tt2/my.tt2 \
 	web_tt2/nav.tt2 \

--- a/default/mail_tt2/report.tt2
+++ b/default/mail_tt2/report.tt2
@@ -363,6 +363,12 @@
 [%~ ELSIF report_entry == 'del_performed' ~%]
   [%|loc(report_param.total)%]%1 addresses have been removed[%END%]
 
+[%~ ELSIF report_entry == 'trust_performed' ~%]
+  [%|loc(report_param.total)%]Changed trust status of %1 user(s)[%END%]
+
+[%~ ELSIF report_entry == 'trust_failed' ~%]
+  [%|loc(report_param.email)%]Failed to change trust status for %1[%END%]
+
 [%~ ELSIF report_entry == 'performed' ~%]
   [%|loc(report_param.action)%]%1: action completed[%END%]
 

--- a/default/scenari/create_list.public_listmaster
+++ b/default/scenari/create_list.public_listmaster
@@ -1,4 +1,5 @@
-title.gettext anybody by validation by listmaster required
+title.gettext anybody by validation by listmaster or flagged as trusted required
 
 is_listmaster([sender])   md5,smime -> do_it
+is_trusted([sender])      md5,smime -> do_it
 true()                    smtp,md5,smime -> listmaster,notify

--- a/default/web_tt2/confirm_action.tt2
+++ b/default/web_tt2/confirm_action.tt2
@@ -109,6 +109,21 @@
             [%|loc(list)%]Are you sure you wish to close the %1 list?[%END%]
         </strong>
     </p>
+[%~ ELSIF confirm_action == 'change_trust' ~%]
+    <h2>
+        <i class="fa fa-check-circle"></i>
+        [%|loc%]Change trust status[%END%]
+    </h2>
+    <p>
+        <strong>
+            [%|loc(target)%]Do you really want to change trust status for the following users?[%END%]
+        </strong>
+    </p>
+    <ul>
+        [%~ FOREACH email = emails %]
+            <li>[%|obfuscate(conf.spam_protection) %][% email %][% END %]</li>
+        [%~ END %]
+    </ul>
 [%~ ELSIF confirm_action == 'del' ~%]
     <h2>
         <i class="fa fa-check-circle"></i>
@@ -400,6 +415,10 @@
     [%~ ELSIF confirm_action == 'close_list' ~%]
         <input type="hidden" name="mode" value="[% mode %]" />
         <input type="hidden" name="notify" value="[% notify %]" />
+    [%~ ELSIF confirm_action == 'change_trust' ~%]
+        [% FOREACH email = emails ~%]
+            <input type="hidden" name="email" value="[% email %]" />
+        [%~ END %]
     [%~ ELSIF confirm_action == 'decl_add' ~%]
         [% FOREACH i = id ~%]
             <input type="hidden" name="id" value="[% i %]" />
@@ -468,6 +487,18 @@
     [%~ ELSIF confirm_action == 'open_list' ~%]
         <input type="hidden" name="mode" value="[% mode %]" />
         <input type="hidden" name="notify" value="[% notify %]" />
+        [% IF mode == 'install' ~%]
+            <p>
+                <input id="trust" type="checkbox" name="trust"
+                       [% IF trust %] checked [% END %] />
+                <label for="trust">[%|loc%]Set owner as trusted[%END%]
+                    <a class="openInNewWindow" target="wws_help"
+                       href="[% 'nomenu/help' | url_rel(['faq-admin.html']) %]">
+                        <i class="fa fa-info-circle" title="[%|loc%]Help[%END%]" aria-hidden="true"></i>
+                    </a>
+                </label>
+            </p>
+        [%~ END %]
     [%~ ELSIF confirm_action == 'purge_list' ~%]
         [% FOREACH l = selected_lists ~%]
             <input type="hidden" name="selected_lists" value="[% l %]" />

--- a/default/web_tt2/css.tt2
+++ b/default/web_tt2/css.tt2
@@ -444,6 +444,7 @@ a.button:hover {
 
 input[type="button"]:disabled, input[type="submit"]:disabled, input[type="reset"]:disabled {
     background: none repeat scroll 0 0 [% color_12 %];
+    color: [% color_10 %];
 }
 
 button[disabled], input[disabled] {
@@ -2741,6 +2742,14 @@ p.retraitita, span.retraitita {
 
 a, li {
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+[%# For indicating trusted status in manage_trusted_users table ~%]
+.table_trusted_0 {
+    background-color: rgba(230, 27, 4, 0.62);
+}
+.table_trusted_1 {
+    background-color: rgba(30, 130, 76, 0.2);
 }
 
 [%# end css.tt2 %]

--- a/default/web_tt2/help_faq-admin.tt2
+++ b/default/web_tt2/help_faq-admin.tt2
@@ -1,5 +1,16 @@
 <!-- help_faq-admin.tt2 -->
 
+<h2 class="block">[%|helploc%]Trusted users[%END%]</h2>
+
+<p>
+    [%|helploc%]Trusted users corresponds to <code>is_trusted</code> in scenarii.[%END%]
+    [%|helploc%]For example, <code>create_list.public_listmaster</code> scenario allows trusted users to create lists without moderation.[%END%]
+    [%|helploc%]Lists created by untrusted users need to be activated by listmaster.[%END%]
+</p>
+<p>
+    [%|helploc%]You can flag users as trusted when activating a pending list or on <a href="../../serveradmin/users">user administration page</a>.[%END%]
+</p>
+
 <h2 class="block">[%|helploc%]Administrators Frequently Asked Questions[%END%]</h2>
 
 <h3>[%|helploc%]A subscriber does not receive the list messages[%END%]</h3>

--- a/default/web_tt2/manage_trusted_users.tt2
+++ b/default/web_tt2/manage_trusted_users.tt2
@@ -1,0 +1,70 @@
+<!-- manage_trusted_users.tt2 -->
+<div class="block">
+    <h2>[%|loc%]Manage trusted users[%END%]</h2>
+    <br />
+    [% IF users_count %]
+        <form action="[% path_cgi %]" method="post" id="change_trust" class="toggleContainer" data-toggle-selector="input[name='email']">
+            <table class="responsive listOfItems">
+                [% IF email %]
+                    <caption>[%|loc(email)%]Trust status of %1.[%END%]</caption>
+                [% ELSE %]
+                    <caption>[%|loc%]Trusted users[%END%]</caption>
+                [% END %]
+                <tr>
+                    <th>
+                        <a href="#" data-tooltip aria-haspopup="true"
+                           title="[%|loc%]Toggle Selection[%END%]" class="toggleButton">
+                            <i class="fa fa-check-square-o"></i>
+                        </a>
+                    </th>
+                    <th>[%|loc%]Trusted user[%END%]</th>
+                    <th>[%|loc%]Email[%END%]</th>
+                </tr>
+                [% FOREACH user = users %]
+                    <tr>
+                        <td>
+                            <input type="checkbox" name="email" value="[% user.key %]" form="change_trust">
+                        </td>
+                        <td class="table_trusted_[% user.value %]">
+                            [% IF user.value %]
+                                [%|loc%]Yes[%END%]
+                            [% ELSE %]
+                                [%|loc%]No[%END%]
+                            [% END %]
+                        <td>
+                            <strong>[%|obfuscate(conf.spam_protection) %][% user.key %][% END %]</strong>
+                        </td>
+                    </tr>
+                [% END %]
+            </table>
+            <div>
+                <input class="MainMenuLinks toggleButton" type="button" value="[%|loc%]Toggle Selection[%END%]">
+                <input class="MainMenuLinks disableUnlessChecked"
+                       data-selector="input[name='email']" form="change_trust"
+                       type="submit" name="action_change_trust"
+                       [% IF email %]
+                           [% FOREACH user = users %]
+                               [% IF user.value %]
+                                    value="[%|loc%]Untrust user[%END%]"
+                               [% ELSE %]
+                                    value="[%|loc%]Trust user[%END%]"
+                               [% END %]
+                           [% END %]
+                       [% ELSE %]
+                           value="[%|loc%]Untrust user(s)[%END%]"
+                       [% END %]
+                />
+            </div>
+        </form>
+    [% ELSE %]
+        <p class="small-12 medium-8 medium-centered columns alert-box info text-center">
+            [%|loc%]No trusted users yet.[%END%]
+        </p>
+        <p>
+            <a class="button" href="../sympa/serveradmin/users">
+                [%|loc%]Back to users administration page[%END%]
+            </a>
+        </p>
+    [% END %]
+</div>
+<!-- end manage_trusted_users.tt2 -->

--- a/default/web_tt2/search_user.tt2
+++ b/default/web_tt2/search_user.tt2
@@ -3,7 +3,7 @@
     <h2><i class="fa fa-search"></i> [%|loc%]User search result:[%END%]</h2>
     <br />
     [% IF which %]
-        <table  class="responsive listOfItems toggleContainer" data-toggle-selector="input[name='lists']">
+        <table class="responsive listOfItems toggleContainer" data-toggle-selector="input[name='lists']">
             <caption>[%|loc(email)%]Lists which %1 is subscribed [%END%]</caption>
             <tr>
                 <th>

--- a/default/web_tt2/serveradmin.tt2
+++ b/default/web_tt2/serveradmin.tt2
@@ -91,6 +91,24 @@
     </form>
 
     <hr>
+    <h2>
+        [%|loc%]Trusted users[%END%]
+        <a class="openInNewWindow" target="wws_help"
+           href="[% 'nomenu/help' | url_rel(['faq-admin.html']) %]">
+            <i class="fa fa-info-circle" title="[%|loc%]Help[%END%]" aria-hidden="true"></i>
+        </a>
+    </h2>
+    <p>[%|loc%]Enter an email address of a user to managed his trusted status or leave blank to manage all trusted users[%END%]</p>
+    <form class="bold_label" action="[% path_cgi %]" method="post">
+        <fieldset>
+            <input id="email" type="text" name="email" size="50"/>
+            <div style="padding-top:1.0em; clear:both;">
+                <input class="MainMenuLinks" type="submit" name="action_manage_trusted_users" value="[%|loc%]Manage user(s) trust status[%END%]" />
+            </div>
+        </fieldset>
+    </form>
+
+    <hr>
     <h2>[%|loc%]Sessions[%END%]</h2>
     <form class="bold_label" action="[% path_cgi %]" method="post">
         <fieldset>

--- a/default/web_tt2/set_pending_list_request.tt2
+++ b/default/web_tt2/set_pending_list_request.tt2
@@ -33,6 +33,13 @@
                     <input class="MainMenuLinks" type="submit" value="[%|loc%]submit[%END%]" />
                     <input id="notify" type="checkbox" name="notify" checked="checked" />
                     <label for="notify">[%|loc%]notify owner[%END%]</label>
+                    <input id="trust" type="checkbox" name="trust" />
+                    <label for="trust">[%|loc%]Set owner as trusted[%END%]
+                        <a class="openInNewWindow" target="wws_help"
+                           href="[% 'nomenu/help' | url_rel(['faq-admin.html']) %]">
+                            <i class="fa fa-info-circle" title="[%|loc%]Help[%END%]" aria-hidden="true"></i>
+                        </a>
+                    </label>
                 </fieldset>
             </form>
         </div>

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -245,59 +245,61 @@ our %comm = (
     'install_pending_list'     => 'do_install_pending_list',
     'edit_config'              => 'do_edit_config',
     #XXX'submit_list' => 'do_submit_list',
-    'editsubscriber'      => 'do_editsubscriber',
-    'edit'                => 'do_edit',
-    'viewbounce'          => 'do_viewbounce',
-    'redirect'            => 'do_redirect',
-    'rename_list_request' => 'do_rename_list_request',
-    'move_list'           => 'do_move_list',
-    'copy_list'           => 'do_copy_list',
-    'reviewbouncing'      => 'do_reviewbouncing',
-    'resetbounce'         => 'do_resetbounce',
-    'scenario_test'       => 'do_scenario_test',
-    'search_list'         => 'do_search_list',
-    'search_list_request' => 'do_search_list_request',
-    'show_cert'           => 'do_show_cert',
-    'close_list'          => 'do_close_list',
-    'open_list'           => 'do_open_list',
-    'purge_list'          => 'do_purge_list',
-    'upload_pictures'     => 'do_upload_pictures',
-    'delete_pictures'     => 'do_delete_pictures',
-    'd_read'              => 'do_d_read',
-    'd_create_child'      => 'do_d_create_child',
-    'd_unzip'             => 'do_d_unzip',
-    'd_editfile'          => 'do_d_editfile',
-    'd_properties'        => 'do_d_properties',
-    'd_update'            => 'do_d_update',
-    'd_describe'          => 'do_d_describe',
-    'd_delete'            => 'do_d_delete',
-    'd_rename'            => 'do_d_rename',
-    'd_control'           => 'do_d_control',
-    'd_change_access'     => 'do_d_change_access',
-    'd_set_owner'         => 'do_d_set_owner',
-    'd_admin'             => 'do_d_admin',
-    'dump_scenario'       => 'do_dump_scenario',
-    'export_member'       => 'do_export_member',
-    'remind'              => 'do_remind',
-    'move_user'           => 'do_move_user',
-    'load_cert'           => 'do_load_cert',
-    'compose_mail'        => 'do_compose_mail',
-    'send_mail'           => 'do_send_mail',
-    'request_topic'       => 'do_request_topic',
-    'tag_topic_by_sender' => 'do_tag_topic_by_sender',
-    'search_user'         => 'do_search_user',
-    'set_lang'            => 'do_set_lang',
-    'attach'              => 'do_attach',
-    'stats'               => 'do_stats',
-    'viewlogs'            => 'do_viewlogs',
-    'wsdl'                => 'do_wsdl',
-    'sync_include'        => 'do_sync_include',
-    'review_family'       => 'do_review_family',
-    'ls_templates'        => 'do_ls_templates',
-    'remove_template'     => 'do_remove_template',
-    'copy_template'       => 'do_copy_template',
-    'view_template'       => 'do_view_template',
-    'edit_template'       => 'do_edit_template',
+    'editsubscriber'       => 'do_editsubscriber',
+    'edit'                 => 'do_edit',
+    'viewbounce'           => 'do_viewbounce',
+    'redirect'             => 'do_redirect',
+    'rename_list_request'  => 'do_rename_list_request',
+    'move_list'            => 'do_move_list',
+    'copy_list'            => 'do_copy_list',
+    'reviewbouncing'       => 'do_reviewbouncing',
+    'resetbounce'          => 'do_resetbounce',
+    'scenario_test'        => 'do_scenario_test',
+    'search_list'          => 'do_search_list',
+    'search_list_request'  => 'do_search_list_request',
+    'show_cert'            => 'do_show_cert',
+    'close_list'           => 'do_close_list',
+    'open_list'            => 'do_open_list',
+    'purge_list'           => 'do_purge_list',
+    'upload_pictures'      => 'do_upload_pictures',
+    'change_trust'         => 'do_change_trust',
+    'delete_pictures'      => 'do_delete_pictures',
+    'd_read'               => 'do_d_read',
+    'd_create_child'       => 'do_d_create_child',
+    'd_unzip'              => 'do_d_unzip',
+    'd_editfile'           => 'do_d_editfile',
+    'd_properties'         => 'do_d_properties',
+    'd_update'             => 'do_d_update',
+    'd_describe'           => 'do_d_describe',
+    'd_delete'             => 'do_d_delete',
+    'd_rename'             => 'do_d_rename',
+    'd_control'            => 'do_d_control',
+    'd_change_access'      => 'do_d_change_access',
+    'd_set_owner'          => 'do_d_set_owner',
+    'd_admin'              => 'do_d_admin',
+    'dump_scenario'        => 'do_dump_scenario',
+    'export_member'        => 'do_export_member',
+    'remind'               => 'do_remind',
+    'manage_trusted_users' => 'do_manage_trusted_users',
+    'move_user'            => 'do_move_user',
+    'load_cert'            => 'do_load_cert',
+    'compose_mail'         => 'do_compose_mail',
+    'send_mail'            => 'do_send_mail',
+    'request_topic'        => 'do_request_topic',
+    'tag_topic_by_sender'  => 'do_tag_topic_by_sender',
+    'search_user'          => 'do_search_user',
+    'set_lang'             => 'do_set_lang',
+    'attach'               => 'do_attach',
+    'stats'                => 'do_stats',
+    'viewlogs'             => 'do_viewlogs',
+    'wsdl'                 => 'do_wsdl',
+    'sync_include'         => 'do_sync_include',
+    'review_family'        => 'do_review_family',
+    'ls_templates'         => 'do_ls_templates',
+    'remove_template'      => 'do_remove_template',
+    'copy_template'        => 'do_copy_template',
+    'view_template'        => 'do_view_template',
+    'edit_template'        => 'do_edit_template',
     #'rss' => 'do_rss', #FIXME:Currently processed in differenct way.
     'rss_request'     => 'do_rss_request',
     'maintenance'     => 'do_maintenance',
@@ -654,6 +656,7 @@ our %required_privileges = (
     'blacklist'                => ['owner', 'editor'],
     'close_list'               => ['privileged_owner'],
     'copy_template'            => ['listmaster'],
+    'change_trust'             => ['listmaster'],
     'd_install_shared'         => ['editor', 'owner'],
     'd_reject_shared'          => ['editor', 'owner'],
     'distribute'               => ['editor', 'owner', 'listmaster'],
@@ -691,6 +694,7 @@ our %required_privileges = (
     'reject'                   => ['editor', 'owner', 'listmaster'],
     'remove_template'          => ['listmaster'],
     'move_list'                => ['privileged_owner'],
+    'manage_trusted_users'     => ['listmaster'],
     'copy_list'                => ['owner', 'listmaster'],
     'open_list'                => ['listmaster'],
     'rename_list_request'      => ['privileged_owner'],
@@ -769,38 +773,40 @@ my %action_type = (
     'open_list'         => 'admin',
     'remind'            => 'admin',
     #'subindex' => 'admin',
-    'stats'               => 'admin',
-    'decl_del'            => 'admin',
-    'decl_add'            => 'admin',
-    'move_list'           => 'admin',
-    'copy_list'           => 'admin',
-    'rename_list_request' => 'admin',
-    'arc_manage'          => 'admin',
-    'sync_include'        => 'admin',
-    'view_template'       => 'admin',
-    'remove_template'     => 'admin',
-    'copy_template'       => 'admin',
-    'edit_template'       => 'admin',
-    'blacklist'           => 'admin',
-    'viewlogs'            => 'admin',
-    'serveradmin'         => 'serveradmin',
-    'get_pending_lists'   => 'serveradmin',
-    'get_closed_lists'    => 'serveradmin',
-    'get_inactive_lists'  => 'serveradmin',
-    'get_latest_lists'    => 'serveradmin',
-    'get_biggest_lists'   => 'serveradmin',
-    'ls_templates'        => 'serveradmin',
-    'skinsedit'           => 'serveradmin',
-    'review_family'       => 'serveradmin',
-    'search_user'         => 'serveradmin',
-    'show_sessions'       => 'serveradmin',
-    'show_exclude'        => 'admin',
-    'rebuildarc'          => 'serveradmin',
-    'set_session_email'   => 'serveradmin',
-    'set_loglevel'        => 'serveradmin',
-    'editfile'            => 'serveradmin',    #FIXME: admin?
-    'unset_dumpvars'      => 'serveradmin',
-    'set_dumpvars'        => 'serveradmin',
+    'stats'                => 'admin',
+    'decl_del'             => 'admin',
+    'decl_add'             => 'admin',
+    'move_list'            => 'admin',
+    'copy_list'            => 'admin',
+    'rename_list_request'  => 'admin',
+    'arc_manage'           => 'admin',
+    'sync_include'         => 'admin',
+    'view_template'        => 'admin',
+    'remove_template'      => 'admin',
+    'copy_template'        => 'admin',
+    'edit_template'        => 'admin',
+    'blacklist'            => 'admin',
+    'viewlogs'             => 'admin',
+    'change_trust'         => 'serveradmin',
+    'serveradmin'          => 'serveradmin',
+    'get_pending_lists'    => 'serveradmin',
+    'get_closed_lists'     => 'serveradmin',
+    'get_inactive_lists'   => 'serveradmin',
+    'get_latest_lists'     => 'serveradmin',
+    'get_biggest_lists'    => 'serveradmin',
+    'ls_templates'         => 'serveradmin',
+    'manage_trusted_users' => 'serveradmin',
+    'skinsedit'            => 'serveradmin',
+    'review_family'        => 'serveradmin',
+    'search_user'          => 'serveradmin',
+    'show_sessions'        => 'serveradmin',
+    'show_exclude'         => 'admin',
+    'rebuildarc'           => 'serveradmin',
+    'set_session_email'    => 'serveradmin',
+    'set_loglevel'         => 'serveradmin',
+    'editfile'             => 'serveradmin',    #FIXME: admin?
+    'unset_dumpvars'       => 'serveradmin',
+    'set_dumpvars'         => 'serveradmin',
     #XXX'automatic_lists_management_request' => 'serveradmin',
     #XXX'automatic_lists_management'         => 'serveradmin',
 );
@@ -11227,6 +11233,7 @@ sub do_open_list {
     $param->{'mode'}            = $mode;
     $param->{'previous_action'} = $in{'previous_action'} || 'admin';
     $param->{'notify'}          = $notify;
+    $param->{'trust'}           = $in{'trust'};
 
     # Action confirmed?
     my $next_action = $session->confirm_action(
@@ -11242,6 +11249,7 @@ sub do_open_list {
         current_list => $list,
         mode         => $mode,
         notify       => $notify,
+        trust        => $in{trust},
         sender       => $param->{'user'}{'email'},
         (   $param->{'user'}{'email'}
             ? (md5_check => 1)
@@ -15168,6 +15176,94 @@ sub do_tag_topic_by_sender {
     Sympa::WWW::Report::notice_report_web('performed_soon', {},
         $param->{'action'});
     return 'info';
+}
+
+sub do_manage_trusted_users {
+    if (defined($in{'email'}) && $in{'email'} =~ /[<>\\\*\$]/) {
+        Sympa::WWW::Report::reject_report_web('user', 'syntax_errors',
+            {p_name => 'email'},
+            $param->{'action'});
+        wwslog('err', 'Syntax error');
+        return undef;
+    }
+
+    my $email = Sympa::Tools::Text::canonic_email($in{'email'});
+
+    my $users = {};
+    if ($in{'email'}) {
+        my $user = Sympa::User->new($email);
+        if ($user) {
+            $users->{$user->email} = $user->trusted;
+        } else {
+            Sympa::WWW::Report::reject_report_web('user', 'no_entry',
+                {'email' => $in{'email'}},
+                $param->{'action'});
+            wwslog('info', 'No entry for %s', $in{'email'});
+            return 'serveradmin';
+        }
+    } else {
+        for my $user (Sympa::User::get_trusted_users()) {
+            $users->{$user} = 1;
+        }
+    }
+
+    $param->{'email'}       = $email;
+    $param->{'users'}       = $users;
+    $param->{'users_count'} = scalar(keys %{$users});
+
+    return 1;
+}
+
+sub do_change_trust {
+    wwslog(
+        'info',
+        'Request to change trust status of (%s)',
+        join(', ', split /\0/, $in{'email'})
+    );
+
+    # Access control is done by %required_privileges
+
+    my @emails = sort(split /\0/, $in{'email'});
+
+    # Action confirmed?
+    $param->{'emails'} = \@emails;
+
+    my $next_action = $session->confirm_action(
+        $in{'action'}, $in{'response_action'},
+        arg             => join(',', @emails),
+        previous_action => 'serveradmin'
+    );
+    return $next_action unless $next_action eq '1';
+
+    return $in{'previous_action'} || 'serveradmin' unless scalar(@emails);
+
+    my $changed = 0;
+    for my $email (@emails) {
+        $email = Sympa::Tools::Text::canonic_email($email);
+        my $user = Sympa::User->new($email);
+
+        if ($user) {
+            if ($user->trusted) {
+                Sympa::User::update_global_user($email, {'trusted' => 0});
+                $log->syslog('info', 'User %s flagged as untrusted', $email);
+            } else {
+                Sympa::User::update_global_user($email, {'trusted' => 1});
+                $log->syslog('info', 'User %s flagged as trusted', $email);
+            }
+            $changed++;
+        } else {
+            $log->syslog('info', 'Unable to change trust status of %s',
+                $email);
+            Sympa::WWW::Report::notice_report_web('trust_failed',
+                {'email' => $email},
+                $param->{'action'});
+        }
+    }
+
+    Sympa::WWW::Report::notice_report_web('trust_performed',
+        {'total' => $changed},
+        $param->{'action'});
+    return $in{'previous_action'} || 'serveradmin';
 }
 
 sub do_search_user {

--- a/src/lib/Sympa/DatabaseDescription.pm
+++ b/src/lib/Sympa/DatabaseDescription.pm
@@ -238,6 +238,12 @@ my %full_db_struct = (
                 'doc'    => 'FIXME',
                 'order'  => 11,
             },
+            'trusted_user' => {
+                'struct' => 'int(1)',
+                'doc' =>
+                    'Boolean, if true, the user can create lists without listmaster moderation if "create_list" is set to "public_listmaster"',
+                'order' => 12,
+            },
         },
         'doc' =>
             'The user_table is mainly used to manage login from web interface. A subscriber may not appear in the user_table if they never log through the web interface.',

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -53,7 +53,9 @@ use Sympa::Spindle::ProcessDigest;
 use Sympa::Spindle::ProcessRequest;
 use Sympa::Template;
 use Sympa::Tools::Data;
+use Sympa::Tools::Text;
 use Sympa::Upgrade;
+use Sympa::User;
 
 ## Init random engine
 srand(time());
@@ -87,7 +89,8 @@ unless (
         'send_digest',                  'keep_digest',
         'upgrade_config_location',      'role=s',
         'dump_users',                   'restore_users',
-        'open_list=s',
+        'open_list=s',                  'trust_users=s',
+        'untrust_users=s',              'show_trusted_users',
     )
 ) {
     pod2usage(-exitval => 1, -output => \*STDERR);
@@ -1078,6 +1081,45 @@ elsif ($main::options{'sync_list_db'}) {
         exit 1;
     }
     exit 0;
+} elsif ($main::options{'trust_users'}) {
+    my @emails = split(',', $main::options{'trust_users'});
+    for my $email (@emails) {
+        $email = Sympa::Tools::Text::canonic_email($email);
+        my $user = Sympa::User->new($email);
+
+        if ($user) {
+            Sympa::User::update_global_user($email, {'trusted' => 1});
+            printf "User %s has been flagged as trusted.\n", $email;
+        } else {
+            printf STDERR "$email is not in the users table.\n";
+        }
+    }
+    exit 0;
+} elsif ($main::options{'untrust_users'}) {
+    my @emails = split(',', $main::options{'untrust_users'});
+    for my $email (@emails) {
+        $email = Sympa::Tools::Text::canonic_email($email);
+        my $user = Sympa::User->new($email);
+
+        if ($user) {
+            Sympa::User::update_global_user($email, {'trusted' => 0});
+            printf "User %s has been flagged as untrusted.\n", $email;
+        } else {
+            printf STDERR "$email is not in the users table.\n";
+        }
+    }
+    exit 0;
+} elsif ($main::options{'show_trusted_users'}) {
+    my @emails = Sympa::User::get_trusted_users();
+    if (@emails) {
+        print "Trusted users:\n";
+        for my $email (@emails) {
+            printf "  %s\n", $email;
+        }
+    } else {
+        print "No trusted users.\n";
+    }
+    exit 0;
 }
 
 die 'Unknown option';
@@ -1242,17 +1284,24 @@ sympa, sympa.pl - Command line utility to manage Sympa
 
 =head1 SYNOPSIS
 
-C<sympa.pl> S<[ C<-d, --debug> ]> S<[ C<-f, --file>=I<another.sympa.conf> ]>
-S<[ C<-l, --lang>=I<lang> ]> S<[ C<-m, --mail> ]>
-S<[ C<-h, --help> ]> S<[ C<-v, --version> ]>
-S<>
-S<[ C<--import>=I<listname> ]>
-S<[ C<--open_list>=I<list>[I<@robot>] ]>
-S<[ C<--close_list>=I<list>[I<@robot>] ]>
-S<[ C<--purge_list>=I<list>[I<@robot>] ]>
-S<[ C<--lowercase> ]> S<[ C<--make_alias_file> ]>
-S<[ C<--dump_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
-S<[ C<--restore_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
+ sympa.pl [ -d, --debug ]
+          [ -f, --file=<another.sympa.conf> ]
+          [ -l, --lang=<lang> ]
+          [ -m, --mail ]
+          [ -h, --help ]
+          [ -v, --version ]
+
+          [ --import=<listname> ]
+          [ --open_list=<list>[<@robot>] ]
+          [ --close_list=<list>[<@robot>] ]
+          [ --purge_list=<list>[<@robot>] ]
+          [ --lowercase ]
+          [ --make_alias_file ]
+          [ --dump_users --list=<list>@<domain>|ALL [ --role=<roles> ] ]
+          [ --restore_users --list=<list>@<domain>|ALL [ --role=<roles> ] ]
+          [ --trust_users=<email>[,<other_email>] ]
+          [ --untrust_users=<email>[,<other_email>] ]
+          [ --show_trusted_users ]
 
 =head1 DESCRIPTION
 
@@ -1453,6 +1502,18 @@ B<Note>:
 This option was deprecated.
 
 Test the database message buffer size.
+
+=item C<--trust_users=>I<email>[,I<other_email>]
+
+Set users of the comma separated list as trusted. It corresponds to I<is_trusted> in scenarii.
+
+=item C<--untrust_users=>I<email>[,I<other_email>]
+
+Set users of the comma separated list as untrusted. They no longer corresponds to I<is_trusted> in scenarii.
+
+=item C<--show_trusted_users>
+
+Print the list of trusted users.
 
 =item C<--upgrade> [ C<--from=>I<X> ] [ C<--to=>I<Y> ]
 


### PR DESCRIPTION
- Add "is_trusted" authorization to scenario create_list.public_listmaster
- You can change the trust status when activating pending list
- You can manage trust status through serveradmin/users, for one user or
  all trusted users
- You can see trusted users and manage trust status with sympa.pl

Fix #633