### PR TITLE
Fixing #813

### DIFF
--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -242,15 +242,13 @@ sub compile {
 
     my $parsed = _parse_scenario($data, $file_path);
     if ($parsed and not($function and $function eq 'include')) {
-        my $compiled = _compile_scenario($that, $function, $parsed);
-        if ($compiled) {
-            my $sub = eval $compiled;
+        $parsed->{compiled} = _compile_scenario($that, $function, $parsed);
+        if ($parsed->{compiled}) {
+            $parsed->{sub} = eval $parsed->{compiled};
             # Bad syntax in compiled Perl code.
-            die sprintf "%s: %s\n", ($file_path || '(data)'), $EVAL_ERROR
-                unless $sub;
-
-            $parsed->{compiled} = $compiled;
-            $parsed->{sub}      = $sub;
+            $log->syslog('err', '%s: %s\n', ($file_path || '(data)'),
+                $EVAL_ERROR)
+                unless ref $parsed->{sub} eq 'CODE';
         }
     }
 

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -827,7 +827,11 @@ sub _compile_condition {
             $str =~ s{(\\.|.)}{($1 eq "'" or $1 eq "\\")? "\\\'" : $1}eg;
             $value = sprintf "'%s'", $str;
         } else {
-            # Parse error.
+            # Texts with unknown format may be treated as the string constants
+            # for compatibility to loose parsing with earlier ver (<=6.2.48).
+            my $str = $value;
+            $str =~ s/([\\\'])/\\$1/g;
+            $value = sprintf "'%s'", $str;
         }
         push(@args, $value);
     }


### PR DESCRIPTION
Scenario: Fixing a bug injected by #782. File names for search filters may not be quoted.

This may fix #813.
