### PR TITLE
WWSympa: Use the label 'Apply modifications' instead of 'Update'

### DIFF
--- a/default/web_tt2/edit.tt2
+++ b/default/web_tt2/edit.tt2
@@ -52,7 +52,7 @@
                 <input type="hidden" name="submit" value="submit" />
                 <div class="columns">
                     <input class="MainMenuLinks" type="submit" name="action_edit"
-                           value="[%|loc%]Update[%END%]" />
+                           value="[%|loc%]Apply modifications[%END%]" />
                 </div>
             [%~ END %]
         </div>

--- a/default/web_tt2/edit_list_request.tt2
+++ b/default/web_tt2/edit_list_request.tt2
@@ -254,7 +254,7 @@
                 <input type="hidden" name="action" value="edit_list" />
                 [% IF is_form_editable ~%]
                     <input class="MainMenuLinks" type="submit" name="action_edit_list"
-                           value="[%|loc%]Update[%END%]" />
+                           value="[%|loc%]Apply modifications[%END%]" />
                 [%~ END %]
             </fieldset>
         </form>

--- a/default/web_tt2/editsubscriber.tt2
+++ b/default/web_tt2/editsubscriber.tt2
@@ -86,7 +86,7 @@
         [% END %]
 
         <div class="form_row">
-            <input class="MainMenuLinks" type="submit" name="action_set" value="[%|loc%]Update[%END%]" />
+            <input class="MainMenuLinks" type="submit" name="action_set" value="[%|loc%]Apply modifications[%END%]" />
         </div>
 
         <input class="MainMenuLinks" type="submit" name="action_del" value="[%|loc%]Unsubscribe the User[%END%]" />

--- a/default/web_tt2/help_admin-editlist-archives.tt2
+++ b/default/web_tt2/help_admin-editlist-archives.tt2
@@ -47,7 +47,7 @@
     [%|helploc%]This option applies to both the text archive and the online archive, as well as to the compilations sent to those who chose the 'Digest' delivery mode.[%END%]
 </p>
 <p>
-    <strong>[%|helploc%]BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]
+    <strong>[%|helploc%]BE CAREFUL: do not forget to click on the 'Apply modifications' button</strong> on bottom of page to save all your changes.[%END%]
 </p>
 
 <!-- end help_admin-editlist-archives.tt2 -->

--- a/default/web_tt2/help_admin-editlist-bounces.tt2
+++ b/default/web_tt2/help_admin-editlist-bounces.tt2
@@ -37,7 +37,7 @@
     [%|helploc%]<strong>To manage bounces</strong> (reset errors for some subscribers, unsubscribe bouncing subscribers, request a subscription reminder, etc.), <strong>go to the '<a href="admin-bounces.html">Bounces</a>' page</strong> of the list administration module.[%END%]
 </p>
 <p>
-    <strong>[%|helploc%]BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]
+    <strong>[%|helploc%]BE CAREFUL: do not forget to click on the 'Apply modifications' button</strong> on bottom of page to save all your changes.[%END%]
 </p>
 
 <!-- end help_admin-editlist-bounces.tt2 -->

--- a/default/web_tt2/help_admin-editlist-command.tt2
+++ b/default/web_tt2/help_admin-editlist-command.tt2
@@ -177,7 +177,7 @@
     [%|helploc%]To know <strong>more about the management of the shared document web space</strong> (how to organize it, change access rights, name documents, etc.), please refer to the '<a href="shared.html">Using the shared document web space</a>' section of the User guide.[%END%]
 </p>
 <p>
