### PR TITLE
Deprecate one time ticket (1) (#156)

### DIFF
--- a/default/mail_tt2/listmaster_notification.tt2
+++ b/default/mail_tt2/listmaster_notification.tt2
@@ -10,7 +10,7 @@ Subject: [%"List \"%1@%2\" creation request from %3"|loc(list.name,domain,email)
 [% 'info' | url_abs([list.name]) %]
 
 [%|loc%]To activate/delete this mailing list:[%END%]
-[% 'ticket' | url_abs([one_time_ticket]) %]
+[% 'get_pending_lists' | url_abs %]
 
 [%- ELSIF type == 'list_created' -%]
 [% PROCESS 'list_created.tt2' -%]
@@ -30,7 +30,7 @@ Subject: [%"List \"%1\" renaming"|loc(list.name)|qencode%]
 [% END %]
 
 [%|loc%]To activate/delete this mailing list:[%END%]
-[% 'ticket' | url_abs([one_time_ticket]) %]
+[% 'get_pending_lists' | url_abs %]
 
 [% ELSIF type == 'no_db' -%]
 Subject: [%"No database"|loc|qencode%]

--- a/default/mail_tt2/listowner_notification.tt2
+++ b/default/mail_tt2/listowner_notification.tt2
@@ -32,7 +32,7 @@ Subject: [%"FYI: %1 List \"%2\" from %3 %4"|loc(type,list.name,who,gecos)|qencod
 [%|loc(who,gecos,list.name)%]WARNING: %1 %2 failed to unsubscribe from %3 because their address was not found in the list.
 You may help this person looking for similar email in subscriber list using the following link :[%END%]
 
-[% 'ticket' | url_abs([one_time_ticket]) %]
+[% 'search' | url_abs([list.name,who]) %]
  
 [% ELSIF type == 'erase_customizing' -%]
 Subject: [%"List \"%1\" customizations have been removed"|loc(list.name)|qencode%]

--- a/default/mail_tt2/moderate.tt2
+++ b/default/mail_tt2/moderate.tt2
@@ -15,7 +15,7 @@ Content-Disposition: inline
 
 [% IF method == 'md5' -%]
 [%|loc(mod_spool_size)%]%1 messages are awaiting moderation.[%END%] 
-[%|loc%]To view the messages, please click on the following URL:[%END%] <[% 'ticket' | url_abs([one_time_ticket]) %]>
+[%|loc%]To view the messages, please click on the following URL:[%END%] <[% 'modindex' | url_abs([list.name]) %]>
 
 [% IF request_topic -%][%|loc()%]This mailing list is configured to require topics; that's probably why this message went through the moderation process.[%END%]
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018, 2019 The Sympa Community. See the AUTHORS.md file at
-# the top-level directory of this distribution and at
+# Copyright 2017, 2018, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -54,7 +54,6 @@ use Sympa::Spindle::ProcessRequest;
 use Sympa::Spindle::ProcessTemplate;
 use Sympa::Spool::Auth;
 use Sympa::Template;
-use Sympa::Ticket;
 use Sympa::Tools::Data;
 use Sympa::Tools::Domains;
 use Sympa::Tools::File;
@@ -1731,11 +1730,13 @@ The key for naming message waiting for confirmation (or tagging) in auth spool, 
 ######################################################
 sub send_notify_to_owner {
     $log->syslog('debug2', '(%s, %s, %s)', @_);
-    my ($self, $operation, $param) = @_;
+    my $self      = shift;
+    my $operation = shift;
+    my $param     = shift;
 
-    my @rcpt  = $self->get_admins_email('receptive_owner');
-    my $robot = $self->{'domain'};
+    die 'bug in logic. Ask developer' unless defined $operation;
 
+    my @rcpt = $self->get_admins_email('receptive_owner');
     unless (@rcpt) {
         $log->syslog(
             'notice',
@@ -1744,41 +1745,13 @@ sub send_notify_to_owner {
         );
         @rcpt = Sympa::get_listmasters_email($self);
     }
-    unless (defined $operation) {
-        die 'missing incoming parameter "$operation"';
-    }
 
-    if (ref($param) eq 'HASH') {
-
+    if (ref $param eq 'HASH') {
         $param->{'auto_submitted'} = 'auto-generated';
         $param->{'to'}             = join(',', @rcpt);
         $param->{'type'}           = $operation;
 
-        if ($operation eq 'warn-signoff') {
-            foreach my $owner (@rcpt) {
-                $param->{'one_time_ticket'} = Sympa::Ticket::create(
-                    $owner,
-                    $robot,
-                    'search/'
-                        . Sympa::Tools::Text::encode_uri($self->{'name'})
-                        . '/'
-                        . Sympa::Tools::Text::encode_uri($param->{'who'}),
-                    $param->{'ip'}
-                );
-                unless (
-                    Sympa::send_file(
-                        $self, 'listowner_notification', [$owner], $param
-                    )
-                ) {
-                    $log->syslog(
-                        'notice',
-                        'Unable to send template "listowner_notification" to %s list owner %s',
-                        $self,
-                        $owner
-                    );
-                }
-            }
-        } elsif ($operation eq 'sigrequest' or $operation eq 'subrequest') {
+        if ($operation eq 'sigrequest' or $operation eq 'subrequest') {
             # Sends notifications by each so that auth links with owners'
             # addresses will be included.
             foreach my $owner (@rcpt) {
@@ -1801,7 +1774,7 @@ sub send_notify_to_owner {
             }
             unless (
                 Sympa::send_file(
-                    $self, 'listowner_notification', \@rcpt, $param
+                    $self, 'listowner_notification', [@rcpt], $param
                 )
             ) {
                 $log->syslog(
@@ -1812,8 +1785,7 @@ sub send_notify_to_owner {
                 return undef;
             }
         }
-
-    } elsif (ref($param) eq 'ARRAY') {
+    } elsif (ref $param eq 'ARRAY') {
 
         my $data = {
             'to'   => join(',', @rcpt),

--- a/src/lib/Sympa/Spindle/ToModeration.pm
+++ b/src/lib/Sympa/Spindle/ToModeration.pm
@@ -8,6 +8,9 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
+# Copyright 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,7 +35,6 @@ use Sympa;
 use Sympa::Log;
 use Sympa::Message::Template;
 use Sympa::Spool::Moderation;
-use Sympa::Ticket;
 
 use base qw(Sympa::Spindle);
 
@@ -184,27 +186,6 @@ sub _send_confirm_to_editor {
             }
         }
         $param->{'msg'} = $new_message;
-
-        # create a one time ticket that will be used as un md5 URL credential
-        unless (
-            $param->{'one_time_ticket'} = Sympa::Ticket::create(
-                $recipient,                    $list->{'domain'},
-                'modindex/' . $list->{'name'}, 'mail'
-            )
-        ) {
-            $log->syslog(
-                'notice',
-                'Unable to create one_time_ticket for %s, service modindex/%s',
-                $recipient,
-                $list->{'name'}
-            );
-        } else {
-            $log->syslog(
-                'debug',
-                'Ticket %s created',
-                $param->{'one_time_ticket'}
-            );
-        }
 
         # Ensure 1 second elapsed since last message.
         unless (


### PR DESCRIPTION
This may fix (partly) #156: This deprecates some of one-time ticket feature.

- `get_pending_list` action in notification about created/renamed lists for listmaster.
- `search` action in notification about failed unsubscriber for list owner.
- `modindex` action in notification about held messages for list moderator.

Now actions above need authentication on web interface.

On the other hand:

- ~~`family_signoff` action: Since this action has never been documented nor completely implemented, **it will be removed**.~~ `family_signoff` is documented.  It should be rewritten not to use one-time ticket.
- `sso_login/confirmemail` action ditto.
- `choosepasswd` action ditto.

