### PR TITLE
WWSympa: viewlogs: selected type of action is not preserved

### DIFF
--- a/default/web_tt2/viewlogs.tt2
+++ b/default/web_tt2/viewlogs.tt2
@@ -110,13 +110,13 @@
                         </th>
                     [% ELSE %]
                         <th>
-                            <a href="[% 'viewlogs' | url_rel([list,1,size,'date']) %]" >
+                            <a href="[% 'viewlogs' | url_rel([list,1,size,'date'],{type=>type}) %]" >
                                 [%|loc%]Date[%END%]
                             </a>
                         </th>
                     [% END %]
                         <th>
-                            <a href="[% 'viewlogs' | url_rel([list,1,size,'list']) %]">
+                            <a href="[% 'viewlogs' | url_rel([list,1,size,'list'],{type=>type}) %]">
                                 [%|loc%]List[%END%]
                             </a>
                         </th>
@@ -127,7 +127,7 @@
                         </th>
                     [% ELSE %]
                         <th>
-                            <a href="[% 'viewlogs' | url_rel([list,1,size,'action']) %]">
+                            <a href="[% 'viewlogs' | url_rel([list,1,size,'action'],{type=>type}) %]">
                                 [%|loc%]Action[%END%]
                             </a>
                         </th>
@@ -155,7 +155,7 @@
                         </th>
                     [% ELSE %]
                         <th>
-                            <a href="[% 'viewlogs' | url_rel([list,1,size,'user_email']) %]">
+                            <a href="[% 'viewlogs' | url_rel([list,1,size,'user_email'],{type=>type}) %]">
                                 [%|loc%]User Email[%END%]
                             </a>
                         </th>
@@ -200,7 +200,7 @@
                         </td>
                         <td>
                             [% IF l.msg_id %]
-                                <a href="[% 'viewlogs' | url_rel([list,page,size,sortby],{type=>'all_actions',target_type=>'msg_id',target=>l.msg_id}) %]"
+                                <a href="[% 'viewlogs' | url_rel([list,page,size,sortby],{type=>type,target_type=>'msg_id',target=>l.msg_id}) %]"
                                    data-tooltip aria-haspopup="true"
                                    title="[%|loc%]view other events related to this message id.[%END%]">
                                     [%|loc%]Other events[%END%]
@@ -270,7 +270,7 @@
             </form>
             <br />
             [% IF prev_page ~%]
-                <a href="[% 'viewlogs' | url_rel([list,prev_page,size,sortby]) %]">
+                <a href="[% 'viewlogs' | url_rel([list,prev_page,size,sortby],{type=>type}) %]">
                     <i class="fa fa-caret-left fa-lg" title="[%|loc%]Previous page[%END%]"></i>
                 </a>
             [%~ END %]
@@ -278,7 +278,7 @@
                 [%|loc(page,total_page)%]page %1 / %2[%END%]
             [%~ END %]
             [% IF next_page ~%]
-                <a href="[% 'viewlogs' | url_rel([list,next_page,size,sortby]) %]">
+                <a href="[% 'viewlogs' | url_rel([list,next_page,size,sortby],{type=>type}) %]">
                     <i class="fa fa-caret-right fa-lg" title="[%|loc%]Next page[%END%]"></i>
                 </a>
             [%~ END %]

--- a/src/lib/Sympa/Log.pm
+++ b/src/lib/Sympa/Log.pm
@@ -472,16 +472,22 @@ sub get_first_db_log {
                   FROM logs_table
                   WHERE robot_logs = %s }, $sdm->quote($select->{'robot'});
 
-    #if a type of target and a target are specified
-    if (($select->{'target_type'}) && ($select->{'target_type'} ne 'none')) {
-        if ($select->{'target'}) {
-            $select->{'target_type'} = lc($select->{'target_type'});
-            $select->{'target'}      = lc($select->{'target'});
-            $statement .= 'AND '
-                . $select->{'target_type'}
-                . '_logs = '
-                . $sdm->quote($select->{'target'}) . ' ';
-        }
+    if (    $select->{target_type}
+        and $select->{target_type} ne 'none'
+        and $select->{target_type} =~ /\A\w+\z/
+        and $select->{target}) {
+        # If a type of target and a target are specified:
+        $statement .= sprintf 'AND %s_logs = %s ',
+            lc $select->{target_type}, $sdm->quote(lc $select->{target});
+    } elsif ($select->{type}
+        and $select->{type} ne 'none'
+        and $select->{type} ne 'all_actions'
+        and $action_type{$select->{type}}) {
+        # If the search is on a precise type:
+        $statement .= sprintf 'AND (%s) ',
+            join ' OR ',
+            map { sprintf "logs_table.action_logs = '%s'", $_ }
+            @{$action_type{$select->{'type'}}};
     }
 
     #if the search is between two date
@@ -505,29 +511,6 @@ sub get_first_db_log {
             $statement .= sprintf "AND date_logs >= %s AND date_logs <= %s ",
                 $date_from, $date_to;
         }
-    }
-
-    #if the search is on a precise type
-    if ($select->{'type'}) {
-        if (   ($select->{'type'} ne 'none')
-            && ($select->{'type'} ne 'all_actions')) {
-            my $first = 'false';
-            foreach my $type (@{$action_type{$select->{'type'}}}) {
-                if ($first eq 'false') {
-                    #if it is the first action, put AND on the statement
-                    $statement .=
-                        sprintf "AND (logs_table.action_logs = '%s' ", $type;
-                    $first = 'true';
-                }
-                #else, put OR
-                else {
-                    $statement .= sprintf "OR logs_table.action_logs = '%s' ",
-                        $type;
-                }
-            }
-            $statement .= ')';
-        }
-
     }
 
     # if the listmaster want to make a search by an IP address.


### PR DESCRIPTION
When the user changes sorting order or goes to the next/previous page, action type selected previously will be reset.
