### PR TITLE
Fix crash of RC4 encrypted password notice.

### DIFF
--- a/src/lib/Sympa/WWW/Auth.pm
+++ b/src/lib/Sympa/WWW/Auth.pm
@@ -157,7 +157,7 @@ sub authentication {
                 $log->syslog('notice',
                     'Password in database seems encrypted. Run upgrade_sympa_password.pl to rehash passwords'
                 );
-                Sympa::send_notify_to_listmaster('*', 'password_encrypted');
+                Sympa::send_notify_to_listmaster('*', 'password_encrypted', {});
                 return undef;
             }
 


### PR DESCRIPTION
As reported by Jacques Tissot on the mailing list:

```
DIED: [Tue Jul 23 08:47:54 2019] wwsympa.fcgi: Error on incoming parameter "$data", it must be a ref on HASH or a ref on ARRAY at /home/sympa/bin/Sympa.pm line 422.
at /usr/share/perl5/CGI/Carp.pm line 362.
                CGI::Carp::realdie('[Tue Jul 23 08:47:54 2019] wwsympa.fcgi: Error on incoming pa...') called at /usr/share/perl5/CGI/Carp.pm line 461
                CGI::Carp::die('Error on incoming parameter "$data", it must be a ref on HASH...') called at /home/sympa/bin/Sympa.pm line 422
                Sympa::send_notify_to_listmaster('*', 'password_encrypted') called at /home/sympa/bin/Sympa/WWW/Auth.pm line 160
                Sympa::WWW::Auth::authentication('unifr.ch', '<loginName>', '<password>') called at /home/sympa/bin/Sympa/WWW/Auth.pm line 60
                Sympa::WWW::Auth::check_auth('unifr.ch', '<loginName>', '<password>') called at /home/sympa/bin/wwsympa.fcgi line 3155
                main::do_login() called at /home/sympa/bin/wwsympa.fcgi line 1544
```

Sympa version: 6.2.44