### PR TITLE
List admins deletion through the command line

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@
     - coverage-setup
     - cpanm --quiet --notest --installdeps --with-develop --with-feature=Data::Password --with-feature=ldap --with-feature=safe-unicode --with-feature=smime --with-feature=soap --with-feature=sqlite .
     - cpanm --notest --quiet Unicode::CaseFold
+    - cpanm --notest --quiet DBD::SQLite
     - autoreconf -i
     - ./configure
     - cd src; make; cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - cpan-install --coverage
   - cpanm --installdeps --notest --with-develop --with-feature=Data::Password --with-feature=ldap --with-feature=safe-unicode --with-feature=smime --with-feature=soap --with-feature=sqlite .
   - cpanm --notest --quiet Unicode::CaseFold
+  - cpanm --notest --quiet DBD::SQLite
 
 before_script:
   - coverage-setup

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ check_SCRIPTS = \
 	t/Message_smime.t \
 	t/Message_urlize.t \
 	t/Regexps.t \
+	t/RequestHandler_delete_list_admin.t \
 	t/Tools_Data.t \
 	t/Tools_File.t \
 	t/Tools_Password.t \

--- a/default/mail_tt2/report.tt2
+++ b/default/mail_tt2/report.tt2
@@ -248,6 +248,9 @@
 [%~ ELSIF report_entry == 'sync_include_admin_failed' ~%]
   [%|loc%]Failed to include list admins[%END%] 
 
+[%~ ELSIF report_entry == 'list_admin_deletion_failed' ~%]
+  [%|loc(report_param.role,report_param.email,report_param.listname)%]Failed to remove the role '%1' to user '%2' in list '%3'.[%END%]
+
 [%~ ELSIF report_entry == 'no_owner_defined' ~%]
   [%|loc%]No owner is defined for the list[%END%] 
 
@@ -466,6 +469,9 @@
     [%|loc%]Command syntax error.[%END%]
   [%~ END %]
 
+[%~ ELSIF report_entry == 'missing_parameters' ~%]
+  [%|loc(report_param.p_name)%]Missing the following mandatory parameters: %1[%END%]
+
 [%~ ELSIF report_entry == 'unknown_list' ~%]
   [%|loc(report_param.listname)%]List '%1' does not exist.[%END%]
 
@@ -512,6 +518,12 @@
 
 [%~ ELSIF report_entry == 'already_subscriber' ~%]
   [%|loc(report_param.email,report_param.listname)%]The User '%1' is already subscriber of list '%2'.[%END%]
+
+[%~ ELSIF report_entry == 'not_list_admin' ~%]
+  [%|loc(report_param.email,report_param.role,report_param.listname)%]The User '%1' has not the role '%2' in list '%3'.[%END%]
+
+[%~ ELSIF report_entry == 'last_owner_deletion_attempt' ~%]
+  [%|loc(report_param.email,report_param.listname)%]The User '%1' is the last owner in list '%2'. Deletion forbidden.[%END%]
 
 [%~ ELSIF report_entry == 'list_not_open' ~%]
   [% statdesc = BLOCK %][% report_param.status | optdesc('status') %][%END ~%]

--- a/default/mail_tt2/user_notification.tt2
+++ b/default/mail_tt2/user_notification.tt2
@@ -31,6 +31,15 @@ Subject: [%"Management of list %1"|loc(list.name)|qencode%]
 [%|loc(delegator,list.name,domain)%]You have been delegated the responsibility of list moderator by %1 for list %2@%3.[%END%]
 [% END %]
 
+[% ELSIF type == 'removed_from_listadmin' -%]
+Subject: [%"Management of list %1 removed"|loc(list.name)|qencode%]
+
+[% IF admin_type == 'owner' %]
+[%|loc(delegator,list.name,domain)%]You have been removed from the owners of list %2@%3 by %1.[%END%]
+[% ELSE %]
+[%|loc(delegator,list.name,domain)%]You have been removed from the editors of list %2@%3 by %1.[%END%]
+[% END %]
+
 [% IF conf.wwsympa_url -%]
 [%|loc%]The list homepage:[%END%] [% 'info' | url_abs([list.name]) %]
 [%|loc%]Owner and moderator guide:[%END%] [% 'help' | url_abs(['admin.html']) %]

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -91,6 +91,7 @@ nobase_modules_DATA = \
 	Sympa/Request/Handler/create_list.pm \
 	Sympa/Request/Handler/decl.pm \
 	Sympa/Request/Handler/del.pm \
