### PR TITLE
Additional fix to #693

### DIFF
--- a/src/lib/Sympa/DataSource.pm
+++ b/src/lib/Sympa/DataSource.pm
@@ -94,6 +94,10 @@ sub new {
     my @defkeys = sort keys %{$defopts || {}};
     my @defvals = @{$defopts || {}}{@defkeys} if @defkeys;
 
+    #FIXME: consider boundaries of Unicode characters (or grapheme clusters)
+    $options{name} = substr $options{name}, 0, 50
+        if $options{name} and 50 < length $options{name};
+
     return $type->_new(
         %options,
         _role    => $role,

--- a/src/lib/Sympa/DataSource/RemoteFile.pm
+++ b/src/lib/Sympa/DataSource/RemoteFile.pm
@@ -79,8 +79,8 @@ sub _open {
             if $key_passwd;
         $ua->ssl_opts(
             SSL_verify_mode => (
-                {none => 0, optional => 1, required => 3}->$self->{ca_verify}
-                    || 0
+                {none => 0, optional => 1, required => 3}
+                ->{$self->{ca_verify}} || 0
             )
         ) if defined $self->{ca_verify};
         $ua->ssl_opts(SSL_ca_file => $ca_file) if $ca_file;

--- a/src/lib/Sympa/DatabaseDescription.pm
+++ b/src/lib/Sympa/DatabaseDescription.pm
@@ -138,7 +138,7 @@ my %full_db_struct = (
                 'order' => 12.7,
             },
             'inclusion_label_subscriber' => {
-                'struct' => 'varchar(15)',
+                'struct' => 'varchar(50)',
                 'doc'    => 'name of data source',
                 'order'  => 12.8,
             },
@@ -951,7 +951,7 @@ my %full_db_struct = (
                 'order' => 7.7,
             },
             'inclusion_label_admin' => {
-                'struct' => 'varchar(15)',
+                'struct' => 'varchar(50)',
                 'doc'    => 'name of data source',
                 'order'  => 7.8,
             },

--- a/src/lib/Sympa/ListDef.pm
+++ b/src/lib/Sympa/ListDef.pm
@@ -1109,7 +1109,7 @@ our %pinfo = (
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
                 'format'     => '.+',
-                'length'     => 15
+                'length'     => 50,
             },
             'url' => {
                 'order'      => 2,
@@ -1203,7 +1203,7 @@ our %pinfo = (
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
                 'format'     => '.+',
-                'length'     => 15
+                'length'     => 50,
             },
             'listname' => {
                 'order'      => 2,
@@ -1237,7 +1237,7 @@ our %pinfo = (
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
                 'format'     => '.+',
-                'length'     => 15
+                'length'     => 50,
             },
             'url' => {
                 'order'      => 2,
@@ -1374,7 +1374,7 @@ our %pinfo = (
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
                 'format'     => '.+',
-                'length'     => 15
+                'length'     => 50,
             },
             'host' => {
                 'order'      => 2,
@@ -1516,7 +1516,7 @@ our %pinfo = (
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
                 'format'     => '.+',
-                'length'     => 15
+                'length'     => 50,
             },
             'host' => {
                 'order'      => 2,
@@ -1704,7 +1704,7 @@ our %pinfo = (
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
                 'format'     => '.+',
-                'length'     => 15
+                'length'     => 50,
             },
             'db_type' => {
                 'order'      => 1.5,
@@ -1812,7 +1812,7 @@ our %pinfo = (
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
                 'format'     => '.+',
-                'length'     => 15
+                'length'     => 50,
             },
             'host' => {
                 'order'      => 2,
@@ -1957,7 +1957,7 @@ our %pinfo = (
             'name' => {
                 'format'     => '.+',
                 'gettext_id' => "short name for this source",
-                'length'     => 15,
+                'length'     => 50,
                 'order'      => 1,
             },
             'host' => {
@@ -2151,7 +2151,7 @@ our %pinfo = (
                 'order'      => 1,
                 'gettext_id' => "short name for this source",
                 'format'     => '.+',
-                'length'     => 15
+                'length'     => 50,
             },
             'db_type' => {
                 'order'      => 1.5,


### PR DESCRIPTION
This fixes:
  - a typo mislead by the fix for #693.
  - lack of consideration about column size.

See also [a post on sympa-users](https://listes.renater.fr/sympa/arcsearch_id/sympa-users/2019-09/E830CF905957404CB59FAEF2A5FD302A01ADB335%40CNREXCMBX05P.core-res.rootcore.local).

