### PR TITLE
Prevent Sympa daemon crash due to a broken plugin module.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -95,6 +95,9 @@ requires 'List::Util::XS', '>= 1.20';
 # Note: 1.22 or later is recommended.
 requires 'Locale::Messages', '>= 1.20';
 
+# Used to load plugins
+requires 'Module::Runtime';
+
 # MHonArc is used to build Sympa web archives
 requires 'MHonArc::UTF8';
 

--- a/cpanfile
+++ b/cpanfile
@@ -95,9 +95,6 @@ requires 'List::Util::XS', '>= 1.20';
 # Note: 1.22 or later is recommended.
 requires 'Locale::Messages', '>= 1.20';
 
-# Used to load plugins
-requires 'Module::Runtime';
-
 # MHonArc is used to build Sympa web archives
 requires 'MHonArc::UTF8';
 

--- a/src/lib/Sympa/Message/Plugin.pm
+++ b/src/lib/Sympa/Message/Plugin.pm
@@ -30,6 +30,7 @@ package Sympa::Message::Plugin;
 use strict;
 use warnings;
 use English qw(-no_match_vars);
+use Module::Runtime qw(use_module);
 
 use Sympa::Log;
 
@@ -58,8 +59,7 @@ sub execute {
         unless $hook_module =~ /::/;
 
     unless (exists $handlers{$hook_module . '->' . $hook_name}) {
-        eval "use $hook_module;";
-        if ($EVAL_ERROR) {
+        unless (eval { use_module($hook_module); 1; }) {
             $log->syslog('err', 'Cannot load hook module %s: %s',
                 $hook_module, $EVAL_ERROR);
             return undef;

--- a/src/lib/Sympa/Message/Plugin.pm
+++ b/src/lib/Sympa/Message/Plugin.pm
@@ -30,7 +30,6 @@ package Sympa::Message::Plugin;
 use strict;
 use warnings;
 use English qw(-no_match_vars);
-use Module::Runtime qw(use_module);
 
 use Sympa::Log;
 
@@ -59,7 +58,7 @@ sub execute {
         unless $hook_module =~ /::/;
 
     unless (exists $handlers{$hook_module . '->' . $hook_name}) {
-        unless (eval { use_module($hook_module); 1; }) {
+        unless (eval "require $hook_module") {
             $log->syslog('err', 'Cannot load hook module %s: %s',
                 $hook_module, $EVAL_ERROR);
             return undef;


### PR DESCRIPTION
A mistake in a plugin module crashed sympa hard:

```
Nov 21 17:54:14 local-sympa sympa_msg[14599]: err main::#243 > Sympa::Spindle::spin#95 > Sympa::Spindle::TransformOutgoing::_twist#48 > Sympa::Message::Plugin::execute#61 > (eval)#1 > (eval)#1 > Sympa::Message::Plugin::BEGIN#1 DIED: Global symbol "$list" requires explicit package name (did you forget to declare "my $list"?) at /usr/local/lib/site_perl/Sympa/Plugin/DistributionNotification.pm line 24. Compilation failed in require at (eval 208) line 1.
Nov 21 17:54:14 local-sympa systemd[1]: sympa.service: Main process exited, code=exited, status=255/n/a
Nov 21 17:54:14 local-sympa systemd[1]: sympa.service: Unit entered failed state.
Nov 21 17:54:14 local-sympa systemd[1]: sympa.service: Failed with result 'exit-code'.
```

Justification for the introduction of the [Module::Runtime](https://metacpan.org/pod/Module::Runtime) dependency:

- does the right thing without head scratching and homegrown code
- small footprint

