### PR TITLE
Patch for a working include_ldap_2level_query (#785)

### DIFF
--- a/src/lib/Sympa/DataSource/LDAP2.pm
+++ b/src/lib/Sympa/DataSource/LDAP2.pm
@@ -68,10 +68,10 @@ sub _load_next {
     my %options = @_;
 
     if ($options{turn} eq 'first') {
-        $self->SUPER::_load_next(%options);
-        return;
+        return $self->SUPER::_load_next(%options);
     }
-
+    
+    my @retrieved;
     while (my $value = shift @{$self->{_attr1values} || []}) {
         my ($escaped, $suffix, $filter);
 
@@ -106,11 +106,13 @@ sub _load_next {
         next unless $mesg;
         $self->{_ds} = $mesg;    # hack __dsh()
 
-        $self->SUPER::_load_next(%options);
-        last if $self->{_retrieved} and @{$self->{_retrieved}};
+        my @tmp_array = $self->SUPER::_load_next(%options);
+        @tmp_array = map{@$_} @tmp_array;
+        push @retrieved, @tmp_array;
     }
 
-    return;
+    $self->{_retrieved} = [@retrieved];
+    return $self->{_retrieved};
 }
 
 sub _next {


### PR DESCRIPTION
Since 6.2.48, LDAP2 queries don't work anymore.
This is a simple and stupid patch to make it works.