### PR TITLE
Add list name to "is now subscriber of list" message.

### DIFF
--- a/src/lib/Sympa/Request/Handler/add.pm
+++ b/src/lib/Sympa/Request/Handler/add.pm
@@ -137,7 +137,7 @@ sub _twist {
     }
 
     $self->add_stash($request, 'notice', 'now_subscriber',
-        {'email' => $email});
+        {'email' => $email, listname => $list->{'name'}});
 
     my $user = Sympa::User->new($email);
     $user->lang($list->{'admin'}{'lang'}) unless $user->lang;


### PR DESCRIPTION
Fixes missing list name in output of the `sympa.pl --import` as reported in #656.