### PR TITLE
mtime of file like .last_change.admin was not updated

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -648,6 +648,7 @@ sub _cache_publish_expiry {
     # Touch status file.
     my $fh;
     open $fh, '>', $stat_file and close $fh;
+    utime undef, undef, $stat_file;    # required for such as NFS.
 }
 
 sub _cache_read_expiry {


### PR DESCRIPTION
[bug] Since mtime for cache file like .last_change.admin on some filesystems like NFS with Linux was not updated.  Fixed by updating it explicitly with utime(), User pages will not be refreshed after update.