### PR TITLE
Explicitely setting members visibility to 'noconceal' when the value is undefined in database

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -3297,7 +3297,7 @@ sub get_members {
     if ($role eq 'member') {
         $filter = '';
     } elsif ($role eq 'unconcealed_member') {
-        $filter = " AND visibility_subscriber <> 'conceal'";
+        $filter = " AND (visibility_subscriber <> 'conceal' OR visibility_subscriber IS NULL)";
     } else {
         die sprintf 'Unknown role "%s"', $role;
     }


### PR DESCRIPTION
When a user reviews the list, if she is not allowed to see concealed list members, only the users with a value in the 'visibility_subscriber' database field are actually displayed. Those with an undefined value are not.

The default behaviour in Sympa is that users are visible. Being concealed is an explicit request from the users.

Consequently, I suggest this patch to include a test on undefined values for this field when requesting unconcealed users.

Regards,

David