### PR TITLE
Text wrapping consumes large amount of memory.

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -14692,8 +14692,11 @@ sub do_send_mail {
         my $page_source;
         if ($in{'uploaded_file'} =~ /\S/) {
             my $fh = $query->upload('uploaded_file');
-            unless ($fh) {
-                wwslog('err', 'Can\'t upload %s', $in{'uploaded_file'});
+            my $ctype = $query->uploadInfo($fh)->{'Content-Type'}
+                if $fh;
+            unless ($ctype and lc $ctype eq 'text/html') {
+                wwslog('err', 'Can\'t upload %s (%s)', $in{'uploaded_file'},
+                    $ctype || 'unknown type');
                 Sympa::WWW::Report::reject_report_web(
                     'intern',
                     'cannot_upload',


### PR DESCRIPTION
Sympa::Tools::Text::wrap_text() consumes large amount of memory for large size of texts. Reduce it.
