### PR TITLE
Prevent welcome emails on import with --quiet.

### DIFF
--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -513,6 +513,7 @@ if ($main::options{'dump'} or $main::options{'dump_users'}) {
         force            => 1,
         sender           => Sympa::get_address($list, 'listmaster'),
         scenario_context => {skip => 1},
+        quiet            => $main::options{quiet},
     );
     unless ($spindle and $spindle->spin) {
         printf STDERR "Failed to add email addresses to %s\n", $list;
@@ -1873,6 +1874,8 @@ Import subscribers in the list. Data are read from standard input.
 The imported data should contain one entry per line : the first field
 is an email address, the second (optional) field is the free form name.
 Fields are spaces-separated.
+
+Use C<--quiet> to prevent welcome emails.
 
 Sample:
 


### PR DESCRIPTION
See related mailing list post "Welcome message when importing users".