### PR TITLE
Various improvements to --sync-include output

### DIFF
--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -884,6 +884,14 @@ if ($main::options{'dump'} or $main::options{'dump_users'}) {
         exit 1;
     }
 
+    my $result = $list->sync_include();
+
+    if ($result == 0) {
+        printf STDERR "No data sources defined for inclusion into list %s.\n",
+            $list->get_id;
+        exit 1;
+    }
+
     unless (defined $list->sync_include()) {
         print STDERR "Failed to synchronize list members\n";
         exit 1;

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -889,7 +889,7 @@ if ($main::options{'dump'} or $main::options{'dump_users'}) {
         exit 1;
     }
 
-    printf "Members of list %s have been successfully update.\n",
+    printf "Members of list %s have been successfully updated.\n",
         $list->get_id;
     exit 0;
 ## Migration from one version to another

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -884,9 +884,7 @@ if ($main::options{'dump'} or $main::options{'dump_users'}) {
         exit 1;
     }
 
-    my $result = $list->sync_include();
-
-    if ($result == 0) {
+    unless ($list->has_include_data_sources) {
         printf STDERR "No data sources defined for inclusion into list %s.\n",
             $list->get_id;
         exit 1;


### PR DESCRIPTION
Starting with: Fix typo in output from --sync_include commandline option.
More to come.