### PR TITLE
Deprecate one time ticket (2) (#156)

### DIFF
--- a/default/Makefile.am
+++ b/default/Makefile.am
@@ -86,6 +86,8 @@ nobase_default_DATA = \
 	scenari/d_read.private \
 	scenari/d_read.private-https \
 	scenari/d_read.public \
+	scenari/family_signoff.auth \
+	scenari/family_signoff.closed \
 	scenari/global_remind.listmaster \
 	scenari/info.open \
 	scenari/info.private \
@@ -216,8 +218,6 @@ nobase_default_DATA = \
 	web_tt2/editsubscriber.tt2 \
 	web_tt2/edit_template.tt2 \
 	web_tt2/error.tt2 \
-	web_tt2/family_signoff.tt2 \
-	web_tt2/family_signoff_request.tt2 \
 	web_tt2/footer.tt2 \
 	web_tt2/get_closed_lists.tt2 \
 	web_tt2/get_inactive_lists.tt2 \

--- a/default/mail_tt2/listmaster_notification.tt2
+++ b/default/mail_tt2/listmaster_notification.tt2
@@ -10,7 +10,7 @@ Subject: [%"List \"%1@%2\" creation request from %3"|loc(list.name,domain,email)
 [% 'info' | url_abs([list.name]) %]
 
 [%|loc%]To activate/delete this mailing list:[%END%]
-[% 'ticket' | url_abs([one_time_ticket]) %]
+[% 'get_pending_lists' | url_abs %]
 
 [%- ELSIF type == 'list_created' -%]
 [% PROCESS 'list_created.tt2' -%]
@@ -30,7 +30,7 @@ Subject: [%"List \"%1\" renaming"|loc(list.name)|qencode%]
 [% END %]
 
 [%|loc%]To activate/delete this mailing list:[%END%]
-[% 'ticket' | url_abs([one_time_ticket]) %]
+[% 'get_pending_lists' | url_abs %]
 
 [% ELSIF type == 'no_db' -%]
 Subject: [%"No database"|loc|qencode%]

--- a/default/mail_tt2/listowner_notification.tt2
+++ b/default/mail_tt2/listowner_notification.tt2
@@ -32,7 +32,7 @@ Subject: [%"FYI: %1 List \"%2\" from %3 %4"|loc(type,list.name,who,gecos)|qencod
 [%|loc(who,gecos,list.name)%]WARNING: %1 %2 failed to unsubscribe from %3 because their address was not found in the list.
 You may help this person looking for similar email in subscriber list using the following link :[%END%]
 
-[% 'ticket' | url_abs([one_time_ticket]) %]
+[% 'search' | url_abs([list.name,who]) %]
  
 [% ELSIF type == 'erase_customizing' -%]
 Subject: [%"List \"%1\" customizations have been removed"|loc(list.name)|qencode%]

--- a/default/mail_tt2/moderate.tt2
+++ b/default/mail_tt2/moderate.tt2
@@ -15,7 +15,7 @@ Content-Disposition: inline
 
 [% IF method == 'md5' -%]
 [%|loc(mod_spool_size)%]%1 messages are awaiting moderation.[%END%] 
-[%|loc%]To view the messages, please click on the following URL:[%END%] <[% 'ticket' | url_abs([one_time_ticket]) %]>
+[%|loc%]To view the messages, please click on the following URL:[%END%] <[% 'modindex' | url_abs([list.name]) %]>
 
 [% IF request_topic -%][%|loc()%]This mailing list is configured to require topics; that's probably why this message went through the moderation process.[%END%]
 

--- a/default/mail_tt2/request_auth.tt2
+++ b/default/mail_tt2/request_auth.tt2
@@ -1,6 +1,8 @@
 [%# request_auth.tt2 ~%]
 To: [% to %]
-[% IF conf.wwsympa_url && type == 'signoff' -%]
+[% IF conf.wwsympa_url && type == 'family_signoff' -%]
+Subject: [%"%1 / unsubscribing from family %2"|loc(conf.title,family.name)|qencode%]
+[%- ELSIF conf.wwsympa_url && type == 'signoff' -%]
 Subject: [%"%1 / unsubscribing from %2"|loc(conf.title,list.name)|qencode%]
 [%- ELSIF conf.wwsympa_url && type == 'subscribe' -%]
 Subject: [%"%1 / subscribing to %2"|loc(conf.title,list.name)|qencode%]
@@ -8,7 +10,10 @@ Subject: [%"%1 / subscribing to %2"|loc(conf.title,list.name)|qencode%]
 Subject: [%"AUTH ${keyauth} ${cmd}"|qencode%]
 [%- END %]
 
-[% IF type == 'signoff' -%]
+[% IF type == 'family_signoff' -%]
+[%|loc(family.name)-%]You requested that your e-mail address be removed from family '%1'.[%- END -%]
+
+[%- ELSIF type == 'signoff' -%]
 [%|loc(list.name)-%]You requested that your e-mail address be removed from list '%1'.[%- END -%]
 
 [%- ELSIF type == 'subscribe' -%]

--- a/default/mail_tt2/user_notification.tt2
+++ b/default/mail_tt2/user_notification.tt2
@@ -36,17 +36,6 @@ Subject: [%"Management of list %1"|loc(list.name)|qencode%]
 [%|loc%]Owner and moderator guide:[%END%] [% 'help' | url_abs(['admin.html']) %]
 [% END -%]
 
-[% ELSIF type == 'ticket_to_family_signoff' -%]
-Subject: [%"Unsubscribing from family %1"|loc(family)|qencode%]
-[% IF context == 'family_signoff'%]
-[%|loc(family,ip)%]Somebody (probably you) requested to unsubscribe you from family %1. This query was issued from the IP address %2.
-To confirm and be removed from all the lists of this family, please click the link below: [%END%] 
-[% ELSE %]
-[%|loc(family)%]You have requested to be removed from family %1. To confirm and be removed from all the lists of this family, please click the link below: [%END%] 
-[% END %]
-  [% 'ticket' | url_abs([one_time_ticket]) %]
-
-
 [% ELSIF type == 'hundred_percent_error' -%]
 Subject: [%"No valid recipient in list %1"|loc(list.name)|qencode%]
 

--- a/default/scenari/family_signoff.auth
+++ b/default/scenari/family_signoff.auth
@@ -1,0 +1,6 @@
+# family_signoff.auth
+title.gettext need authentication
+
+!equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
+true()                             smtp,dkim           -> request_auth([email])
+true()                             md5,smime           -> do_it

--- a/default/scenari/family_signoff.closed
+++ b/default/scenari/family_signoff.closed
@@ -1,0 +1,4 @@
+# family_signoff.closed
+title.gettext impossible
+
+true()  smtp,dkim,md5,smime -> reject(reason='unsub_closed')

--- a/default/web_tt2/confirm_action.tt2
+++ b/default/web_tt2/confirm_action.tt2
@@ -56,6 +56,8 @@
             [%|loc%]Add subscribers[%END%]
         [%~ ELSIF heldaction == 'del' ~%]
             [%|loc%]Delete selected email addresses[%END%]
+        [%~ ELSIF heldaction == 'family_signoff' ~%]
+            [%|loc%]Global unsubscription[%END%]
         [%~ ELSIF heldaction == 'move_user' ~%]
             [%|loc%]Changing user's email[%END%]
         [%~ ELSIF heldaction == 'remind' || heldaction == 'global_remind' ~%]
@@ -215,6 +217,16 @@
     <p>
         <strong>
             [%|loc(shared_doc.name)%]Do you really want to delete %1?[%END%]
+        </strong>
+    </p>
+[%~ ELSIF confirm_action == 'family_signoff' ~%]
+    <h2>
+        <i class="fa fa-check-circle"></i>
+        [%|loc%]Global unsubscription[%END%]
+    </h2>
+    <p>
+        <strong>
+            [%|loc(family)%]Do you really want to unsubscribe from the lists in family %1?[%END%]
         </strong>
     </p>
 [%~ ELSIF confirm_action == 'move_list' ~%]
@@ -387,6 +399,9 @@
         <input type="hidden" name="heldaction" value="[% heldaction %]" />
         <input type="hidden" name="listname" value="[% listname %]" />
         <input type="hidden" name="email" value="[% email %]" />
+        [% IF heldaction == 'family_signoff' ~%]
+            <input type="hidden" name="family" value="[% family %]" />
+        [%~ END %]
     [%~ ELSIF confirm_action == 'auth_add' ~%]
         [% FOREACH i = id ~%]
             <input type="hidden" name="id" value="[% i %]" />
@@ -453,6 +468,8 @@
         <input type="hidden" name="d_admin" value="[% d_admin %]" />
     [%~ ELSIF confirm_action == 'd_delete' ~%]
         <input type="hidden" name="path" value="[% shared_doc.paths.join("/") %]" />
+    [%~ ELSIF confirm_action == 'family_signoff' ~%]
+        <input type="hidden" name="email" value="[% email %]" />
     [%~ ELSIF confirm_action == 'move_user' ~%]
         <input type="hidden" name="current_email" value="[% current_email %]" />
         <input type="hidden" name="email" value="[% email %]" />
@@ -507,6 +524,7 @@
     # Confirmation common hidden fields
     #%]
     <input type="hidden" name="action" value="[% confirm_action %]" />
+    <input type="hidden" name="family" value="[% family %]" />
     <input type="hidden" name="list" value="[% list %]" />
     <input type="hidden" name="previous_action" value="[% previous_action %]" />
 

--- a/default/web_tt2/family_signoff.tt2
+++ b/default/web_tt2/family_signoff.tt2
@@ -1,6 +1,0 @@
-<!-- family_signoff.tt2 -->
-<h3>[%|loc%]Global unsubscription[% END %]</h3>
-<p>
-    [%|loc(signing_off_email,family)%]You successfully unsubscribed the address %1 from family %2.[% END %]
-</p>
-<!-- end family_signoff.tt2 -->

--- a/default/web_tt2/family_signoff_request.tt2
+++ b/default/web_tt2/family_signoff_request.tt2
@@ -1,9 +1,0 @@
-<!-- family_signoff_request.tt2 -->
-<h3>[%|loc%]Global unsubscription request[% END %]</h3>
-<p>
-    [%|loc(signing_off_email,family)%]You clicked a link to unsubscribe the address %1 from family %2.[% END %]
-</p>
-<p>
-    [%|loc(family)%]A confirmation request was just sent to this address. By clicking the link it contains, you will be completely unsubscribed from all the lists from family %1[% END %]
-</p>
-<!-- end family_signoff_request.tt2 -->

--- a/default/web_tt2/family_signoff_request2.tt2
+++ b/default/web_tt2/family_signoff_request2.tt2
@@ -1,6 +1,0 @@
-<!-- family_signoff_request2.tt2 -->
-<h3>[%|loc%]Global unsubscription[% END %]</h3>
-<p>
-    [%|loc(signing_off_email,family)%]You successfully unsubscribed the address %1 from family %2.[% END %]
-</p>
-<!-- end family_signoff_request2.tt2 -->

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -2727,7 +2727,7 @@ sub check_param_in {
         next unless $family;
 
         my $result =
-            Sympa::Scenario->new($family->{'robot'},
+            Sympa::Scenario->new($family->{'domain'},
             'automatic_list_creation')->authz(
             $param->{'auth_method'},
             {   'sender'             => $param->{'user'}{'email'},

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -9,8 +9,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018, 2019 The Sympa Community. See the AUTHORS.md file at
-# the top-level directory of this distribution and at
+# Copyright 2017, 2018, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -158,12 +158,12 @@ our %comm = (
     'subscribe'           => 'do_subscribe',
     #'multiple_subscribe'     => 'do_multiple_subscribe',
     #'subrequest'             => 'do_subrequest',
-    'subindex'               => 'do_subindex',
-    'suboptions'             => 'do_suboptions',
-    'signoff'                => 'do_signoff',
-    'auto_signoff'           => 'do_auto_signoff',
-    'family_signoff'         => 'do_family_signoff',
-    'family_signoff_request' => 'do_family_signoff_request',
+    'subindex'       => 'do_subindex',
+    'suboptions'     => 'do_suboptions',
+    'signoff'        => 'do_signoff',
+    'auto_signoff'   => 'do_auto_signoff',
+    'family_signoff' => 'do_family_signoff',
+    #'family_signoff_request' => 'do_family_signoff_request',
     #XXX'multiple_signoff'    => 'do_multiple_signoff',
     #'sigrequest' => 'do_sigrequest',
     'sigindex' => 'do_sigindex',
@@ -339,6 +339,7 @@ my %comm_aliases = (
     'change_email_request'    => 'move_user',
     'del_fromsig'             => 'auth_del',
     'dump'                    => 'export_member',
+    'family_signoff_request'  => 'family_signoff',
     'ignoresig'               => 'decl_del',
     'ignoresub'               => 'decl_add',
     'loginrequest'            => 'login',
@@ -412,12 +413,12 @@ our %action_args = (
     'show_cert'     => [],
     'subscribe'     => ['list'],
     #'subrequest' => ['list','email'],
-    'subindex'               => ['list'],
-    'decl_add'               => ['list'],
-    'signoff'                => ['list'],
-    'auto_signoff'           => ['list'],
-    'family_signoff'         => ['family', 'email'],
-    'family_signoff_request' => ['family', 'email'],
+    'subindex'       => ['list'],
+    'decl_add'       => ['list'],
+    'signoff'        => ['list'],
+    'auto_signoff'   => ['list'],
+    'family_signoff' => ['family'],
+    #'family_signoff_request' => ['family', 'email'],
     #'sigrequest'             => ['list',   'email'],
     'sigindex'           => ['list'],
     'decl_del'           => ['list'],
@@ -556,6 +557,7 @@ our %required_args = (
     'editfile'          => ['param.user.email'],
     'editsubscriber'    => ['param.list',       'param.user.email', 'email'],
     'export_member'        => ['param.list'],
+    'family_signoff'       => ['family', 'email'],
     'get_closed_lists'     => ['param.user.email'],
     'get_inactive_lists'   => ['param.user.email'],
     'get_latest_lists'     => ['param.user.email'],
@@ -5763,50 +5765,71 @@ sub do_auto_signoff {
     return $default_home;
 }
 
-sub do_family_signoff_request {
-    wwslog('info', '');
+# Became an alias of do_family_signoff().
+#sub do_family_signoff_request {
+
+sub do_family_signoff {
+    wwslog('info', '(%s, %s)', $in{'family'}, $in{'email'});
     # If the URL isn't valid, then go to home page. No need to guide the
     # user: this function is supposed to be used by clicking on autocreated
     # URL only.
-    return Conf::get_robot_conf($robot, 'default_home') unless $in{'email'};
+    my $default_home = Conf::get_robot_conf($robot, 'default_home');
+
+    my $scenario = Sympa::Scenario->new($robot, 'family_signoff')
+        or return undef;
+    return $default_home if $scenario->is_purely_closed;
+
+    return $default_home unless $in{'email'} and $in{'family'};    #FIXME
     my $family = Sympa::Family->new($in{'family'}, $robot);
-    return Conf::get_robot_conf($robot, 'default_home') unless $family;
+    return $default_home
+        unless $family;
+    my $email = Sympa::Tools::Text::canonic_email($in{'email'});
+    return $default_home
+        unless $email and Sympa::Tools::Text::valid_email($email);
 
-    Sympa::send_notify_to_user(
-        $robot,
-        'ticket_to_family_signoff',
-        $in{'email'},
-        {context => 'family_signoff', family => $family->{'name'}, ip => $ip}
-    ) or return undef;
+    $param->{'email'}  = $email;
+    $param->{'family'} = $family->{name};
 
-    $param->{'signing_off_email'} = $in{'email'};
-    $param->{'family'}            = $in{'family'};
-    # If OK, return the page displaying the information to the user.
-    return 1;
-}
+    # Action confirmed?
+    my $next_action = $session->confirm_action(
+        $in{'action'}, $in{'response_action'},
+        arg             => $email,
+        previous_action => $default_home
+    );
+    return $next_action unless $next_action eq '1';
 
-sub do_family_signoff {
-    wwslog('info', '');
-    $param->{'signing_off_email'} = $in{'email'};
-    $param->{'family'}            = $in{'family'};
-
-    unless ($in{'email'} eq $session->{'email'}) {
-        Sympa::WWW::Report::reject_report_web('user', 'cannot_do_signoff');
-        wwslog('err',
-            'User %s tried to unsubscribe address %s from family %s',
-            $session->{'email'}, $in{'email'}, $in{'family'});
+    my $spindle = Sympa::Spindle::ProcessRequest->new(
+        context          => $family,
+        action           => 'family_signoff',
+        sender           => 'nobody',
+        email            => $email,
+        scenario_context => {
+            sender      => 'nobody',
+            remote_host => $param->{'remote_host'},
+            remote_addr => $param->{'remote_addr'},
+        },
+    );
+    unless ($spindle and $spindle->spin) {
+        wwslog('err', 'Failed to delete user');
         return undef;
     }
 
-    my $family = Sympa::Family->new($param->{'family'}, $robot);
-    unless ($family
-        and $family->insert_delete_exclusion($in{'email'}, 'insert')) {
-        Sympa::WWW::Report::reject_report_web('user', 'cannot_do_signoff');
-        wwslog('err', 'Unsubscription of address %s from family %s failed',
-            $in{'email'}, $in{'family'});
-        return undef;
+    foreach my $report (@{$spindle->{stash} || []}) {
+        if ($report->[1] eq 'notice') {
+            Sympa::WWW::Report::notice_report_web(@{$report}[2, 3],
+                $param->{'action'});
+        } else {
+            Sympa::WWW::Report::reject_report_web(@{$report}[1 .. 3],
+                $param->{action});
+        }
     }
-    return 1;
+    unless (@{$spindle->{stash} || []}) {
+        Sympa::WWW::Report::notice_report_web('performed_soon', {},
+            $param->{'action'});
+        web_db_log({'parameters' => $in{'email'}, 'status' => 'success'});
+    }
+
+    return $default_home;
 }
 
 # Unsubcribes a user from a list

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -92,6 +92,7 @@ nobase_modules_DATA = \
 	Sympa/Request/Handler/decl.pm \
 	Sympa/Request/Handler/del.pm \
 	Sympa/Request/Handler/distribute.pm \
+	Sympa/Request/Handler/family_signoff.pm \
 	Sympa/Request/Handler/finished.pm \
 	Sympa/Request/Handler/get.pm \
 	Sympa/Request/Handler/global_remind.pm \

--- a/src/lib/Sympa.pm
+++ b/src/lib/Sympa.pm
@@ -174,7 +174,7 @@ sub _get_search_path {
         }
     } elsif (ref $that and ref $that eq 'Sympa::Family') {
         my $path_family;
-        @search_path = _get_search_path($that->{'robot'}, @_);
+        @search_path = _get_search_path($that->{'domain'}, @_);
 
         if ($subdir) {
             $path_family = $that->{'dir'} . '/' . $subdir;
@@ -616,7 +616,7 @@ sub get_address {
         }
     } elsif (ref $that eq 'Sympa::Family') {
         # robot address, for convenience.
-        return Sympa::get_address($that->{'robot'}, $type);
+        return Sympa::get_address($that->{'domain'}, $type);
     } else {
         unless ($type) {
             return Conf::get_robot_conf($that, 'email') . '@'
@@ -654,7 +654,7 @@ sub get_listmasters_email {
     if (ref $that eq 'Sympa::List') {
         $listmaster = Conf::get_robot_conf($that->{'domain'}, 'listmaster');
     } elsif (ref $that eq 'Sympa::Family') {
-        $listmaster = Conf::get_robot_conf($that->{'robot'}, 'listmaster');
+        $listmaster = Conf::get_robot_conf($that->{'domain'}, 'listmaster');
     } elsif (not ref($that) and $that and $that ne '*') {
         $listmaster = Conf::get_robot_conf($that, 'listmaster');
     } else {

--- a/src/lib/Sympa.pm
+++ b/src/lib/Sympa.pm
@@ -45,7 +45,6 @@ use Sympa::Language;
 use Sympa::Log;
 use Sympa::Regexps;
 use Sympa::Spindle::ProcessTemplate;
-use Sympa::Ticket;
 use Sympa::Tools::Text;
 
 my $log = Sympa::Log->instance;
@@ -489,14 +488,6 @@ sub send_notify_to_user {
     if (ref $param eq "HASH") {
         $param->{'to'}   = $user;
         $param->{'type'} = $operation;
-
-        if ($operation eq 'ticket_to_family_signoff') {
-            $param->{one_time_ticket} =
-                Sympa::Ticket::create($user, $robot_id,
-                'family_signoff/' . $param->{family} . '/' . $user,
-                $param->{ip})
-                or return undef;
-        }
 
         unless (Sympa::send_file($that, 'user_notification', $user, $param)) {
             $log->syslog('notice',

--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018, 2019 The Sympa Community. See the AUTHORS.md file at
-# the top-level directory of this distribution and at
+# Copyright 2017, 2018, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -967,6 +967,13 @@ our @params = (
         'split_char' => ',',
         'default' =>
             'message_header,message_header.mime,message_footer,message_footer.mime,info',
+        'vhost' => '1',
+    },
+    {
+        'name' => 'family_signoff',
+        'gettext_id' => 'Global unsubscription',
+        'default' => 'auth',    # Compat. to <=6.2.52
+        'scenario' => 1,
         'vhost' => '1',
     },
 

--- a/src/lib/Sympa/Family.pm
+++ b/src/lib/Sympa/Family.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018, 2019 The Sympa Community. See the AUTHORS.md file
-# at the top-level directory of this distribution and at
+# Copyright 2017, 2018, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -103,7 +103,7 @@ sub new {
         $self = $list_of_families{$robot}{$name};
         ###########
         # the robot can be different from latest new ...
-        if ($robot eq $self->{'robot'}) {
+        if ($robot eq $self->{'domain'}) {
             return $self;
         } else {
             $self = {};
@@ -123,9 +123,10 @@ sub new {
 
     ## Lowercase the family name.
     $name =~ tr/A-Z/a-z/;
-    $self->{'name'} = $name;
+    $self->{'name'}   = $name;
+    $self->{'domain'} = $robot;
 
-    $self->{'robot'} = $robot;
+    $self->{'robot'} = $self->{'domain'};    # Compat.<=6.2.52
 
     ## Adding configuration related to automatic lists.
     my $all_families_config =
@@ -354,10 +355,11 @@ sub get_uncompellable_param {
 # finally in the distrib.
 # OUT : -directory name or undef if the directory does not exist
 sub _get_directory {
+    $log->syslog('debug3', '(%s)', @_);
     my $self  = shift;
-    my $robot = $self->{'robot'};
+
     my $name  = $self->{'name'};
-    $log->syslog('debug3', '(%s)', $name);
+    my $robot = $self->{'domain'};
 
     my @try = @{Sympa::get_search_path($robot, subdir => 'families')};
 
@@ -471,7 +473,7 @@ sub _load_param_constraint_conf {
         }
     }
     if ($error) {
-        Sympa::send_notify_to_listmaster($self->{'robot'},
+        Sympa::send_notify_to_listmaster($self->{'domain'},
             'param_constraint_conf_error', [$file]);
     }
     close FILE;
@@ -501,7 +503,7 @@ sub insert_delete_exclusion {
     my $action = shift;
 
     my $name     = $self->{'name'};
-    my $robot_id = $self->{'robot'};
+    my $robot_id = $self->{'domain'};
 
     if ($action eq 'insert') {
         ##FXIME: Check if user belong to any list of family
@@ -539,8 +541,8 @@ sub insert_delete_exclusion {
 sub get_id {
     my $self = shift;
 
-    return '' unless $self->{'name'} and $self->{'robot'};
-    return $self->{'name'} . '@' . $self->{'robot'};
+    return '' unless $self->{'name'} and $self->{'domain'};
+    return sprintf '%s@%s', $self->{'name'}, $self->{'domain'};
 }
 
 1;
@@ -757,9 +759,12 @@ Gets unique identifier of instance.
 
 The name of family.
 
-=item {robot}
+=item {domain}
 
-The robot the family belongs to.
+The mail domain (a.k.a. "robot") the family belongs to.
+
+B<Note>:
+On Sympa 6.2.52 or earlier, C<{robot}> was used.
 
 =item {dir}
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -5108,7 +5108,7 @@ sub get_lists {
     my (@lists, @robot_ids, $family_name);
 
     if (ref $that and ref $that eq 'Sympa::Family') {
-        @robot_ids   = ($that->{'robot'});
+        @robot_ids   = ($that->{'domain'});
         $family_name = $that->{'name'};
     } elsif (!ref $that and $that and $that ne '*') {
         @robot_ids = ($that);

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018, 2019 The Sympa Community. See the AUTHORS.md file at
-# the top-level directory of this distribution and at
+# Copyright 2017, 2018, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -54,7 +54,6 @@ use Sympa::Spindle::ProcessRequest;
 use Sympa::Spindle::ProcessTemplate;
 use Sympa::Spool::Auth;
 use Sympa::Template;
-use Sympa::Ticket;
 use Sympa::Tools::Data;
 use Sympa::Tools::Domains;
 use Sympa::Tools::File;
@@ -1731,11 +1730,13 @@ The key for naming message waiting for confirmation (or tagging) in auth spool, 
 ######################################################
 sub send_notify_to_owner {
     $log->syslog('debug2', '(%s, %s, %s)', @_);
-    my ($self, $operation, $param) = @_;
+    my $self      = shift;
+    my $operation = shift;
+    my $param     = shift;
 
-    my @rcpt  = $self->get_admins_email('receptive_owner');
-    my $robot = $self->{'domain'};
+    die 'bug in logic. Ask developer' unless defined $operation;
 
+    my @rcpt = $self->get_admins_email('receptive_owner');
     unless (@rcpt) {
         $log->syslog(
             'notice',
@@ -1744,41 +1745,13 @@ sub send_notify_to_owner {
         );
         @rcpt = Sympa::get_listmasters_email($self);
     }
-    unless (defined $operation) {
-        die 'missing incoming parameter "$operation"';
-    }
 
-    if (ref($param) eq 'HASH') {
-
+    if (ref $param eq 'HASH') {
         $param->{'auto_submitted'} = 'auto-generated';
         $param->{'to'}             = join(',', @rcpt);
         $param->{'type'}           = $operation;
 
-        if ($operation eq 'warn-signoff') {
-            foreach my $owner (@rcpt) {
-                $param->{'one_time_ticket'} = Sympa::Ticket::create(
-                    $owner,
-                    $robot,
-                    'search/'
-                        . Sympa::Tools::Text::encode_uri($self->{'name'})
-                        . '/'
-                        . Sympa::Tools::Text::encode_uri($param->{'who'}),
-                    $param->{'ip'}
-                );
-                unless (
-                    Sympa::send_file(
-                        $self, 'listowner_notification', [$owner], $param
-                    )
-                ) {
-                    $log->syslog(
-                        'notice',
-                        'Unable to send template "listowner_notification" to %s list owner %s',
-                        $self,
-                        $owner
-                    );
-                }
-            }
-        } elsif ($operation eq 'sigrequest' or $operation eq 'subrequest') {
+        if ($operation eq 'sigrequest' or $operation eq 'subrequest') {
             # Sends notifications by each so that auth links with owners'
             # addresses will be included.
             foreach my $owner (@rcpt) {
@@ -1801,7 +1774,7 @@ sub send_notify_to_owner {
             }
             unless (
                 Sympa::send_file(
-                    $self, 'listowner_notification', \@rcpt, $param
+                    $self, 'listowner_notification', [@rcpt], $param
                 )
             ) {
                 $log->syslog(
@@ -1812,8 +1785,7 @@ sub send_notify_to_owner {
                 return undef;
             }
         }
-
-    } elsif (ref($param) eq 'ARRAY') {
+    } elsif (ref $param eq 'ARRAY') {
 
         my $data = {
             'to'   => join(',', @rcpt),

--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018, 2019 The Sympa Community. See the AUTHORS.md file at
-# the top-level directory of this distribution and at
+# Copyright 2017, 2018, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -648,6 +648,8 @@ sub check_dkim_signature {
 
     my $robot_id =
         (ref $self->{context} eq 'Sympa::List')
+        ? $self->{context}->{'domain'}
+        : (ref $self->{context} eq 'Sympa::Family')
         ? $self->{context}->{'domain'}
         : $self->{context};
 
@@ -1569,7 +1571,8 @@ sub personalize_text {
     my $robot_id = $list->{'domain'};
 
     $data->{'listname'}    = $listname;
-    $data->{'robot'}       = $robot_id;
+    $data->{'domain'}      = $robot_id;
+    $data->{'robot'}       = $data->{'domain'};    # Compat.<=6.2.52.
     $data->{'wwsympa_url'} = Conf::get_robot_conf($robot_id, 'wwsympa_url');
 
     my $message_output;

--- a/src/lib/Sympa/Message/Template.pm
+++ b/src/lib/Sympa/Message/Template.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2018 The Sympa Community. See the AUTHORS.md file at the
-# top-level directory of this distribution and at
+# Copyright 2018, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -71,9 +71,9 @@ sub new {
         $list     = $that;
         $domain   = $that->{'domain'};
     } elsif (ref $that eq 'Sympa::Family') {
-        $robot_id = $that->{'robot'};    #FIXME
+        $robot_id = $that->{'domain'};
         $family   = $that;
-        $domain   = $that->{'robot'};
+        $domain   = $that->{'domain'};
     } elsif ($that and $that ne '*') {
         $robot_id = $that;
         $domain = Conf::get_robot_conf($that, 'domain');
@@ -260,7 +260,7 @@ sub _new_from_template {
         $robot_id = $list->{'domain'};
     } elsif (ref $that eq 'Sympa::Family') {
         $family   = $that;
-        $robot_id = $family->{'robot'};
+        $robot_id = $family->{'domain'};
     } elsif ($that and $that ne '*') {
         $robot_id = $that;
     } else {

--- a/src/lib/Sympa/Message/Template.pm
+++ b/src/lib/Sympa/Message/Template.pm
@@ -65,11 +65,15 @@ sub new {
     die 'Parameter $tpl is not defined'
         unless defined $tpl and length $tpl;
 
-    my ($list, $robot_id, $domain);
+    my ($list, $family, $robot_id, $domain);
     if (ref $that eq 'Sympa::List') {
         $robot_id = $that->{'domain'};
         $list     = $that;
         $domain   = $that->{'domain'};
+    } elsif (ref $that eq 'Sympa::Family') {
+        $robot_id = $that->{'robot'};    #FIXME
+        $family   = $that;
+        $domain   = $that->{'robot'};
     } elsif ($that and $that ne '*') {
         $robot_id = $that;
         $domain = Conf::get_robot_conf($that, 'domain');
@@ -170,6 +174,10 @@ sub new {
         # Compat. < 6.2.32
         $data->{'list'}{'domain'} = $list->{'domain'};
         $data->{'list'}{'host'}   = $list->{'domain'};
+    } elsif ($family) {
+        $data->{family} = {
+            name => $family->{'name'},
+        };
     }
 
     # Sign mode
@@ -246,10 +254,13 @@ sub _new_from_template {
     my $data     = shift;
     my %options  = @_;
 
-    my ($list, $robot_id);
+    my ($list, $family, $robot_id);
     if (ref $that eq 'Sympa::List') {
         $list     = $that;
         $robot_id = $list->{'domain'};
+    } elsif (ref $that eq 'Sympa::Family') {
+        $family   = $that;
+        $robot_id = $family->{'robot'};
     } elsif ($that and $that ne '*') {
         $robot_id = $that;
     } else {

--- a/src/lib/Sympa/Request.pm
+++ b/src/lib/Sympa/Request.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2019 The Sympa Community. See the AUTHORS.md file at
-# the top-level directory of this distribution and at
+# Copyright 2017, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -144,7 +144,10 @@ sub cmd_line {
     if (ref $context eq 'Sympa::List') {
         @attrs{qw(localpart domainpart)} =
             split /\@/, Sympa::get_address($context);
-    } else {    #FIXME:handle Sympa::Family too
+    } elsif (ref $context eq 'Sympa::Family') {
+        #FIXME:family name
+        $attrs{domainpart} = $context->{'domain'};
+    } else {
         $attrs{domainpart} = $context;
     }
     return sprintf $cmd_format,
@@ -161,7 +164,9 @@ sub dup {
 
         unless (Scalar::Util::blessed($val)) {
             $clone->{$key} = Sympa::Tools::Data::dup_var($val);
-        } elsif ($val->can('dup') and !$val->isa('Sympa::List')) {
+        } elsif ($val->can('dup')
+            and !$val->isa('Sympa::List')
+            and !$val->isa('Sympa::Family')) {
             $clone->{$key} = $val->dup;
         } else {
             $clone->{$key} = $val;

--- a/src/lib/Sympa/Request.pm
+++ b/src/lib/Sympa/Request.pm
@@ -144,7 +144,7 @@ sub cmd_line {
     if (ref $context eq 'Sympa::List') {
         @attrs{qw(localpart domainpart)} =
             split /\@/, Sympa::get_address($context);
-    } else {
+    } else {    #FIXME:handle Sympa::Family too
         $attrs{domainpart} = $context;
     }
     return sprintf $cmd_format,

--- a/src/lib/Sympa/Request/Handler/create_automatic_list.pm
+++ b/src/lib/Sympa/Request/Handler/create_automatic_list.pm
@@ -4,8 +4,8 @@
 
 # Sympa - SYsteme de Multi-Postage Automatique
 #
-# Copyright 2017, 2018, 2019 The Sympa Community. See the AUTHORS.md file
-# at the top-level directory of this distribution and at
+# Copyright 2017, 2018, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -53,7 +53,7 @@ sub _twist {
     my $family         = $request->{context};
     my $param          = $request->{parameters};
     my $abort_on_error = $request->{abort_on_error};
-    my $robot_id       = $family->{'robot'};
+    my $robot_id       = $family->{'domain'};
 
     my $path;
 

--- a/src/lib/Sympa/Request/Handler/family_signoff.pm
+++ b/src/lib/Sympa/Request/Handler/family_signoff.pm
@@ -1,0 +1,88 @@
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+# $Id$
+
+# Sympa - SYsteme de Multi-Postage Automatique
+#
+# Copyright 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package Sympa::Request::Handler::family_signoff;
+
+use strict;
+use warnings;
+
+use Sympa::Language;
+use Sympa::Log;
+
+use base qw(Sympa::Request::Handler);
+
+my $language = Sympa::Language->instance;
+my $log      = Sympa::Log->instance;
+
+use constant _action_regexp   => qr'reject|request_auth|do_it'i;
+use constant _action_scenario => 'family_signoff';
+use constant _context_class   => 'Sympa::Family';
+
+sub _twist {
+    my $self    = shift;
+    my $request = shift;
+
+    my $family = $request->{context};
+    my $sender = $request->{sender};
+    my $email  = $request->{email};
+
+    unless ($email eq $sender) {
+        $self->add_stash($request, 'user', 'user_not_subscriber');
+        $log->syslog('err',
+            'User %s tried to unsubscribe address %s from family %s',
+            $sender, $email, $family);
+        return undef;
+    }
+
+    unless ($family->insert_delete_exclusion($email, 'insert')) {
+        $self->add_stash($request, 'user', 'cannot_do_signoff');
+        $log->syslog('err',
+            'Unsubscription of address %s from family %s failed',
+            $email, $family);
+        return undef;
+    }
+    return 1;
+}
+
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Sympa::Request::Handler::family_signoff - family 'signoff' request handler
+
+=head1 DESCRIPTION
+
+Unsubscribes from all the lists belonging to specified family.
+
+=head1 SEE ALSO
+
+L<Sympa::Request::Handler>.
+
+=head1 HISTORY
+
+L<Sympa::Request::Handler::family_signoff> appeared on Sympa 6.2.53b.
+
+=cut

--- a/src/lib/Sympa/Request/Handler/update_automatic_list.pm
+++ b/src/lib/Sympa/Request/Handler/update_automatic_list.pm
@@ -4,8 +4,8 @@
 
 # Sympa - SYsteme de Multi-Postage Automatique
 #
-# Copyright 2018, 2019 The Sympa Community. See the AUTHORS.md file
-# at the top-level directory of this distribution and at
+# Copyright 2018, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -51,7 +51,7 @@ sub _twist {
     my $family   = $request->{context};
     my $list     = $request->{current_list};
     my $param    = $request->{parameters};
-    my $robot_id = $family->{'robot'};
+    my $robot_id = $family->{'domain'};
 
     my $path;
 
@@ -70,7 +70,7 @@ sub _twist {
     # getting list
     if ($list and $param->{listname}) {
         unless ($list->get_id eq
-            sprintf('%s@%s', lc $param->{listname}, $family->{'robot'})) {
+            sprintf('%s@%s', lc $param->{listname}, $family->{'domain'})) {
             $log->syslog('err', 'The list %s and list name %s mismatch',
                 $list, $param->{listname});
             $self->add_stash($request, 'user', 'XXX');
@@ -79,7 +79,7 @@ sub _twist {
     } elsif (
         $list
         or ($list = Sympa::List->new(
-                $param->{listname}, $family->{'robot'},
+                $param->{listname}, $family->{'domain'},
                 {just_try => 1, no_check_family => 1}
             )
         )

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -77,6 +77,7 @@ my %list_ppath_maps = (
 #FIXME: should be taken from Sympa::ConfDef.
 my %domain_ppath_maps = (
     create_list             => 'create_list',
+    family_signoff          => 'family_signoff',
     global_remind           => 'global_remind',
     move_user               => 'move_user',
     automatic_list_creation => 'automatic_list_creation',

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018, 2019 The Sympa Community. See the AUTHORS.md file
-# at the top-level directory of this distribution and at
+# Copyright 2017, 2018, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/src/lib/Sympa/Spindle/ProcessAutomatic.pm
+++ b/src/lib/Sympa/Spindle/ProcessAutomatic.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2019 The Sympa Community. See the AUTHORS.md file at
-# the top-level directory of this distribution and at
+# Copyright 2017, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -264,13 +264,13 @@ sub _twist {
             return undef;
         } elsif (
             not(    $spindle_req->success
-                and $list = Sympa::List->new($listname, $dyn_family->{robot}))
+                and $list = Sympa::List->new($listname, $dyn_family->{'domain'}, {just_try => 1}))
         ) {
             $log->syslog('err',
                 'Unable to create list %s. Message %s ignored',
                 $listname, $message);
             Sympa::send_notify_to_listmaster(
-                $dyn_family->{'robot'},
+                $dyn_family->{'domain'},
                 'automatic_list_creation_failed',
                 {   'listname' => $listname,
                     'family'   => $dyn_list_family,
@@ -280,10 +280,10 @@ sub _twist {
             );
             Sympa::send_dsn($robot, $message, {}, '5.3.5');
             $log->db_log(
-                'robot'        => $dyn_family->{'robot'},
+                'robot'        => $dyn_family->{'domain'},
                 'list'         => $listname,
                 'action'       => 'process_message',
-                'parameters'   => $msg_id . "," . $dyn_family->{'robot'},
+                'parameters'   => $msg_id . "," . $dyn_family->{'domain'},
                 'target_email' => '',
                 'msg_id'       => $msg_id,
                 'status'       => 'error',

--- a/src/lib/Sympa/Spindle/ToModeration.pm
+++ b/src/lib/Sympa/Spindle/ToModeration.pm
@@ -8,6 +8,9 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
+# Copyright 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,7 +35,6 @@ use Sympa;
 use Sympa::Log;
 use Sympa::Message::Template;
 use Sympa::Spool::Moderation;
-use Sympa::Ticket;
 
 use base qw(Sympa::Spindle);
 
@@ -184,27 +186,6 @@ sub _send_confirm_to_editor {
             }
         }
         $param->{'msg'} = $new_message;
-
-        # create a one time ticket that will be used as un md5 URL credential
-        unless (
-            $param->{'one_time_ticket'} = Sympa::Ticket::create(
-                $recipient,                    $list->{'domain'},
-                'modindex/' . $list->{'name'}, 'mail'
-            )
-        ) {
-            $log->syslog(
-                'notice',
-                'Unable to create one_time_ticket for %s, service modindex/%s',
-                $recipient,
-                $list->{'name'}
-            );
-        } else {
-            $log->syslog(
-                'debug',
-                'Ticket %s created',
-                $param->{'one_time_ticket'}
-            );
-        }
 
         # Ensure 1 second elapsed since last message.
         unless (

--- a/src/lib/Sympa/Spool.pm
+++ b/src/lib/Sympa/Spool.pm
@@ -39,6 +39,7 @@ use Time::HiRes qw();
 use Sympa;
 use Conf;
 use Sympa::Constants;
+use Sympa::Family;
 use Sympa::List;
 use Sympa::LockedFile;
 use Sympa::Log;

--- a/src/lib/Sympa/Spool.pm
+++ b/src/lib/Sympa/Spool.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017 The Sympa Community. See the AUTHORS.md file at the top-level
-# directory of this distribution and at
+# Copyright 2017, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -401,17 +401,23 @@ sub unmarshal_metadata {
         } @{$marshal_keys}
     };
 
-    my ($robot_id, $listname, $type, $list, $priority);
+    my ($robot_id, $family, $listname, $type, $list, $priority);
 
     $robot_id = lc($data->{'domainpart'})
         if defined $data->{'domainpart'}
         and length $data->{'domainpart'}
         and Conf::valid_robot($data->{'domainpart'}, {just_try => 1});
-    ($listname, $type) =
-        Sympa::Spool::split_listname($robot_id || '*', $data->{'localpart'});
 
-    $list = Sympa::List->new($listname, $robot_id || '*', {'just_try' => 1})
-        if defined $listname;
+    if ($data->{localpart} and 0 == index $data->{localpart}, '@') {
+        my $familyname = substr $data->{localpart}, 1;
+        $family = Sympa::Family->new($familyname, $robot_id || '*');
+    } else {
+        ($listname, $type) = Sympa::Spool::split_listname($robot_id || '*',
+            $data->{'localpart'});
+        $list =
+            Sympa::List->new($listname, $robot_id || '*', {'just_try' => 1})
+            if defined $listname;
+    }
 
     ## Get priority
     #FIXME: is this always needed?
@@ -433,7 +439,7 @@ sub unmarshal_metadata {
         $priority = Conf::get_robot_conf($robot_id, 'default_list_priority');
     }
 
-    $data->{context} = $list || $robot_id || '*';
+    $data->{context} = $list || $family || $robot_id || '*';
     $data->{'listname'} = $listname if $listname;
     $data->{'listtype'} = $type     if defined $type;
     $data->{'priority'} = $priority if defined $priority;
@@ -450,15 +456,19 @@ sub marshal_metadata {
     my $marshal_keys   = shift;
     my %options        = @_;
 
-    #FIXME: Currently only "sympa@DOMAIN" and "LISTNAME(-TYPE)@DOMAIN" are
+    # "sympa@DOMAIN", "@FAMILYNAME@DOMAIN" and "LISTNAME(-TYPE)@DOMAIN" are
     # supported.
     my ($localpart, $domainpart);
-    if (ref $message->{context} eq 'Sympa::List') {
-        ($localpart) = split /\@/,
-            Sympa::get_address($message->{context}, $message->{listtype});
-        $domainpart = $message->{context}->{'domain'};
+    my $that = $message->{context};
+    if (ref $that eq 'Sympa::List') {
+        ($localpart, $domainpart) = split /\@/,
+            Sympa::get_address($that, $message->{listtype});
+    } elsif (ref $that eq 'Sympa::Family') {
+        my $familyname;
+        ($familyname, $domainpart) = split /\@/, $that->get_id;
+        $localpart = sprintf '@%s', $familyname;
     } else {
-        my $robot_id = $message->{context} || '*';
+        my $robot_id = $that || '*';
         $localpart  = Conf::get_robot_conf($robot_id, 'email');
         $domainpart = Conf::get_robot_conf($robot_id, 'domain');
     }
@@ -963,8 +973,8 @@ encodes the metadata
   domainpart => 'domain.name',
   date       => 143599229,
 
-Metadata always includes information of B<context>: List, Robot or
-Site.  For example:
+Metadata always includes information of B<context>: List, Robot, Site
+(or Family).  For example:
 
 - Message in incoming spool bound for E<lt>listname@domain.nameE<gt>:
 
@@ -982,6 +992,27 @@ Context is determined when the generator class is instantiated, and
 generally never changed through lifetime of instance.
 Thus, constructor of generator class should take context object as an
 argument.
+
+C<localpart> is encoded in a bit complex manner.
+
+=over
+
+=item *
+
+If the context is Site or Robot, it is a value of C<email> parameter,
+typically "C<sympa>".
+
+=item *
+
+If the context is Family, it is encoded as C<@I<family name>>.
+This encoding was added on Sympa 6.2.53b.
+
+=item *
+
+If the context is List, it is encoded as local part of list address
+according to listtype (See also L<Sympa/get_address>).
+
+=back
 
 =head1 CONFIGURATION PARAMETERS
 

--- a/src/lib/Sympa/Spool/Auth.pm
+++ b/src/lib/Sympa/Spool/Auth.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017 The Sympa Community. See the AUTHORS.md file at the top-level
-# directory of this distribution and at
+# Copyright 2017, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -69,7 +69,7 @@ use constant _marshal_format => '%ld,%s@%s_%s,%s,%s';
 use constant _marshal_keys =>
     [qw(date localpart domainpart KEYAUTH email action)];
 use constant _marshal_regexp =>
-    qr{\A(\d+),([^\s\@]+)\@([-.\w]+)_([\da-f]+),([^\s,]*),(\w+)\z};
+    qr{\A(\d+),(\@?[^\s\@]+)\@([-.\w]+)_([\da-f]+),([^\s,]*),(\w+)\z};
 use constant _store_key => 'keyauth';
 
 1;
@@ -110,8 +110,11 @@ See also L<Sympa::Spool/"Public methods">.
 
 =over
 
-=item new ( [ context =E<gt> $list ], [ action =E<gt> $action ],
+=item new ( [ context =E<gt> $that ], [ action =E<gt> $action ],
 [ keyauth =E<gt> $id ], [ email =E<gt> $email ])
+
+Context may be either instance of L<Sympa::List> or L<Sympa::Family>,
+or robot.
 
 =item next ( [ no_lock =E<gt> 1 ] )
 

--- a/src/lib/Sympa/Spool/Outgoing.pm
+++ b/src/lib/Sympa/Spool/Outgoing.pm
@@ -131,7 +131,7 @@ sub next {
         $metadata = Sympa::Spool::unmarshal_metadata(
             $self->{pct_directory},
             $marshalled,
-            qr{\A(\w+)\.(\w+)\.(\d+)\.(\d+\.\d+)\.([^\s\@]*)\@([\w\.\-*]*)_(\w+),(\d+),(\d+)/(\w+)\z},
+            qr{\A(\w+)\.(\w+)\.(\d+)\.(\d+\.\d+)\.(\@?[^\s\@]*)\@([\w\.\-*]*)_(\w+),(\d+),(\d+)/(\w+)\z},
             [   qw(priority packet_priority date time localpart domainpart tag pid rand serial)
             ]
         );

--- a/src/lib/Sympa/Spool/Outgoing.pm
+++ b/src/lib/Sympa/Spool/Outgoing.pm
@@ -4,8 +4,8 @@
 
 # Sympa - SYsteme de Multi-Postage Automatique
 #
-# Copyright 2019 The Sympa Community. See the AUTHORS.md file at
-# the top-level directory of this distribution and at
+# Copyright 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/src/lib/Sympa/Template.pm
+++ b/src/lib/Sympa/Template.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018 The Sympa Community. See the AUTHORS.md file at the
-# top-level directory of this distribution and at
+# Copyright 2017, 2018, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -309,7 +309,7 @@ sub _get_option_description {
         if (ref $that eq 'Sympa::List') {
             $robot_id = $that->{'domain'};
         } elsif (ref $that eq 'Sympa::Family') {
-            $robot_id = $that->{'robot'};
+            $robot_id = $that->{'domain'};
         } elsif ($that and $that ne '*') {
             $robot_id = $that;
         } else {
@@ -371,7 +371,7 @@ sub _url_func {
     my $that = $self->{context};
     my $robot_id =
           (ref $that eq 'Sympa::List') ? $that->{'domain'}
-        : (ref $that eq 'Sympa::Family') ? $that->{'robot'}
+        : (ref $that eq 'Sympa::Family') ? $that->{'domain'}
         : ($that and $that ne '*') ? $that
         :                            '*';
 

--- a/src/lib/Sympa/Template.pm
+++ b/src/lib/Sympa/Template.pm
@@ -308,6 +308,8 @@ sub _get_option_description {
         my $robot_id;
         if (ref $that eq 'Sympa::List') {
             $robot_id = $that->{'domain'};
+        } elsif (ref $that eq 'Sympa::Family') {
+            $robot_id = $that->{'robot'};
         } elsif ($that and $that ne '*') {
             $robot_id = $that;
         } else {
@@ -369,6 +371,7 @@ sub _url_func {
     my $that = $self->{context};
     my $robot_id =
           (ref $that eq 'Sympa::List') ? $that->{'domain'}
+        : (ref $that eq 'Sympa::Family') ? $that->{'robot'}
         : ($that and $that ne '*') ? $that
         :                            '*';
 

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -9,8 +9,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018, 2019 The Sympa Community. See the AUTHORS.md file
-# at the top-level directory of this distribution and at
+# Copyright 2017, 2018, 2019, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -964,7 +964,7 @@ elsif ($main::options{'close_family'}) {
         my $listname = $list->{'name'};
 
         my $spindle = Sympa::Spindle::ProcessRequest->new(
-            context          => $family->{'robot'},
+            context          => $family->{'domain'},
             action           => 'close_list',
             current_list     => $list,
             sender           => Sympa::get_address($family, 'listmaster'),
@@ -1284,7 +1284,7 @@ sub instantiate {
     # EACH FAMILY LIST
     foreach my $listname (@$list_to_generate) {
         my $path = $family->{'dir'} . '/' . $listname . '.xml';
-        my $list = Sympa::List->new($listname, $family->{'robot'},
+        my $list = Sympa::List->new($listname, $family->{'domain'},
             {no_check_family => 1});
 
         if ($list) {
@@ -1322,7 +1322,7 @@ sub instantiate {
                 next;
             }
 
-            $list = Sympa::List->new($listname, $family->{'robot'},
+            $list = Sympa::List->new($listname, $family->{'domain'},
                 {no_check_family => 1});
 
             ## aliases
@@ -1355,7 +1355,7 @@ sub instantiate {
     foreach my $l (keys %{$previous_family_lists}) {
         my $list;
         unless ($list =
-            Sympa::List->new($l, $family->{'robot'}, {no_check_family => 1}))
+            Sympa::List->new($l, $family->{'domain'}, {no_check_family => 1}))
         {
             push(@{$family->{'errors'}{'previous_list'}}, $l);
             next;
@@ -1374,7 +1374,7 @@ sub instantiate {
         }
         if ($options{close_unknown} or $answer eq 'y') {
             my $spindle = Sympa::Spindle::ProcessRequest->new(
-                context          => $family->{'robot'},
+                context          => $family->{'domain'},
                 action           => 'close_list',
                 current_list     => $list,
                 sender           => Sympa::get_address($family, 'listmaster'),


### PR DESCRIPTION
This may fix (partially) #156 .

- `family_signoff` action  no longer does use one-time ticket.

(This PR depends on PR #853 .)

---
**Change**

URL for this action became
>_`wwsympa_url`_`/family_signoff/`_`family`_`?email=`_`email@add.ress`_

that was previously
>_`wwsympa_url`_`/family_signoff/`_`family`_`/`_`email@add.ress`_

This change is required to handle e-mail addresses containing solidus (`/`) properly.
 