### PR TITLE
Changes in mhonarc-ressources.tt2 (#699)

### DIFF
--- a/default/mhonarc-ressources.tt2
+++ b/default/mhonarc-ressources.tt2
@@ -96,9 +96,9 @@ POWERED_BY
 <DECODEHEADS>
 
 <MIMEARGS>
-text/plain; asis=us-ascii:iso-8859-1:iso-8859-2 nonfixed quote htmlcheck maxwidth=78
-text/html; asis=us-ascii:iso-8859-1:iso-8859-2 allownoncidurls
-m2h_external::filter; subdir usename
+text/plain; asis=us-ascii nonfixed quote htmlcheck maxwidth=78
+text/html; asis=us-ascii allownoncidurls
+m2h_external::filter; subdir
 </MIMEARGS>
 
 <CHARSETALIASES>


### PR DESCRIPTION
- Attachment with long filename can break list archives
- Only us-ascii will be treated as-is.

This may fix #699  


