### PR TITLE
pod2md: Some fixes

### DIFF
--- a/support/pod2md
+++ b/support/pod2md
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!perl
 # -*- indent-tabs-mode: nil; -*-
 # vim:ft=perl:et:sw=4
 
@@ -27,10 +27,10 @@ use Encode qw();
 use English qw(-no_match_vars);
 use FindBin qw($Bin);
 use Getopt::Long;
-use Pod::Markdown;
+use Pod::Markdown 3.000;
 use Pod::Usage;
 
-# Available options are "help" and "verbose".
+# Available options are "help", "release" and "verbose".
 # Others are there for compatibility to pod2man(1).
 my %options;
 GetOptions(
@@ -46,9 +46,12 @@ GetOptions(
 ) or exit 1;
 pod2usage(0) if $options{help};
 my $verbose = $options{verbose};
-#my $release = $options{release};
+my $release = $options{release};
 
-my $parser = Pod::Markdown::Sympa->new(output_encoding => 'utf-8',);
+my $parser = Pod::Markdown::Sympa->new(
+    output_encoding   => 'utf-8',
+    html_encode_chars => '|',
+);
 do {
     my ($ifile, $ofile) = splice @ARGV, 0, 2;
     my $fname = [split m{/}, $ofile || $ifile || 'manual']->[-1];
@@ -73,7 +76,7 @@ do {
     # Write preamble compatible to GHF Markdown.
     print $ofh "---\n";
     print $ofh "title: '$title'\n" if $title =~ /\S/;
-    #print $ofh "release: '$release'\n" if $release;
+    print $ofh "release: '$release'\n" if $release;
     print $ofh "---\n\n";
 
     $parser->output_fh($ofh);


### PR DESCRIPTION
- Pod::Markdown 3.000 or better required.
- Enable `--release` option.
- Escape "`|`" to avoid bug on Jelyll converter which treats it as table.