### PR TITLE
Scenario fails with negative indices in [header->Field][n] (#831)

### DIFF
--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -785,7 +785,7 @@ sub _compile_condition {
             ## available.
             if (defined $index) {
                 $value =
-                    sprintf '[$context->{message}->get_header(\'%s\')]->[%s]',
+                    sprintf 'do { my @h = $context->{message}->get_header(\'%s\'); $h[%s] }',
                     $field_name, $index;
             } else {
                 $value = sprintf '[$context->{message}->get_header(\'%s\')]',

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -583,11 +583,11 @@ sub _compile_scenario {
     my $required = join "\n", map {
         my $req;
         if ($_ eq 'list_object') {
-            $req = 'return undef unless ref $that eq \'Sympa::List\';';
+            $req = 'die "No list context" unless ref $that eq \'Sympa::List\';';
         } elsif ($_ eq 'message') {
             $req = sprintf '$context->{message} ||= Sympa::Message->new("\n");';
         } else {
-            $req = sprintf 'return undef unless exists $context->{%s};', $_;
+            $req = sprintf 'die "Missing parameter \'%s\'" unless exists $context->{%s};', $_, $_;
         }
         "    $req";
     } sort keys %required;

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -584,6 +584,8 @@ sub _compile_scenario {
         my $req;
         if ($_ eq 'list_object') {
             $req = 'return undef unless ref $that eq \'Sympa::List\';';
+        } elsif ($_ eq 'message') {
+            $req = sprintf '$context->{message} ||= Sympa::Message->new("\n");';
         } else {
             $req = sprintf 'return undef unless exists $context->{%s};', $_;
         }

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018 The Sympa Community. See the AUTHORS.md file at the
-# top-level directory of this distribution and at
+# Copyright 2017, 2018, 2019 The Sympa Community. See the AUTHORS.md file
+# at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
This PR may prevent:
- the error on "Modification of non-creatable array value" by using "`[header->Field][-1]`" in scenarios.
- failure of scenario execution without required "message" parameter.

This may fix #831 
