### PR TITLE
Unable to sort column in subscriber list (#866)

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -3314,7 +3314,7 @@ sub get_members {
             . (
             {   email   => 'email',
                 date    => 'date DESC',
-                sources => 'subscribed DESC, id ASC',
+                sources => 'subscribed DESC, inclusion_label ASC',
                 name    => 'gecos',
             }->{$order}
                 || 'email'


### PR DESCRIPTION
This may fix #866 

Comment: This bug has been injected on 6.2.45beta.