### PR TITLE
Make storage into outgoing spool more efficient (#604)

### DIFF
--- a/src/lib/Sympa/Spool/Outgoing.pm
+++ b/src/lib/Sympa/Spool/Outgoing.pm
@@ -326,6 +326,15 @@ sub _get_recipient_tabs_by_domain {
 
     return unless @rcpt;
 
+    # Sort by domain.
+    @rcpt = map {
+        join '@', grep { defined $_ } @$_;
+    } sort {
+        (($a->[1] // '') cmp ($b->[1] // '')) || ($a->[0] cmp $b->[0])
+    } map {
+        [split /\@/, $_, 2]
+    } @rcpt;
+
     my ($i, $j, $nrcpt);
     my $size = 0;
 


### PR DESCRIPTION
Sort recipients to be stored by domains.

This may fix #604.
