### PR TITLE
List admins addition through command line.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@
     - coverage-setup
     - cpanm --quiet --notest --installdeps --with-develop --with-feature=Data::Password --with-feature=ldap --with-feature=safe-unicode --with-feature=smime --with-feature=soap --with-feature=sqlite .
     - cpanm --notest --quiet Unicode::CaseFold
+    - cpanm --notest --quiet DBD::SQLite
     - autoreconf -i
     - ./configure
     - cd src; make; cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - cpan-install --coverage
   - cpanm --installdeps --notest --with-develop --with-feature=Data::Password --with-feature=ldap --with-feature=safe-unicode --with-feature=smime --with-feature=soap --with-feature=sqlite .
   - cpanm --notest --quiet Unicode::CaseFold
+  - cpanm --notest --quiet DBD::SQLite
 
 before_script:
   - coverage-setup

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ check_SCRIPTS = \
 	t/Message_smime.t \
 	t/Message_urlize.t \
 	t/Regexps.t \
+	t/RequestHandler_add_list_admin.t \
 	t/Tools_Data.t \
 	t/Tools_File.t \
 	t/Tools_Password.t \

--- a/default/mail_tt2/report.tt2
+++ b/default/mail_tt2/report.tt2
@@ -248,6 +248,9 @@
 [%~ ELSIF report_entry == 'sync_include_admin_failed' ~%]
   [%|loc%]Failed to include list admins[%END%] 
 
+[%~ ELSIF report_entry == 'list_admin_addition_failed' ~%]
+  [%|loc(report_param.email,report_param.role,report_param.listname)%]Failed to grant user '%1' the role '%2' in list '%3'.[%END%]
+
 [%~ ELSIF report_entry == 'no_owner_defined' ~%]
   [%|loc%]No owner is defined for the list[%END%] 
 
@@ -466,6 +469,9 @@
     [%|loc%]Command syntax error.[%END%]
   [%~ END %]
 
+[%~ ELSIF report_entry == 'missing_parameters' ~%]
+  [%|loc(report_param.p_name)%]Missing the following mandatory parameters: %1[%END%]
+
 [%~ ELSIF report_entry == 'unknown_list' ~%]
   [%|loc(report_param.listname)%]List '%1' does not exist.[%END%]
 
@@ -512,6 +518,9 @@
 
 [%~ ELSIF report_entry == 'already_subscriber' ~%]
   [%|loc(report_param.email,report_param.listname)%]The User '%1' is already subscriber of list '%2'.[%END%]
+
+[%~ ELSIF report_entry == 'already_list_admin' ~%]
+  [%|loc(report_param.email,report_param.role,report_param.listname)%]The User '%1' has the role '%2' in list '%3' already.[%END%]
 
 [%~ ELSIF report_entry == 'list_not_open' ~%]
   [% statdesc = BLOCK %][% report_param.status | optdesc('status') %][%END ~%]

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -84,6 +84,7 @@ nobase_modules_DATA = \
 	Sympa/Request/Collection.pm \
 	Sympa/Request/Handler.pm \
 	Sympa/Request/Handler/add.pm \
+	Sympa/Request/Handler/add_list_admin.pm \
 	Sympa/Request/Handler/auth.pm \
 	Sympa/Request/Handler/close_list.pm \
 	Sympa/Request/Handler/confirm.pm \

