### PR TITLE
Fix errors 'Can't use an undefined value as an ARRAY reference' while running sympa.pl --modify_list

### DIFF
--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -987,15 +987,19 @@ elsif ($main::options{'modify_list'}) {
         "\n************************************************************\n";
 
     unless (defined $result->{'ok'}) {
-        printf STDERR "\n%s\n", join("\n", @{$result->{'string_info'}});
         print STDERR "\nThe action has been stopped because of error :\n";
-        printf STDERR "\n%s\n", join("\n", @{$result->{'string_error'}});
+        if (defined $result->{'string_error'} && (ref($result->{'string_error'}) eq 'ARRAY')) {
+            printf STDERR "\n%s\n", join("\n", @{$result->{'string_error'}});
+	}
         exit 1;
     }
 
     close INFILE;
 
-    printf STDOUT "\n%s\n", join("\n", @{$result->{'string_info'}});
+    if (defined $result->{'string_info'} && (ref($result->{'string_info'}) eq 'ARRAY')) {
+         printf STDOUT "\n%s\n", join("\n", @{$result->{'string_info'}});
+    }
+
     exit 0;
 }
 


### PR DESCRIPTION
I get this error while running 
```
$ sympa.pl -d --modify_list testfamily  --input_file /usr/local/sympa/list_data/testlist1/instance.xml
Can't use an undefined value as an ARRAY reference at /usr/local/sympa/bin/sympa.pl line 931.
```

I fixed `sympa.pl` to ensure `$result->{'string_info'} `and `$result->{'string_info'}` are defined before trying go through a `ARRAYREF`.

