### PR TITLE
Skip edit for shared document options when disabled (#872) [3]

### DIFF
--- a/default/edit_list.conf
+++ b/default/edit_list.conf
@@ -49,6 +49,7 @@ export				owner,privileged_owner 		hidden
 
 ttl 				owner,privileged_owner 		hidden
 
+shared_feature			owner,privileged_owner		read
 shared_doc 			owner,privileged_owner 		write
 shared_doc.quota		owner,privileged_owner		read
 

--- a/default/web_tt2/config_common.tt2
+++ b/default/web_tt2/config_common.tt2
@@ -118,7 +118,9 @@
     [% IF pitem.privilege == 'write' ~%]
         <select name="single_param.[% ppaths.join('.') %]"
                 id="param.[% ppaths.join('.') %]"
-                [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]>
+                [%~ IF pitem.field_type == 'lang' %] class="neutral"[% END %]
+                [%~ IF pitem.enabling %] class="disableIfOff" data-selector="
+                    [%~ "#item\\." _ pitem.enabling.join(",#item\\.") %]"[% END %]>
             [% IF pitem.occurrence.match('^0') || val.length() == 0 %][%# FIXME ~%]
                 <option value=""></option>
             [%~ END %]
@@ -132,6 +134,8 @@
             [% END %]
         </select>
     [%~ ELSE ~%]
+        <span[%~ IF pitem.enabling %] class="disableIfOff" data-selector="
+            [%~ "#item\\." _ pitem.enabling.join(",#item\\.") %]"[% END %]>
         [% FOREACH enum = pitem.format ~%]
             [% IF enum == val ~%]
                 [% IF pitem.field_type == 'lang' ~%]
@@ -145,6 +149,7 @@
                 [%~ LAST %]
             [%~ END %]
         [%~ END %]
+        </span>
     [%~ END %]
     <!-- end enum -->
 [%~ END ~%]

--- a/src/lib/Sympa/Config/Schema.pm
+++ b/src/lib/Sympa/Config/Schema.pm
@@ -1594,8 +1594,8 @@ our %pinfo = (
 
     shared_doc => {
         context    => [qw(list domain site)],
-        order      => 30.09,
-        group      => 'command',                #FIXME www_other/shared_doc
+        order      => 190.11,
+        group      => 'www_other',
         gettext_id => "Shared documents",
         gettext_comment =>
             'This paragraph defines read and edit access to the shared document repository.',
@@ -1617,7 +1617,6 @@ our %pinfo = (
             quota => {
                 context => [qw(list domain site)],
                 order   => 3,
-                #FIXME: group www_other/shared_doc
                 gettext_id   => "quota",
                 gettext_unit => 'Kbytes',
                 format       => '\d+',
@@ -5560,6 +5559,7 @@ our %pinfo = (
         context    => [qw(domain site)],
         order      => 190.10,
         group      => 'www_other',
+        enabling   => ['shared_doc'],
         format     => ['on', 'off'],                #XXX
         gettext_id => 'Enable shared repository',
         gettext_comment =>

--- a/www/js/sympa.js
+++ b/www/js/sympa.js
@@ -268,6 +268,20 @@ $(function() {
     });
 });
 
+/* If set to "on" / "off", enable / disable item specified by data-selector. */
+$(function() {
+    $('.disableIfOff').each(function(){
+        var selector = $(this).data('selector');
+        $(this).on('change', function(){
+            if ($(this).val() == 'off')
+                $(selector).fadeOut('slow');
+            else
+                $(selector).slideDown('normal');
+        });
+        $(selector).trigger('change');
+    });
+});
+
 /* Help button to hide/show online help.
    It may be closed only when javascript is enabled. */
 $(function() {


### PR DESCRIPTION
One more alternative to #877 , #898.

This may fix #872 .