-    [%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]
+    [%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Apply modifications' button</strong> on bottom of page to save all your changes.[%END%]
 </p>
 
 <!-- end help_admin-editlist-command.tt2 -->

--- a/default/web_tt2/help_admin-editlist-description.tt2
+++ b/default/web_tt2/help_admin-editlist-description.tt2
@@ -30,7 +30,7 @@
     [%|helploc%]You can not change the <strong>Internet domain</strong> of the list: only the listmasters can change this parameter.[%END%]
 </p>
 <p>
-    [%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]
+    [%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Apply modifications' button</strong> on bottom of page to save all your changes.[%END%]
 </p>
 
 <!-- end help_admin-editlist-description.tt2 -->

--- a/default/web_tt2/help_admin-editlist-other.tt2
+++ b/default/web_tt2/help_admin-editlist-other.tt2
@@ -13,6 +13,6 @@
     [%|helploc%]On this page, you can also view <strong>information about the last update of the list</strong> (who made it and when), as well as the <strong>number of configuration change</strong> since the list was created.[%END%]
 </p>
 <p>
-    [%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]
+    [%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Apply modifications' button</strong> on bottom of page to save all your changes.[%END%]
 </p>
 <!-- end help_admin-editlist-other.tt2 -->

--- a/default/web_tt2/help_admin-editlist-sending.tt2
+++ b/default/web_tt2/help_admin-editlist-sending.tt2
@@ -36,7 +36,7 @@
     [%|helploc%]Last, the '<strong>Subject tagging</strong>' option lets you choose the <strong>text included before the subject of all messages</strong> sent to the list: this allows subscribers to sort their messages easily, to use message filters on them in order to process messages automatically, etc. By default, this text consists of the <strong>list name surrounded by square brackets</strong> (the square brackets are automatically added by the system, thus it is useless that you add them yourself).[%END%]
 </p>
 <p>
-    [%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Update' button</strong> on bottom of page to save all your changes.[%END%]
+    [%|helploc%]<strong>BE CAREFUL: do not forget to click on the 'Apply modifications' button</strong> on bottom of page to save all your changes.[%END%]
 </p>
 
 <!-- end help_admin-editlist-sending.tt2 -->

--- a/default/web_tt2/help_admin-users.tt2
+++ b/default/web_tt2/help_admin-users.tt2
@@ -22,6 +22,6 @@
     [%|helploc%]Be careful: becoming owner or moderator of a list does not mean that you are automatically subscribed to that list. Thus owners and moderators have to subscribe themselves to the list.[%END%]
 </p>
 <p>
-    [%|helploc%]To <strong>delete owners/moderators</strong>, clear the content of the input boxes relating to the person you want to delete and click on the 'Update' button.[%END%]
+    [%|helploc%]To <strong>delete owners/moderators</strong>, check the checkbox relating to the person you want to delete and click on the 'Apply modifications' button.[%END%]
 </p>
 <!-- end help_admin-users.tt2 -->

--- a/default/web_tt2/help_user-suboptions.tt2
+++ b/default/web_tt2/help_user-suboptions.tt2
@@ -65,7 +65,7 @@
         </ul>
     </li>
     <li>
-        [%|helploc%]<strong>Click on the 'Update' button</strong>.[%END%]
+        [%|helploc%]<strong>Click on the 'Apply modifications' button</strong>.[%END%]
     </li>
 </ol>
 

--- a/default/web_tt2/review.tt2
+++ b/default/web_tt2/review.tt2
@@ -451,7 +451,7 @@
             [% IF pS.privilege == 'write' && is_privileged_owner ~%]
                 <input type="hidden" name="submit" value="submit" />
                 <input class="MainMenuLInks" type="submit" name="action_review"
-                       value="[%|loc%]Update[%END%]" />
+                       value="[%|loc%]Apply modifications[%END%]" />
             [% END ~%]
         </fieldset>
     </form>

--- a/default/web_tt2/suboptions.tt2
+++ b/default/web_tt2/suboptions.tt2
@@ -76,7 +76,7 @@
 
     <input type="hidden" name="list" value="[% list %]" />
     <input type="hidden" name="previous_action" value="[% action %]" />
-    <input class="MainMenuLinks" type="submit" name="action_set" value="[%|loc%]Update[%END%]" />
+    <input class="MainMenuLinks" type="submit" name="action_set" value="[%|loc%]Apply modifications[%END%]" />
 
 </form>
 


### PR DESCRIPTION
Use 'Apply modifications' instead of 'Update' to make sure the changes/deletions will be effective only if update is performed.  These functions are subject to the change: `edit_list`, `editsubscriber/review/set` and `edit`.

This may fix #698.
