### PR TITLE
Updating dependency Test::Pod

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -306,7 +306,7 @@ on 'test' => sub {
     requires 'Test::Compile';
     requires 'Test::Harness';
     requires 'Test::More';
-    requires 'Test::Pod';
+    requires 'Test::Pod', '>= 1.41';
 };
 
 on 'develop' => sub {

--- a/t/pod-syntax.t
+++ b/t/pod-syntax.t
@@ -7,14 +7,19 @@ use warnings;
 use English qw(-no_match_vars);
 use Test::More;
 
+my $test_pod_ok;
 BEGIN {
-    eval 'use Test::Pod';
+    # Test::Pod 1.40 mistakenly complains about the construct L<text|url>.
+    eval 'use Test::Pod 1.41';
+    $test_pod_ok = 1 unless $EVAL_ERROR;
 }
-plan(skip_all => 'Test::Pod required') unless $Test::Pod::VERSION;
+unless ($test_pod_ok) {
+    plan(skip_all => 'Test::Pod 1.41 or later required');
+} else {
+    my @files = (
+        all_pod_files('src'), glob('doc/*.pod'),
+        glob('doc/*.podin'),  glob('doc/*.podpl')
+    );
+    all_pod_files_ok(@files);
+}
 
-my @files = (
-    all_pod_files('src'), glob('doc/*.pod'),
-    glob('doc/*.podin'),  glob('doc/*.podpl')
-);
-
-all_pod_files_ok(@files);


### PR DESCRIPTION
Test: t/pod-syntax.t: Test::Pod 1.40 mistakenly complains about the construct L<text|url>. Use 1.41 or later.