+	Sympa/Request/Handler/delete_list_admin.pm \
 	Sympa/Request/Handler/distribute.pm \
 	Sympa/Request/Handler/family_signoff.pm \
 	Sympa/Request/Handler/finished.pm \

--- a/src/lib/Sympa/Request/Handler/delete_list_admin.pm
+++ b/src/lib/Sympa/Request/Handler/delete_list_admin.pm
@@ -1,0 +1,247 @@
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+# $Id$
+
+# Sympa - SYsteme de Multi-Postage Automatique
+#
+# Copyright 2019 The Sympa Community. See the AUTHORS.md file at the top-level
+# directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package Sympa::Request::Handler::delete_list_admin;
+
+use strict;
+use warnings;
+use Data::Dumper;
+
+use Sympa;
+use Sympa::List;
+use Sympa::Log;
+use Sympa::Robot;
+use Sympa::Tools::Text;
+
+use base qw(Sympa::Request::Handler);
+
+my $log = Sympa::Log->instance;
+
+use constant _action_scenario => undef; # Only privileged owners and listmasters allowed.
+use constant _context_class   => undef;
+
+sub _twist {
+    my $self    = shift;
+    my $request = shift;
+    my $context    = $request->{context};
+    my $listname;
+    my $robot;
+    my $list;
+    if (defined $context and ref $context and $context->isa('Sympa::List')) {
+        $list   = $context;
+        $listname   = $list->{'name'};
+        $robot   = $list->{'domain'};
+    }elsif(defined $context and Sympa::List::get_lists($context)) {
+        $robot   = $context;
+    }else{
+        $log->syslog('err', 'Wrong context type: %s.', $context);
+        $self->add_stash(
+            $request, 'user', 'syntax_errors',
+            {p_name => 'context'}
+        );
+        return undef;
+    }
+    my $role = $request->{role};
+    my $sender = $request->{sender};
+    my $notify = $request->{notify};
+    my $updater_user = $sender || Sympa::get_address($list, 'listmaster');
+    my $user;
+    $user->{email} = Sympa::Tools::Text::canonic_email($request->{email});
+
+    unless( $user->{email} ) {
+        $log->syslog('err', 'Trying to delete list admin without giving its email');
+        $self->add_stash(
+            $request, 'user', 'missing_parameters',
+            'email'
+        );
+        return undef;
+    }
+    if ( $role && !($role eq 'owner' or $role eq 'editor')) {
+        $self->add_stash(
+            $request, 'user', 'syntax_errors',
+            {p_name => 'role'}
+        );
+        $log->syslog('err', 'Error: %s is not a defined role type',
+            $role);
+        return undef;
+    }
+    my $schema = $Sympa::ListDef::user_info{owner};
+    unless($user->{email} =~ /$schema->{format}{email}{file_format}/) {
+        $self->add_stash(
+            $request, 'user', 'syntax_errors',
+            {p_name => 'email'}
+        );
+        $log->syslog('err', 'Error while deleting %s as %s to list %s@%s. Bad email parameter.');
+        return undef;
+    }
+    
+    
+    ## if role given: use it only
+    my @roles;
+    if ($role) {
+        @roles = ($role);
+    ## else: use all roles
+    }else{
+        @roles = ('owner', 'editor');
+    }
+    my $error_found = 0;
+    my %error_found;
+    foreach my $role (@roles) {
+        my @lists;
+        ## if list given: use it only
+        if ($list) {
+            @lists = ($list);
+        ## else: use all lists in robot.
+        }else{
+            @lists = Sympa::List::get_which($user->{email}, $robot, $role);
+        }
+        foreach my $list (@lists) {
+            # Check if the user is admin of the list with the given role.
+            unless ($list->is_admin($role, $user->{email})) {
+                $error_found{$list->{name}}{$role} = 1;
+            } else {
+                if ($role eq 'owner') {
+                    ## Don't remove the last list owner.
+                    ## Note: it might be refined.
+                    ## We could switch the last user with listmaster.
+                    ## We could also add a "force" option that would ignore this protection.
+                    ## It could also be a mitigation of both solutions:
+                    ## for example, force the deletion but replace the email with the sender's email.
+                    ## To be discussed, I guess.
+                    my @current_owners = $list->get_admins('owner');
+                    if ($#current_owners == 0) {
+                        $self->add_stash(
+                            $request, 'user',
+                            'last_owner_deletion_attempt',
+                            {email => $user->{email}, listname => $list->{'name'}}
+                        );
+                        $log->syslog('err', 'The user %s is the last owner of list %s@%s. Deletion forbidden.',
+                            $user->{email}, $listname, $robot);
+                        $error_found = 1;
+                        next;
+                    }
+                }
+                unless ($list->delete_list_admin($role, $user->{email})) {
+                    $self->add_stash(
+                        $request, 'intern',
+                        'list_admin_deletion_failed',
+                        {email => $user->{email}, role => $role, listname => $list->{'name'}}
+                    );
+                    $log->syslog('err', 'Could not remove the role %s to user %s from list %s@%s.',
+                        $role, $user->{email}, $listname, $robot);
+                    $error_found = 1;
+                } else {
+                    if ($notify) {
+                        Sympa::send_notify_to_user(
+                            $list,
+                            'removed_from_listadmin',
+                            $user->{email},
+                            {   admin_type => $role,
+                                delegator  => $updater_user
+                            }
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    foreach my $list (keys %error_found) {
+        my @errors;
+        foreach my $role (@roles) {
+            if ($error_found{$list}{$role}) {
+                if (scalar @roles == 1) {
+                    $self->add_stash(
+                        $request, 'user',
+                        'not_list_admin',
+                        {email => $user->{email}, role => $role, listname => $list}
+                    );
+                    $log->syslog('err', 'User "%s" has not the role "%s" in list "%s@%s"',
+                        $user->{email}, $role, $list, $robot);
+                    $error_found = 1;
+                } else {
+                    push @errors, $role;
+                }
+            }
+        }
+        if (scalar @roles == 2 && scalar @errors == 2) {
+            $self->add_stash(
+                $request, 'user',
+                'not_list_admin',
+                {email => $user->{email}, role => 'any roles', listname => $list}
+            );
+            $log->syslog('err', 'User "%s" has no admin role in list "%s@%s"',
+                $user->{email}, $list, $robot);
+            $error_found = 1;
+        }
+    }
+    return undef if $error_found;
+    return 1;
+}
+
+1;
+
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Sympa::Request::Handler::delete_list_admin - delete list admin from a list.
+
+=head1 DESCRIPTION
+
+Delete an admin, either owner or editor, from a list.
+
+=head2 Attributes
+
+See also L<Sympa::Request/"Attributes">.
+
+=over
+
+=item {email}
+
+I<Mandatory>.
+List admin email address.
+
+=item {list}
+
+I<Mandatory>.
+list email address.
+
+=item {rle}
+
+I<Mandatory>.
+The role from which the user should be removed.
+
+=back
+
+=head1 SEE ALSO
+
+L<Sympa::Request::Handler>.
+
+=head1 HISTORY
+
+L<Sympa::Request::Handler::delete_list_admin> appeared on Sympa 6.2.xxx.
+
+=cut

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -87,7 +87,8 @@ unless (
         'upgrade_config_location',      'role=s',
         'dump_users',                   'restore_users',
         'open_list=s',                  'show_pending_lists=s',
-        'notify'
+        'delete_list_admin',            'email=s', 
+        'role=s',                       'notify'
     )
 ) {
     pod2usage(-exitval => 1, -output => \*STDERR);
@@ -589,6 +590,61 @@ if ($main::options{'dump'} or $main::options{'dump_users'}) {
     unless ($spindle and $spindle->spin and _report($spindle)) {
         printf STDERR "Failed to change user email address %s to %s\n",
             $main::options{'current_email'}, $main::options{'new_email'};
+        exit 1;
+    }
+    exit 0;
+
+} elsif ($main::options{'delete_list_admin'}) {
+    unless ($main::options{'email'}) {
+        print STDERR "Missing email option\n";
+        exit 1;
+    }
+
+    if ($main::options{'robot'} && $main::options{'list'}) {
+        print STDERR "You must specify either a list or a robot. Not both.\n";
+        exit 1;
+    }
+
+    my %parameters;
+    $parameters{email} = $main::options{'email'};
+
+    $parameters{role} = $main::options{'role'} if $main::options{'role'};
+
+    if ($main::options{'robot'}) {
+        $parameters{context} = $main::options{'robot'};
+        $parameters{sender} = 'listmaster@' . $main::options{'robot'};
+    }
+    if ($main::options{'list'}) {
+        my ($listname, $robot_id) = split '@', $main::options{'list'};
+        my $list = Sympa::List->new($listname, $robot_id);
+        unless ($list) {
+            printf STDERR "Incorrect list name %s\n",
+                $main::options{'list'};
+            exit 1;
+        }
+        $parameters{context} = $list;
+        $parameters{sender}  = Sympa::get_address($list, 'listmaster');
+    }
+
+    my $spindle = Sympa::Spindle::ProcessRequest->new(
+        action           => 'delete_list_admin',
+        %parameters
+    );
+    unless ($spindle and $spindle->spin and _report($spindle)) {
+        my $role;
+        if ($main::options{'roles'}) {
+            $role = $main::options{'roles'}.' role';
+        }else{
+            $role = 'all administrative roles';
+        }
+        my $target;
+        if ($main::options{'list'}) {
+            $target = 'list '.$main::options{'list'};
+        }else{
+            $target = 'domain '.$main::options{'robot'}
+        }
+        printf STDERR "Failed to remove %s to user %s for %s\n",
+            $role, $main::options{'email'}, $target;
         exit 1;
     }
     exit 0;
@@ -1757,6 +1813,7 @@ S<[ C<--open_list>=I<list>[I<@robot>] [--notify] ]>
 S<[ C<--close_list>=I<list>[I<@robot>] ]>
 S<[ C<--purge_list>=I<list>[I<@robot>] ]>
 S<[ C<--lowercase> ]> S<[ C<--make_alias_file> ]>
+S<[ C<--delete_list_admin> C<--email>=I<user@example.com> C<--list>=I<list>@I<domain>|C<--robot>=I<domain> [ C<--role>=I<role> ] ]>
 S<[ C<--dump_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
 S<[ C<--restore_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
 S<[ C<--show_pending_lists>=I<robot> ]>
@@ -1834,6 +1891,14 @@ Copy a list.
 C<--input_file=>I</path/to/file.xml >
 
 Create a list with the XML file under robot robot_name.
+
+=item C<--delete_list_admin> C<--email>=I<user@example.com> C<--list>=I<list>@I<domain>|C<--robot>=I<domain> [ C<--role>=I<role> ]
+
+C<--email> is the list admin's email address. It is mandatory.
+C<--role> may specify C<owner> or C<editor>. If C<--role> is absent, both values are used.
+You must specify either C<--list> or C<--robot>. If you specify C<--robot>, the user
+is removed from the role in all this robot's lists.
+Please note that this command WILL NOT remove the user if it is the last list owner.
 
 =item C<--dump=>I<list>@I<domain>|C<ALL>
 

--- a/t/RequestHandler_delete_list_admin.t
+++ b/t/RequestHandler_delete_list_admin.t
@@ -1,0 +1,376 @@
+#!/usr/bin/perl
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+# $Id: tools_data.t 8606 2013-02-06 08:44:02Z rousse $
+
+use strict;
+use warnings;
+use Data::Dumper;
+
+use FindBin qw($Bin);
+use lib "$Bin/stub";
+use lib "$Bin/../src/lib";
+
+use Test::More;
+use File::Path;
+use File::Slurp;
+use Sympa::List;
+use Sympa::DatabaseManager;
+use Sympa::ConfDef;
+
+BEGIN {
+    use_ok('Sympa::Request::Handler::delete_list_admin');
+}
+
+## Definitin of test variables, files and directories
+my $test_list_name = 'testlist';
+my $test_robot_name = 'lists.example.com';
+my $test_user = 'new_owner@example.com';
+my $test_listmaster = 'dude@example.com';
+
+my $test_directory = 't/tmp';
+rmtree $test_directory if -e $test_directory;
+mkdir $test_directory;
+
+my $test_database_file = "$test_directory/sympa-test.sqlite";
+unlink $test_database_file;
+open(my $fh,">$test_database_file");
+print $fh "";
+close $fh;
+
+my $pseudo_list_directory = "$test_directory/$test_list_name";
+foreach my $delta ('','2','3') {
+    mkdir $pseudo_list_directory.$delta;
+    open($fh,">$pseudo_list_directory$delta/config");
+    print $fh "name $test_list_name$delta";
+    close $fh;
+}
+
+## Redirecting standard error to tmp file to prevent having logs all over the output.
+open $fh, '>', "$test_directory/error_log" or die "Can't open file $test_directory/error_log in write mode";
+close(STDERR);
+my $out;
+open(STDERR, ">>", \$out) or do { print $fh, "failed to open STDERR ($!)\n"; die };
+
+## Setting pseudo list
+my $list = {name => $test_list_name, domain => $test_robot_name, dir => $pseudo_list_directory};
+bless $list,'Sympa::List';
+
+## Setting pseudo configuration
+%Conf::Conf = map { $_->{'name'} => $_->{'default'} }
+    @Sympa::ConfDef::params;
+
+$Conf::Conf{domain} = $test_robot_name; # mandatory
+$Conf::Conf{listmaster} = $test_listmaster;  # mandatory
+$Conf::Conf{db_type} = 'SQLite';
+$Conf::Conf{db_name} = $test_database_file;
+$Conf::Conf{queuebulk} = $test_directory.'/bulk';
+$Conf::Conf{home} = $test_directory;
+$Conf::Conf{log_socket_type} = 'stream';
+$Conf::Conf{db_list_cache} = 'off';
+
+Sympa::DatabaseManager::probe_db() or die "Unable to contact test database $test_database_file";
+my $role = 'owner';
+my $user = {
+    email => $test_user,
+};
+$list->add_list_admin($role, $user) or die 'Unable to add owner';
+
+## Second owner that will not be deleted.
+my $henchman_email = 'henchman'.$test_user;
+
+$list->add_list_admin($role, {email =>$henchman_email}) or die 'Unable to add henchman';
+
+my $sdm = Sympa::DatabaseManager->instance;
+
+my $sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote($test_user),
+);
+
+my @stored_admins;
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 1, 'Test owner is correctly stored in database.');
+
+$role = 'editor';
+$list->add_list_admin($role, $user) or die 'Unable to add editor';
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('editor'),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 1, 'Test editor is correctly stored in database.');
+
+## Error checking
+
+my $stash = [];
+my $spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => undef,
+    action           => 'delete_list_admin',
+    email            => $test_user,
+    role             => 'owner',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner deletion fails when no list or robot object given.');
+
+is ($stash->[0][2], 'syntax_errors', 'Correct error in stash when missing email.');
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'delete_list_admin',
+    role             => 'owner',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner deletion fails when no email given.');
+
+is ($stash->[0][2], 'missing_parameters', 'Correct error in stash when missing email.');
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'delete_list_admin',
+    email            => $test_user,
+    role             => 'globuz',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner deletion fails when the given role does not exist.');
+
+is ($stash->[0][2], 'syntax_errors', 'Correct error in stash when role does not exist.');
+
+is ($stash->[0][3]{p_name}, 'role', 'The error parameter is the role.');
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'delete_list_admin',
+    email            => 'globuz',
+    role             => 'owner',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner deletion fails when the given email is invalid.');
+
+is ($stash->[0][2], 'syntax_errors', 'Correct error in stash when the given email is invalid.');
+
+is ($stash->[0][3]{p_name}, 'email', 'The error parameter is the email.');
+
+## List owner deletion check.
+
+ok ($spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'delete_list_admin',
+    email            => $test_user,
+    role             => 'owner',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+), 'Request handler object created');
+
+ok ($spindle->spin(), 'List owner deletion succeeds.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 0, 'test owner has been deleted from database.');
+
+## Error when trying to delete a list owner which does not exist.
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'delete_list_admin',
+    email            => $test_user,
+    role             => 'owner',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner deletion fails when the given email does not have the role to be removed.');
+
+is ($stash->[0][2], 'not_list_admin', 'Correct error in stash when the given email does not have the role to be removed.');
+
+## Last owner deletion prevention check.
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'delete_list_admin',
+    email            => $henchman_email,
+    role             => 'owner',
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner deletion fails when trying to delete the last owner.');
+
+is ($stash->[0][2], 'last_owner_deletion_attempt', 'Correct error in stash when attempting to delete the last owner.');
+
+## List editor deletion
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'delete_list_admin',
+    email            => $test_user,
+    role             => 'editor',
+    stash            => $stash,
+);
+
+ok ($spindle->spin(), 'List editor deletion succeeds.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('editor'),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 0, 'test editor has been removed from database.');
+
+## Removal of all roles in a single list
+
+$list->add_list_admin('owner', $user) or die 'Unable to add owner';
+$list->add_list_admin('editor', $user) or die 'Unable to add owner';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'delete_list_admin',
+    email            => $test_user,
+    stash            => $stash,
+);
+
+ok ($spindle->spin(), 'List admin deletion succeeds.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 0, 'test user got all his roles in test list removed from database.');
+
+## Removal of one role for a whole domain.
+
+my $list2 = {name => $test_list_name.'2', domain => $test_robot_name, dir => $pseudo_list_directory.'2'};
+bless $list2,'Sympa::List';
+
+my $list3 = {name => $test_list_name.'3', domain => $test_robot_name, dir => $pseudo_list_directory.'3'};
+bless $list3,'Sympa::List';
+
+$list->add_list_admin('owner', $user) or die 'Unable to add owner';
+$list2->add_list_admin('owner', $user) or die 'Unable to add owner';
+$list2->add_list_admin('owner', {email =>$henchman_email}) or die 'Unable to add henchman';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $test_robot_name,
+    action           => 'delete_list_admin',
+    role             => 'owner',
+    email            => $test_user,
+    stash            => $stash,
+);
+
+ok ($spindle->spin(), 'List owner deletion succeeds for a whole domain.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    print Dumper $row;
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 0, 'test user got removed ownership for all lists in the domain.');
+
+## Removal of all roles for a whole domain.
+
+$list->add_list_admin('owner', $user) or die 'Unable to add owner';
+$list2->add_list_admin('owner', $user) or die 'Unable to add owner';
+$list->add_list_admin('editor', $user) or die 'Unable to add editor';
+$list2->add_list_admin('editor', $user) or die 'Unable to add editor';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $test_robot_name,
+    action           => 'delete_list_admin',
+    email            => $test_user,
+    stash            => $stash,
+);
+
+ok ($spindle->spin(), 'List admin deletion succeeds for a whole domain.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `robot_admin` LIKE %s and user_admin like %s',
+    $sdm->quote($test_robot_name),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 0, 'test user got removed all adminships for all lists in the domain.');
+
+rmtree $test_directory;
+
+done_testing();


### PR DESCRIPTION
See Issue #524 for discussion.

The aim of this PR is to give administrators the possibility to delete list administrators (owners or editors) through the command line.
As it is based on a Request handler, it also introduces the possibility to do so through the Sympa API (SOAP, and later REST).
It is complemented by two other PR, allowing addition and update of list admins.

Adding :
    - a Request handler dedicated to list admin deletion,
    - a sympa.pl command line option to delete a list admin, based on this handler,
    - tests for the handler module.

The command line allows the following options:

```sympa.pl --delete_list_admin --email=user@example.com --list=list@domain|--robot=domain [ --role=role ]```

    - "--email" is the list admin's email address. It is mandatory.
    - "--role" may specify "owner" or "editor". If "--role" is absent, both values are used.
    - You must specify either "--list" or "--robot". If you specify "--robot", the user is removed from the role in all this robot's lists.

Please note that this command WILL NOT remove the user if it is the last list owner.