--- a/src/lib/Sympa/Request/Handler/add_list_admin.pm
+++ b/src/lib/Sympa/Request/Handler/add_list_admin.pm
@@ -1,0 +1,195 @@
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+# $Id$
+
+# Sympa - SYsteme de Multi-Postage Automatique
+#
+# Copyright 2019 The Sympa Community. See the AUTHORS.md file at the top-level
+# directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package Sympa::Request::Handler::add_list_admin;
+
+use strict;
+use warnings;
+use Data::Dumper;
+
+use Sympa;
+use Sympa::List;
+use Sympa::Log;
+use Sympa::Robot;
+use Sympa::Tools::Text;
+
+use base qw(Sympa::Request::Handler);
+
+my $log = Sympa::Log->instance;
+
+use constant _action_scenario => undef; # Only privileged owners and listmasters allowed.
+use constant _context_class   => 'Sympa::List';
+
+sub _twist {
+    my $self    = shift;
+    my $request = shift;
+
+    my $list    = $request->{context};
+    my $listname   = $list->{'name'};
+    my $robot   = $list->{'domain'};
+    my $role = $request->{role};
+    my $sender = $request->{sender};
+    my $updater_user = $sender || Sympa::get_address($list, 'listmaster');
+    my $user;
+    $user->{email} = Sympa::Tools::Text::canonic_email($request->{email});
+    $user->{visibility} = $request->{visibility};
+    $user->{profile} = $request->{profile};
+    $user->{reception} = $request->{reception};
+    $user->{gecos} = $request->{gecos};
+    $user->{info} = $request->{info};
+
+    my %mandatory_parameters = (
+        email => $user->{email},
+        role  => $role,
+    );
+    
+    my @missing_parameters;
+    foreach my $mandatory_param (keys %mandatory_parameters) {
+        unless ($mandatory_parameters{$mandatory_param}) {
+            push @missing_parameters, $mandatory_param;
+        }
+    }
+    
+    if( scalar @missing_parameters) {
+        $log->syslog('err', 'Trying to add list admin without giving %s.', join (', ', @missing_parameters));
+        $self->add_stash(
+            $request, 'user', 'missing_parameters',
+            {p_name => join ', ', @missing_parameters}
+        );
+        return undef;
+    }
+    
+    unless ($role eq 'owner' or $role eq 'editor') {
+        $self->add_stash(
+            $request, 'user', 'syntax_errors',
+            {p_name => 'role'}
+        );
+        $log->syslog('err', 'Error while adding %s as %s to list %s@%s. Bad parameter(s): %s',
+            $user->{email}, $role, $listname, $robot, 'role');
+        return undef;
+    }
+    
+    if ($role eq 'editor') {
+        delete $user->{profile} if $user->{profile};
+    }
+    my $schema = $Sympa::ListDef::user_info{$role};
+    my @param_in_error;
+    foreach my $param (keys %{$schema->{format}}) {
+        if ($user->{$param}) {
+            unless($user->{$param} =~ /$schema->{format}{$param}{file_format}/) {
+                push @param_in_error, $param;
+            }
+        }
+    }
+     if (scalar @param_in_error) {
+        $self->add_stash(
+            $request, 'user', 'syntax_errors',
+            {p_name => join ', ', @param_in_error}
+        );
+        $log->syslog('err', 'Error while adding %s as %s to list %s@%s. Bad parameter(s): %s',
+            $user->{email}, $role, $listname, $robot, join ', ', @param_in_error);
+        return undef;
+     }
+    # Check if user is already admin of the list.
+    if ($list->is_admin($role, $user->{email})) {
+        $self->add_stash(
+            $request, 'user',
+            'already_list_admin',
+            {email => $user->{email}, role => $role, listname => $list->{'name'}}
+        );
+        $log->syslog('err', 'User "%s" has the role "%s" in list "%s@%s" already',
+            $user->{email}, $role, $listname, $robot);
+        return undef;
+    } else {
+        unless ($list->add_list_admin($role, $user)) {
+            $self->add_stash(
+                $request, 'user',
+                'list_admin_addition_failed',
+                {email => $user->{email}, listname => $list->{'name'}}
+            );
+            $log->syslog('err', 'Could not add %s as list %s@%s admin (role: %s)',
+                $user->{email}, $listname, $robot, $role);
+        } else {
+            
+            eval {Sympa::send_notify_to_user(
+                $list,
+                'added_as_listadmin',
+                $user->{email},
+                {   admin_type => $role,
+                    delegator  => $updater_user
+                }
+            )};
+            $@ and die $@;
+        }
+
+    }
+
+    return 1;
+}
+
+1;
+
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Sympa::Request::Handler::add_list_admin - add list admin to a list.
+
+=head1 DESCRIPTION
+
+Add an admin, either owner or editor, to a list.
+
+=head2 Attributes
+
+See also L<Sympa::Request/"Attributes">.
+
+=over
+
+=item {email}
+
+I<Mandatory>.
+New list admin email address.
+
+=item {list}
+
+I<Mandatory>.
+New list admin email address.
+
+=item {email}
+
+I<Mandatory>.
+New list admin email address.
+
+=back
+
+=head1 SEE ALSO
+
+L<Sympa::Request::Handler>.
+
+=head1 HISTORY
+
+L<Sympa::Request::Handler::add_list_admin> appeared on Sympa 6.2.xxx.
+
+=cut

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -87,6 +87,10 @@ unless (
         'upgrade_config_location',      'role=s',
         'dump_users',                   'restore_users',
         'open_list=s',                  'show_pending_lists=s',
+        'add_list_admin',               'email=s',
+        'gecos=s',                      'role=s',
+        'visibility=s',                 'profile=s',
+        'reception=s',                  'info=s',
         'notify'
     )
 ) {
@@ -589,6 +593,49 @@ if ($main::options{'dump'} or $main::options{'dump_users'}) {
     unless ($spindle and $spindle->spin and _report($spindle)) {
         printf STDERR "Failed to change user email address %s to %s\n",
             $main::options{'current_email'}, $main::options{'new_email'};
+        exit 1;
+    }
+    exit 0;
+
+} elsif ($main::options{'add_list_admin'}) {
+    unless ($main::options{'email'}) {
+        print STDERR "Missing email option\n";
+        exit 1;
+    }
+
+    unless ($main::options{'role'}) {
+        print STDERR "Missing role option\n";
+        exit 1;
+    }
+
+    unless ($main::options{'list'}) {
+        print STDERR "Missing list option\n";
+        exit 1;
+    }
+
+    my ($listname, $robot_id) = split '@', $main::options{'list'};
+    my $list = Sympa::List->new($listname, $robot_id);
+    unless ($list) {
+        printf STDERR "Incorrect list name %s\n",
+            $main::options{'list'};
+        exit 1;
+    }
+
+    my $spindle = Sympa::Spindle::ProcessRequest->new(
+        context          => $list,
+        action           => 'add_list_admin',
+        email            => $main::options{'email'},
+        role             => $main::options{'role'},
+        gecos            => $main::options{'gecos'},
+        info             => $main::options{'info'},
+        profile          => $main::options{'profile'},
+        reception        => $main::options{'reception'},
+        visibility       => $main::options{'visibility'},
+        sender           => Sympa::get_address($list, 'listmaster'),
+    );
+    unless ($spindle and $spindle->spin and _report($spindle)) {
+        printf STDERR "Failed to add user %s as admin for list %s\n",
+            $main::options{'email'}, $main::options{'list'};
         exit 1;
     }
     exit 0;
@@ -1756,6 +1803,7 @@ S<[ C<--import>=I<listname> ]>
 S<[ C<--open_list>=I<list>[I<@robot>] [--notify] ]>
 S<[ C<--close_list>=I<list>[I<@robot>] ]>
 S<[ C<--purge_list>=I<list>[I<@robot>] ]>
+S<[ C<--add_list_admin> C<--email>=I<user@example.com> C<--list>=I<list>@I<domain> C<--role>=I<role> [ C<--profile>=privileged|normal C<--info>=<description> C<--visibility>=conceal|noconceal C<--reception>=mail|nomail C<--gecos>=<a gecos> ] ]>
 S<[ C<--lowercase> ]> S<[ C<--make_alias_file> ]>
 S<[ C<--dump_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
 S<[ C<--restore_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
@@ -1805,6 +1853,13 @@ C<--input_file=>I</path/to/file.xml>
 
 Add the list described by the file.xml under robot_name, to the family
 family_name.
+
+=item C<--add_list_admin> C<--email>=I<user@example.com> C<--list>=I<list>@I<domain> C<--role>=I<role> [ C<--profile>=privileged|normal C<--info>=<description> C<--visibility>=conceal|noconceal C<--reception>=mail|nomail C<--gecos>=<a gecos> ]
+
+Adds a list admin to the list.
+C<--email> is the list admin's email address. It is mandatory.
+C<--role> may specify C<owner> or C<editor>. It is mandatory.
+C<--list> is mandatory.
 
 =item C<--change_user_email> C<--current_email=>I<xx> C<--new_email=>I<xx>
 

--- a/t/RequestHandler_add_list_admin.t
+++ b/t/RequestHandler_add_list_admin.t
@@ -1,0 +1,223 @@
+#!/usr/bin/perl
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+# $Id: tools_data.t 8606 2013-02-06 08:44:02Z rousse $
+
+use strict;
+use warnings;
+use Data::Dumper;
+
+use FindBin qw($Bin);
+use lib ("$Bin/stub", "$Bin/../src/lib");
+
+use Test::More;
+use File::Path;
+use File::Slurp;
+use Sympa::List;
+use Sympa::DatabaseManager;
+use Sympa::ConfDef;
+
+BEGIN {
+    use_ok('Sympa::Request::Handler::add_list_admin');
+}
+## Definitin of test variables, files and directories
+my $test_list_name = 'testlist';
+my $test_robot_name = 'lists.example.com';
+my $test_user = 'new_owner@example.com';
+my $test_gecos = 'Dude McDude';
+my $test_listmaster = 'dude@example.com';
+my %available_owner_options = (
+    info           =>   'Wot?',
+    profile        =>   'privileged',
+    reception      =>   'nomail',
+    visibility     =>   'conceal',
+);
+
+my $test_directory = 't/tmp';
+rmtree $test_directory if -e $test_directory;
+mkdir $test_directory;
+
+my $test_database_file = "$test_directory/sympa-test.sqlite";
+unlink $test_database_file;
+open(my $fh,">$test_database_file");
+print $fh "";
+close $fh;
+
+my $pseudo_list_directory = "$test_directory/$test_list_name";
+mkdir $pseudo_list_directory;
+open($fh,">$pseudo_list_directory/config");
+print $fh "name $test_list_name";
+close $fh;
+
+## Redirecting standard error to tmp file to prevent having logs all over the output.
+open $fh, '>', "$test_directory/error_log" or die "Can't open file $test_directory/error_log in write mode";
+close(STDERR);
+my $out;
+open(STDERR, ">>", \$out) or do { print $fh, "failed to open STDERR ($!)\n"; die };
+
+## Setting pseudo list
+my $list = {name => $test_list_name, domain => $test_robot_name, dir => $pseudo_list_directory};
+bless $list,'Sympa::List';
+
+## Setting pseudo configuration
+%Conf::Conf = map { $_->{'name'} => $_->{'default'} }
+    @Sympa::ConfDef::params;
+
+$Conf::Conf{domain} = $test_robot_name; # mandatory
+$Conf::Conf{listmaster} = $test_listmaster;  # mandatory
+$Conf::Conf{db_type} = 'SQLite';
+$Conf::Conf{db_name} = $test_database_file;
+$Conf::Conf{queuebulk} = $test_directory.'/bulk';
+$Conf::Conf{log_socket_type} = 'stream';
+
+Sympa::DatabaseManager::probe_db() or die "Unable to contact test database $test_database_file";
+my $stash = [];
+
+my $test_start_date = time();
+ok (my $spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'add_list_admin',
+    email            => $test_user,
+    role             => 'owner',
+    gecos          =>   $test_gecos,
+    info           =>   $available_owner_options{info},
+    profile        =>   $available_owner_options{profile},
+    reception      =>   $available_owner_options{reception},
+    visibility     =>   $available_owner_options{visibility},
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+), 'Request handler object created');
+
+ok ($spindle->spin(), 'List owner addition succeeds.');
+
+my $sdm = Sympa::DatabaseManager->instance;
+
+my $sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s', $sdm->quote($test_list_name), $sdm->quote($test_robot_name));
+
+my @stored_admins;
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 1, 'One admin stored in database.');
+
+is($stored_admins[0]->{user_admin}, $test_user, 'The user stored in database is the one we requested.');
+
+is($stored_admins[0]->{comment_admin}, $test_gecos, 'The user stored in database has the right gecos.');
+
+foreach my $option (keys %available_owner_options) {
+    is($stored_admins[0]->{$option.'_admin'}, $available_owner_options{$option}, "Correct value set for option $option");
+}
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'add_list_admin',
+    email            => $test_user,
+    role             => 'editor',
+    stash            => $stash,
+);
+
+ok ($spindle->spin(), 'List editor addition succeeds.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s', $sdm->quote($test_list_name), $sdm->quote($test_robot_name));
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 2, 'Now two admins are stored in database.');
+
+is($stored_admins[0]->{user_admin}, $test_user, 'The editor stored in database is the one we requested.');
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'add_list_admin',
+    email            => $test_user,
+    role             => 'editor',
+    stash            => $stash,
+);
+
+$spindle->spin();
+my $reported_error = 0;
+foreach my $report (@$stash) {
+    if ($report->[2] eq 'already_list_admin') {
+        $reported_error++;
+    }
+}
+ok($reported_error, 'User error returned when trying to add the same address in the same role.');
+
+$stash = [];
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'add_list_admin',
+    email            => $test_user,
+    role             => 'editor',
+    stash            => $stash,
+    profile          => 'privileged',
+);
+
+$spindle->spin();
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s', $sdm->quote($test_list_name), $sdm->quote($test_robot_name));
+
+@stored_admins = ();
+
+my $new_admin = $sth->fetchrow_hashref();
+
+is($new_admin->{profile_admin}, 'normal', 'Profile parameter ignored when adding an editor.');
+
+my %parameters = (
+    context          => $list,
+    action           => 'add_list_admin',
+    email            => $test_user,
+    role             => 'owner',
+    gecos          =>   $test_gecos,
+    info           =>   $available_owner_options{info},
+    profile        =>   $available_owner_options{profile},
+    reception      =>   $available_owner_options{reception},
+    visibility     =>   $available_owner_options{visibility},
+    sender     =>   $test_listmaster,
+);
+
+my @parameters_to_delete = (
+    'email',
+    'role',
+);
+
+foreach my $param (@parameters_to_delete) {
+    my %current_parameters = %parameters;
+    delete $current_parameters{$param};
+    $stash = [];
+    $current_parameters{stash} = $stash;
+    $spindle = Sympa::Spindle::ProcessRequest->new(%current_parameters);
+    $spindle->spin();
+    ok(scalar @$stash && $stash->[0][3]{p_name} =~ /$param/, "When trying to run addition with a missing mandatory $param, an error is stashed.");
+}
+
+my %parameter_errors = (
+    email            => 'wrong email address',
+    role             => 'a role that does not exist',
+    profile          => 'a profile that does not exist',
+    reception        => 'a reception that does not exist',
+    visibility       => 'a visibility that does not exist',
+);
+
+foreach my $param (sort keys %parameter_errors) {
+    my %current_parameters = %parameters;
+    $current_parameters{$param} = $parameter_errors{$param};
+    $stash = [];
+    $current_parameters{stash} = $stash;
+    $spindle = Sympa::Spindle::ProcessRequest->new(%current_parameters);
+    $spindle->spin();
+    ok(scalar @$stash && $stash->[0][3]{p_name} =~ /$param/, "When trying to run addition with a faulty $param, an error is stashed.");
+}
+
+rmtree $test_directory;
+
+done_testing();


### PR DESCRIPTION
See Issue #524 for discussion.

The aim of this PR is to give administrators the possibility to add list administrators (owners or editors) through the command line.
As it is based on a Request handler, it also introduces the possibility to do so through the Sympa API (SOAP, and later REST).
It is complemented by two other PR, allowing deletion and update of list admins.

Adding :
  - a Request handler dedicated to list admin addition,
  - a sympa.pl command line option to add a list admin, based on this handler,
  - tests for the handler module.

The command line allows the following options:

```sympa.pl --add_list_admin --email=user@example.com --list=list@domain --role=role [ --profile=privileged|normal --info=<description> --visibility=conceal|noconceal --reception=mail|nomail --gecos=<a gecos> ]```

  - "--email" is the list admin's email address. It is mandatory.
  - "--role" may specify "owner" or "editor". It is mandatory.
  - "--list" is mandatory.

