### PR TITLE
Add ability to forbid some list names

### DIFF
--- a/default/mail_tt2/report.tt2
+++ b/default/mail_tt2/report.tt2
@@ -581,6 +581,9 @@ Warning: this message may already have been sent by one of the list's moderators
 [%~ ELSIF report_entry == 'missing_arg' ~%]
   [%|loc(report_param.argument)%]Missing argument %1[%END%]
 
+[%~ ELSIF report_entry == 'prohibited_listname' ~%]
+  [%|loc(report_param.argument)%]The name you want to use for your list (%1) is prohibited by the configuration of the server.[%END%]
+
 [%~ ELSIF report_entry == 'missing_post_source' ~%]
   [%|loc()%]You didn't define the web page you want to use to create your newsletter. Please specify either an URL or a file to upload.[%END%]
 

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -1860,6 +1860,27 @@ our @params = (
         'file'     => 'sympa.conf',
         'optional' => 1,
     },
+    {   'name' => 'prohibited_listnames',
+        'gettext_id' =>
+            'Prevent people to use some names for their lists names',
+        'gettext_comment' =>
+            'This parameter is a comma-separated list of names. You can use * as a wildcard character. To use a regex for this, please use listname_blacklist_regex setting.',
+        'default'    => undef,
+        'sample'     => 'www,root,*master',
+        'split_char' => ',',
+        'file'       => 'sympa.conf',
+        'optional'   => 1,
+    },
+    {   'name' => 'prohibited_listnames_regex',
+        'gettext_id' =>
+            'Prevent people to use some names for their lists names, based on a regex',
+        'gettext_comment' =>
+            'This parameter is a regex. Please note that prohibited_listnames and prohibited_listnames_regex will both be applied if set, they are not exclusive.',
+        'default'  => undef,
+        'sample'   => 'www|root|.*master',
+        'file'     => 'sympa.conf',
+        'optional' => 1,
+    },
 
     # Sympa services: Optional features
 

--- a/src/lib/Sympa/Request/Handler/create_list.pm
+++ b/src/lib/Sympa/Request/Handler/create_list.pm
@@ -81,6 +81,7 @@ sub _twist {
             return undef;
         }
     }
+
     # The 'other' topic means no topic.
     $param->{topics} = lc $param->{topics};
     delete $param->{topics} if $param->{topics} eq 'other';


### PR DESCRIPTION
- Add prohibited_listnames setting (comma-separated list, with ability
to use a wildcard)
- Add prohibited_listnames_regex setting

The settings are cumulative. You can use one or the other or both.

May fix #672