### PR TITLE
Some bugs related to urlize mode

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -15358,6 +15358,7 @@ sub do_attach {
     # view a file
     $param->{'file'}   = $doc;
     $param->{'bypass'} = 'asis';
+    print "Content-Disposition: attachment\n";
 
     ## File type
     if ($in{'file'} =~ /\.(\w+)$/) {

--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -1443,10 +1443,8 @@ sub _merge_msg {
     }
 
     # Check for attchment-part, which should not be changed
-    my $cdisposition = $entity->head->mime_attr('Content-Disposition');
-    if ($cdisposition and lc($cdisposition) eq 'attachment') {
-        $log->syslog('notice',
-            'Detected part with Content-Disposition. Not changing it!');
+    if ('attachment' eq
+        lc($entity->head->mime_attr('Content-Disposition') // '')) {
         return $entity;
     }
 

--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -2109,9 +2109,8 @@ sub _urlize_parts {
 
     ## Clean up Message-ID and preventing double percent encoding.
     my $dir1 = Sympa::Tools::Text::encode_filesystem_safe($message_id);
-    #XXX$dir1 = '/' . $dir1;
-    unless (mkdir "$expl/$dir1", 0775) {
-        $log->syslog('err', 'Unable to create urlized directory %s/%s',
+    unless (-d "$expl/$dir1" or mkdir "$expl/$dir1", 0775) {
+        $log->syslog('err', 'Unable to create urlized directory %s/%s: %m',
             $expl, $dir1);
         return 0;
     }


### PR DESCRIPTION
* URLize: If personalization was enabled, urlization is prevented.  Because directory for attachment files will have been created by test_personalize() and can't be created again.
* Suppress unuseful logs skipping urlization of attachments with Content-Disposition.
* WWSympa: do_attach(): Avoid urlized attachments to be rendered by the browser.
