### PR TITLE
List admin update through the command line

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@
     - coverage-setup
     - cpanm --quiet --notest --installdeps --with-develop --with-feature=Data::Password --with-feature=ldap --with-feature=safe-unicode --with-feature=smime --with-feature=soap --with-feature=sqlite .
     - cpanm --notest --quiet Unicode::CaseFold
+    - cpanm --notest --quiet DBD::SQLite
     - autoreconf -i
     - ./configure
     - cd src; make; cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - cpan-install --coverage
   - cpanm --installdeps --notest --with-develop --with-feature=Data::Password --with-feature=ldap --with-feature=safe-unicode --with-feature=smime --with-feature=soap --with-feature=sqlite .
   - cpanm --notest --quiet Unicode::CaseFold
+  - cpanm --notest --quiet DBD::SQLite
 
 before_script:
   - coverage-setup

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ check_SCRIPTS = \
 	t/Message_smime.t \
 	t/Message_urlize.t \
 	t/Regexps.t \
+	t/RequestHandler_update_list_admin.t \
 	t/Tools_Data.t \
 	t/Tools_File.t \
 	t/Tools_Password.t \

--- a/default/mail_tt2/report.tt2
+++ b/default/mail_tt2/report.tt2
@@ -248,6 +248,9 @@
 [%~ ELSIF report_entry == 'sync_include_admin_failed' ~%]
   [%|loc%]Failed to include list admins[%END%] 
 
+[%~ ELSIF report_entry == 'list_admin_update_failed' ~%]
+  [%|loc(report_param.role,report_param.current_email,report_param.new_email,report_param.listname)%]Failed to update user '%2' with user '%3' for the role '%1' in list '%4'.[%END%]
+
 [%~ ELSIF report_entry == 'no_owner_defined' ~%]
   [%|loc%]No owner is defined for the list[%END%] 
 
@@ -466,6 +469,9 @@
     [%|loc%]Command syntax error.[%END%]
   [%~ END %]
 
+[%~ ELSIF report_entry == 'missing_parameters' ~%]
+  [%|loc(report_param.p_name)%]Missing the following mandatory parameters: %1[%END%]
+
 [%~ ELSIF report_entry == 'unknown_list' ~%]
   [%|loc(report_param.listname)%]List '%1' does not exist.[%END%]
 
@@ -512,6 +518,9 @@
 
 [%~ ELSIF report_entry == 'already_subscriber' ~%]
   [%|loc(report_param.email,report_param.listname)%]The User '%1' is already subscriber of list '%2'.[%END%]
+
+[%~ ELSIF report_entry == 'not_list_admin' ~%]
+  [%|loc(report_param.email,report_param.role,report_param.listname)%]The User '%1' has not the role '%2' in list '%3'.[%END%]
 
 [%~ ELSIF report_entry == 'list_not_open' ~%]
   [% statdesc = BLOCK %][% report_param.status | optdesc('status') %][%END ~%]

--- a/default/mail_tt2/user_notification.tt2
+++ b/default/mail_tt2/user_notification.tt2
@@ -31,6 +31,15 @@ Subject: [%"Management of list %1"|loc(list.name)|qencode%]
 [%|loc(delegator,list.name,domain)%]You have been delegated the responsibility of list moderator by %1 for list %2@%3.[%END%]
 [% END %]
 
+[% ELSIF type == 'removed_from_listadmin' -%]
+Subject: [%"Management of list %1 removed"|loc(list.name)|qencode%]
+
+[% IF admin_type == 'owner' %]
+[%|loc(delegator,list.name,domain,new_email)%]You have been replaced by %4 among the owners of list %2@%3. Replacement done by %1.[%END%]
+[% ELSE %]
+[%|loc(delegator,list.name,domain,new_email)%]You have been replaced by %4 among the editors of list %2@%3 Replacement done by %1.[%END%]
+[% END %]
+
 [% IF conf.wwsympa_url -%]
 [%|loc%]The list homepage:[%END%] [% 'info' | url_abs([list.name]) %]
 [%|loc%]Owner and moderator guide:[%END%] [% 'help' | url_abs(['admin.html']) %]

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -119,6 +119,7 @@ nobase_modules_DATA = \
 	Sympa/Request/Handler/subscribe.pm \
 	Sympa/Request/Handler/unknown.pm \
 	Sympa/Request/Handler/update_automatic_list.pm \
+	Sympa/Request/Handler/update_list_admin.pm \
 	Sympa/Request/Handler/verify.pm \
 	Sympa/Request/Handler/which.pm \
 	Sympa/Request/Message.pm \

--- a/src/lib/Sympa/Request/Handler/update_list_admin.pm
+++ b/src/lib/Sympa/Request/Handler/update_list_admin.pm
@@ -1,0 +1,365 @@
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+# $Id$
+
+# Sympa - SYsteme de Multi-Postage Automatique
+#
+# Copyright 2019 The Sympa Community. See the AUTHORS.md file at the top-level
+# directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package Sympa::Request::Handler::update_list_admin;
+
+use strict;
+use warnings;
+use Data::Dumper;
+
+use Sympa;
+use Sympa::List;
+use Sympa::Log;
+use Sympa::Robot;
+use Sympa::Tools::Text;
+
+use base qw(Sympa::Request::Handler);
+
+my $log = Sympa::Log->instance;
+
+use constant _action_scenario => undef; # Only privileged owners and listmasters allowed.
+use constant _context_class   => undef;
+
+sub _twist {
+    my $self    = shift;
+    my $request = shift;
+    my $context    = $request->{context};
+    my $listname;
+    my $robot;
+    my $list;
+    if (defined $context and ref $context and $context->isa('Sympa::List')) {
+        $list   = $context;
+        $listname   = $list->{'name'};
+        $robot   = $list->{'domain'};
+    }elsif(defined $context and Sympa::List::get_lists($context)) {
+        $robot   = $context;
+    }else{
+        $log->syslog('err', 'Wrong context type: %s.', $context);
+        $self->add_stash(
+            $request, 'user', 'syntax_errors',
+            {p_name => 'context'}
+        );
+        return undef;
+    }
+    my $role = $request->{role};
+    my $sender = $request->{sender};
+    my $notify = $request->{notify};
+    my $updater_user = $sender || Sympa::get_address($list, 'listmaster');
+    my $new_values;
+    $new_values->{email} = Sympa::Tools::Text::canonic_email($request->{new_email}) if $request->{new_email};
+    $new_values->{visibility} = $request->{visibility} if $request->{visibility};
+    $new_values->{profile} = $request->{profile} if $request->{profile};
+    $new_values->{reception} = $request->{reception} if $request->{reception};
+    $new_values->{gecos} = $request->{gecos} if $request->{gecos};
+    $new_values->{info} = $request->{info} if $request->{info};
+
+    my $previous_email = Sympa::Tools::Text::canonic_email($request->{current_email});
+
+    unless( $previous_email ) {
+        $log->syslog('err', 'Trying to update list admin without giving its email');
+        $self->add_stash(
+            $request, 'user', 'missing_parameters',
+            'email'
+        );
+        return undef;
+    }
+
+    my $schema = $Sympa::ListDef::user_info{owner};
+    unless($previous_email =~ m{$schema->{format}{email}{file_format}}) {
+        $self->add_stash(
+            $request, 'user', 'syntax_errors',
+            {p_name => 'current_email'}
+        );
+        $log->syslog('err', 'Error : provided email %s is not a valid email.', $previous_email);
+        return undef;
+    }
+
+    my @param_in_error;
+    foreach my $param (keys %{$schema->{format}}) {
+        if ($new_values->{$param}) {
+            unless($new_values->{$param} =~ /$schema->{format}{$param}{file_format}/) {
+                if ($param eq 'email') {
+                    $param = 'new_email';
+                }
+                push @param_in_error, $param;
+            }
+        }
+    }
+     if (scalar @param_in_error) {
+        $self->add_stash(
+            $request, 'user', 'syntax_errors',
+            {p_name => join ', ', @param_in_error}
+        );
+        $log->syslog('err', 'Error while adding %s as %s to list %s@%s. Bad parameter(s): %s',
+            $new_values->{email}, $role, $listname, $robot, join ', ', @param_in_error);
+        return undef;
+     }
+
+    if ( $role && !($role eq 'owner' or $role eq 'editor')) {
+        $self->add_stash(
+            $request, 'user', 'syntax_errors',
+            {p_name => 'role'}
+        );
+        $log->syslog('err', 'Error: %s is not a defined role type',
+            $role);
+        return undef;
+    }
+
+    ## if role given: use it only
+    my @roles;
+    if ($role) {
+        @roles = ($role);
+    ## else: use all roles
+    }else{
+        @roles = ('owner', 'editor');
+    }
+
+    ## Actual update.
+    my $error_found = 0;
+    my %error_found;
+    foreach my $role (@roles) {
+        my @lists;
+        ## if list given: use it only
+        if ($list) {
+            @lists = ($list);
+        ## else: use all lists in robot.
+        }else{
+            @lists = Sympa::List::get_which($previous_email, $robot, $role);
+        }
+        
+        foreach my $list (@lists) {
+
+            my %new_values_copy = %$new_values;
+            if ($role eq 'editor') {
+                $new_values_copy{profile} = 'normal';
+            }
+            unless ($list->is_admin($role, $previous_email)) {
+                 $error_found{$list->{name}}{$role} = 1;
+            } else {
+                ## Verifying if we will replace an amin by another one or just update an existing one.
+                my $is_replacement = 0;
+                my $former_couple = 0;
+                my $mail_to_update = $previous_email;
+                if ($new_values_copy{email} && $new_values_copy{email} ne $previous_email) {
+                    ## If new email already admin, it will be an update.
+                    if ($list->is_admin($role, $new_values_copy{email})) {
+                        $is_replacement = 0;
+                        $mail_to_update = $new_values_copy{email};
+                        $former_couple = 1;
+                    } else {
+                        $is_replacement = 1;
+                    }
+                }
+                ## Replacing an existing admin by a new one
+                if ($is_replacement) {
+                    my $previous_user = $list->get_admins($role, filter => [email => $mail_to_update]);
+                    ## Privilege exception. If no privilege was explicitely given as argument, the new owner
+                    ## will get the same profile as the old one (default to 'normal').
+                    if ($role eq 'owner' and !$new_values_copy{profile}) {
+                        $new_values_copy{profile} = $previous_user->[0]->{profile} || 'normal';
+                    }
+                    ## Add new admin
+                    unless ($list->add_list_admin($role, \%new_values_copy)) {
+                        $self->add_stash(
+                            $request, 'user',
+                            'list_admin_addition_failed',
+                            {email => $new_values_copy{email}, listname => $list->{'name'}}
+                        );
+                        $log->syslog('err', 'Could not add %s as list %s@%s admin (role: %s)',
+                            $new_values_copy{email}, $listname, $robot, $role);
+                        ## Don't go further in the current operation if addition of new user was unsuccessful.
+                        next;
+                    } else {
+                        if ($notify) {
+                            Sympa::send_notify_to_user(
+                                $list,
+                                'added_as_listadmin',
+                                $new_values_copy{email},
+                                {   admin_type => $role,
+                                    delegator  => $updater_user
+                                }
+                            );
+                        }
+                    }
+                    ## Delete old admin
+                    unless ($list->delete_list_admin($role, $previous_email)) {
+                        $self->add_stash(
+                            $request, 'intern',
+                            'list_admin_deletion_failed',
+                            {email => $previous_email, role => $role, listname => $list->{'name'}}
+                        );
+                        $log->syslog('err', 'Could not remove the role %s to user %s from list %s@%s.',
+                            $role, $previous_email, $listname, $robot);
+                        $error_found = 1;
+                    } else {
+                        if ($notify) {
+                            Sympa::send_notify_to_user(
+                                $list,
+                                'removed_from_listadmin',
+                                $previous_email,
+                                {   admin_type => $role,
+                                    delegator  => $updater_user
+                                }
+                            );
+                        }
+                    }
+                ## Updating an existing admin with new values
+                } else {
+                    # Merging data for new user. Don't do anything if data unchanged.
+                    my $previous_user = $list->get_admins($role, filter => [email => $mail_to_update]);
+                    delete $previous_user->[0]->{included};
+                    ## Privilege exception. If user to update was owner already and was privileged, don't decrease this privilege.
+                    ## If the new privilege is 'privileged' it is always applied.
+                    if ($former_couple and $role eq 'owner' and ($previous_user->[0]->{profile} eq 'privileged' or ($new_values_copy{profile} and $new_values_copy{profile} eq 'privileged'))) {
+                        $previous_user->[0]->{profile} = 'privileged';
+                    }
+                    unless ($former_couple) {
+                        my $changed = 0;
+                        foreach my $key (keys %new_values_copy) {
+                            if ($previous_user->[0]->{$key} ne $new_values_copy{$key}) {
+                                $previous_user->[0]->{$key} = $new_values_copy{$key};
+                                $changed = 1;
+                            }
+                        }
+                        next unless $changed;
+                    }
+                    unless ($list->update_list_admin($mail_to_update, $role, $previous_user->[0])) {
+                        $self->add_stash(
+                            $request, 'intern',
+                            'list_admin_update_failed',
+                            {current_email => $mail_to_update, new_email => $mail_to_update, role => $role, listname => $list->{'name'}}
+                        );
+                        $log->syslog('err', 'Could not update data for the user %s with role %s in list %s@%s.',
+                            $mail_to_update, $role, $listname, $robot);
+                        $error_found = 1;
+                    }
+                    if ($former_couple) {
+                        ## Delete old admin
+                        unless ($list->delete_list_admin($role, $previous_email)) {
+                            $self->add_stash(
+                                $request, 'intern',
+                                'list_admin_deletion_failed',
+                                {email => $previous_email, role => $role, listname => $list->{'name'}}
+                            );
+                            $log->syslog('err', 'Could not remove the role %s to user %s from list %s@%s.',
+                                $role, $previous_email, $listname, $robot);
+                            $error_found = 1;
+                        } else {
+                            if ($notify) {
+                                Sympa::send_notify_to_user(
+                                    $list,
+                                    'removed_from_listadmin',
+                                    $previous_email,
+                                    {   admin_type => $role,
+                                        delegator  => $updater_user
+                                    }
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    my $email = $previous_email;
+    foreach my $list (keys %error_found) {
+        my @errors;
+        foreach my $role (@roles) {
+            if ($error_found{$list}{$role}) {
+                if (scalar @roles == 1) {
+                    $self->add_stash(
+                        $request, 'user',
+                        'not_list_admin',
+                        {email => $email, role => $role, listname => $list}
+                    );
+                    $log->syslog('err', 'User "%s" has not the role "%s" in list "%s@%s"',
+                        $email, $role, $list, $robot);
+                    $error_found = 1;
+                } else {
+                    push @errors, $role;
+                }
+            }
+        }
+        if (scalar @roles == 2 && scalar @errors == 2) {
+            $self->add_stash(
+                $request, 'user',
+                'not_list_admin',
+                {email => $email, role => 'any roles', listname => $list}
+            );
+            $log->syslog('err', 'User "%s" has no admin role in list "%s@%s"',
+                $email, $list, $robot);
+            $error_found = 1;
+        }
+    }
+
+    return undef if $error_found;
+    return 1;
+}
+
+1;
+
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Sympa::Request::Handler::update_list_admin - update list admin from a list.
+
+=head1 DESCRIPTION
+
+update an admin, either owner or editor, from a list.
+
+=head2 Attributes
+
+See also L<Sympa::Request/"Attributes">.
+
+=over
+
+=item {email}
+
+I<Mandatory>.
+List admin email address.
+
+=item {list}
+
+I<Mandatory>.
+list email address.
+
+=item {rle}
+
+I<Mandatory>.
+The role from which the user should be removed.
+
+=back
+
+=head1 SEE ALSO
+
+L<Sympa::Request::Handler>.
+
+=head1 HISTORY
+
+L<Sympa::Request::Handler::update_list_admin> appeared on Sympa 6.2.xxx.
+
+=cut

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -87,6 +87,10 @@ unless (
         'upgrade_config_location',      'role=s',
         'dump_users',                   'restore_users',
         'open_list=s',                  'show_pending_lists=s',
+        'update_list_admin',
+        'gecos=s',                      'role=s',
+        'visibility=s',                 'profile=s',
+        'reception=s',                  'info=s',
         'notify'
     )
 ) {
@@ -589,6 +593,76 @@ if ($main::options{'dump'} or $main::options{'dump_users'}) {
     unless ($spindle and $spindle->spin and _report($spindle)) {
         printf STDERR "Failed to change user email address %s to %s\n",
             $main::options{'current_email'}, $main::options{'new_email'};
+        exit 1;
+    }
+    exit 0;
+
+} elsif ($main::options{'update_list_admin'}) {
+    unless ($main::options{'current_email'}) {
+        print STDERR "Missing current_email option\n";
+        exit 1;
+    }
+
+    unless ($main::options{'robot'} || $main::options{'list'}) {
+        print STDERR "You must specify either a list or a robot.\n";
+        exit 1;
+    }
+
+    if ($main::options{'robot'} && $main::options{'list'}) {
+        print STDERR "You can't specify both a list an a robot. One of them only.\n";
+        exit 1;
+    }
+
+    my %parameters;
+    
+    $parameters{role}           = $main::options{'role'} if $main::options{'role'};
+    $parameters{gecos}          = $main::options{'gecos'} if $main::options{'gecos'};
+    $parameters{info}           = $main::options{'info'} if $main::options{'info'};
+    $parameters{profile}        = $main::options{'profile'} if $main::options{'profile'};
+    $parameters{reception}      = $main::options{'reception'} if $main::options{'reception'};
+    $parameters{visibility}     = $main::options{'visibility'} if $main::options{'visibility'};
+    $parameters{current_email}  = $main::options{'current_email'};
+    $parameters{new_email}      = $main::options{'new_email'};
+
+    $parameters{role} = $main::options{'role'} if $main::options{'role'};
+
+    if ($main::options{'robot'}) {
+        $parameters{context} = $main::options{'robot'};
+        $parameters{sender} = 'listmaster@' . $main::options{'robot'};
+    }
+    if ($main::options{'list'}) {
+        my ($listname, $robot_id) = split '@', $main::options{'list'};
+        my $list = Sympa::List->new($listname, $robot_id);
+        unless ($list) {
+            printf STDERR "Incorrect list name %s\n",
+                $main::options{'list'};
+            exit 1;
+        }
+        $parameters{context} = $list;
+        $parameters{sender}  = Sympa::get_address($list, 'listmaster');
+    }
+
+    my $spindle = Sympa::Spindle::ProcessRequest->new(
+        action           => 'update_list_admin',
+        %parameters
+    );
+    unless ($spindle and $spindle->spin and _report($spindle)) {
+        my $role;
+        if ($main::options{'role'}) {
+            $role = $main::options{'role'}.' role';
+        }else{
+            $role = 'all administrative roles';
+        }
+        my $target;
+        if ($main::options{'list'}) {
+            $target = 'list '.$main::options{'list'};
+        }else{
+            $target = 'domain '.$main::options{'robot'}
+        }
+        my $new_email = $main::options{'new_email'};
+        $new_email ||= $main::options{'current_email'};
+        printf STDERR "Failed to update %s from user '%s' to user '%s' for '%s'\n",
+            $role, $main::options{'current_email'}, $new_email, $target;
         exit 1;
     }
     exit 0;
@@ -1968,6 +2042,14 @@ B<Note>:
 This option was deprecated.
 
 Test the database message buffer size.
+
+=item C<--update_list_admin> C<--current_email>=I<user@example.com> (C<--list>=I<list>@I<domain> | C<--robot>=I<robot> ) [ C<--new_email>=I<new_user@example.com> C<--role>=I<role> C<--profile>=privileged|normal C<--info>=<description> C<--visibility>=conceal|noconceal C<--reception>=mail|nomail C<--gecos>=<a gecos> ]
+
+Updates a list admin, either replacing it with a new user (if C<--new_email> is given and is different from C<--current_email>) or simply updating its informations.
+
+C<--current_email> is the list admin's email address. It is mandatory.
+Either C<--list> or C<--robot> is mandatory.
+If no C<--role> is given, all administrative roles will be updated (both editor and owner).
 
 =item C<--upgrade> [ C<--from=>I<X> ] [ C<--to=>I<Y> ]
 

--- a/t/RequestHandler_update_list_admin.t
+++ b/t/RequestHandler_update_list_admin.t
@@ -1,0 +1,943 @@
+#!/usr/bin/perl
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+# $Id: tools_data.t 8606 2013-02-06 08:44:02Z rousse $
+
+use strict;
+use warnings;
+use Data::Dumper;
+
+use FindBin qw($Bin);
+use lib "$Bin/stub";
+use lib "$Bin/../src/lib";
+
+use Test::More;
+use File::Path;
+use File::Slurp;
+use Sympa::List;
+use Sympa::DatabaseManager;
+use Sympa::ConfDef;
+
+BEGIN {
+    use_ok('Sympa::Request::Handler::update_list_admin');
+}
+
+## Definition of test variables, files and directories
+my $test_list_name = 'testlist';
+my $test_robot_name = 'lists.example.com';
+my $test_user = 'owner@example.com';
+my $test_listmaster = 'dude@example.com';
+
+my $test_directory = 't/tmp';
+rmtree $test_directory if -e $test_directory;
+mkdir $test_directory;
+
+my $test_database_file = "$test_directory/sympa-test.sqlite";
+unlink $test_database_file;
+open(my $fh,">$test_database_file");
+print $fh "";
+close $fh;
+
+my $pseudo_list_directory = "$test_directory/$test_list_name";
+foreach my $delta ('','2','3') {
+    mkdir $pseudo_list_directory.$delta;
+    open($fh,">$pseudo_list_directory$delta/config");
+    print $fh "name $test_list_name$delta";
+    close $fh;
+}
+
+## Redirecting standard error to tmp file to prevent having logs all over the output.
+open $fh, '>', "$test_directory/error_log" or die "Can't open file $test_directory/error_log in write mode";
+close(STDERR);
+my $out;
+open(STDERR, ">>", \$out) or do { print $fh, "failed to open STDERR ($!)\n"; die };
+
+## Setting pseudo list
+my $list = {name => $test_list_name, domain => $test_robot_name, dir => $pseudo_list_directory};
+bless $list,'Sympa::List';
+
+## Setting pseudo configuration
+%Conf::Conf = map { $_->{'name'} => $_->{'default'} }
+    @Sympa::ConfDef::params;
+
+$Conf::Conf{domain} = $test_robot_name; # mandatory
+$Conf::Conf{listmaster} = $test_listmaster;  # mandatory
+$Conf::Conf{db_type} = 'SQLite';
+$Conf::Conf{db_name} = $test_database_file;
+$Conf::Conf{queuebulk} = $test_directory.'/bulk';
+$Conf::Conf{home} = $test_directory;
+$Conf::Conf{log_socket_type} = 'stream';
+$Conf::Conf{db_list_cache} = 'off';
+
+Sympa::DatabaseManager::probe_db() or die "Unable to contact test database $test_database_file";
+
+## Error checking
+
+my $stash = [];
+my $spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => undef,
+    action           => 'update_list_admin',
+    current_email            => $test_user,
+    role             => 'owner',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner update fails when no list or robot object given.');
+
+is ($stash->[0][2], 'syntax_errors', 'Correct error in stash when missing email.');
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'update_list_admin',
+    role             => 'owner',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner update fails when no email given.');
+
+is ($stash->[0][2], 'missing_parameters', 'Correct error in stash when missing email.');
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'update_list_admin',
+    current_email            => $test_user,
+    new_email        => 'new'.$test_user,
+    role             => 'globuz',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner update fails when the given role does not exist.');
+
+is ($stash->[0][2], 'syntax_errors', 'Correct error in stash when role does not exist.');
+
+is ($stash->[0][3]{p_name}, 'role', 'The error parameter is the role.');
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'update_list_admin',
+    current_email            => 'globuz',
+    new_email        => 'new'.$test_user,
+    role             => 'owner',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner update fails when the given current_email is invalid.');
+
+is ($stash->[0][2], 'syntax_errors', 'Correct error in stash when the given current_email is invalid.');
+
+is ($stash->[0][3]{p_name}, 'current_email', 'The error parameter is the current_email.');
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'update_list_admin',
+    current_email            => $test_user,
+    new_email        => 'new',
+    role             => 'owner',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner update fails when the given new email is invalid.');
+
+is ($stash->[0][2], 'syntax_errors', 'Correct error in stash when the given new email is invalid.');
+
+is ($stash->[0][3]{p_name}, 'new_email', 'The error parameter is the new_email.');
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'update_list_admin',
+    current_email            => $test_user,
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner update fails when the given current email is not admin.');
+
+is ($stash->[0][2], 'not_list_admin', 'Correct error in stash when the given current email is not admin.');
+
+## List owner: replacement by a new owner;
+
+my $sdm = Sympa::DatabaseManager->instance;
+my $sth;
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+my $role = 'owner';
+my $user = {
+    email => $test_user,
+};
+$list->add_list_admin($role, $user) or die 'Unable to add owner';
+
+## Second owner that should not be updated.
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote($test_user),
+);
+
+my @stored_admins;
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 1, 'Test owner is correctly stored in database.');
+
+ok ($spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'update_list_admin',
+    current_email            => $test_user,
+    new_email        => 'new'.$test_user,
+    role             => 'owner',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+), 'Request handler object created');
+
+ok ($spindle->spin(), 'List owner replacement succeeds.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote('new'.$test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 1, 'new list test owner has been added to the database.');
+
+my $owner = $list->get_admins('owner', filter => [email => 'new'.$test_user]);
+
+is($owner->[0]->{email}, 'new'.$test_user, 'The Sympa primitives now return the new user as list owner.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 0, 'former test owner has been removed from database.');
+
+$owner = $list->get_admins('owner', filter => [email => $test_user]);
+
+is(scalar @$owner, 0, 'The Sympa primitives do not return the old owner when queried.');
+
+## Error when trying to update a list owner which does not exist.
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'update_list_admin',
+    current_email            => $test_user,
+    new_email        => 'new'.$test_user,
+    role             => 'owner',
+    sender     =>   $test_listmaster,
+    stash            => $stash,
+);
+
+$spindle->spin();
+
+ok (scalar @$stash, 'List owner update fails when the given email does not have the role to be removed.');
+
+is ($stash->[0][2], 'not_list_admin', 'Correct error in stash when the given email does not have the role to be removed.');
+
+## Parameters handling: parameters are used to create the new admin
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+
+my %parameters = (
+    visibility => {old_value => 'noconceal', new_value => 'conceal', field => 'visibility_admin'},
+    profile => {old_value => 'normal', new_value => 'privileged', field => 'profile_admin'},
+    reception => {old_value => 'mail', new_value => 'nomail', field => 'reception_admin'},
+    gecos => {old_value => 'Dude', new_value => 'New Dude', field => 'comment_admin'},
+    info => {old_value => 'an info', new_value => 'another info', field => 'info_admin'},
+);
+
+$list->add_list_admin('owner', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add editor';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context         => $list,
+    action          => 'update_list_admin',
+    current_email           => $test_user,
+    new_email       => 'new'.$test_user,
+    role            => 'owner',
+    sender          => $test_listmaster,
+    visibility      => $parameters{visibility}{new_value},
+    profile         => $parameters{profile}{new_value},
+    reception       => $parameters{reception}{new_value},
+    gecos           => $parameters{gecos}{new_value},
+    info            => $parameters{info}{new_value},
+    stash           => $stash,
+);
+
+$spindle->spin();
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote('new'.$test_user),
+);
+
+my $new_admin = $sth->fetchrow_hashref();
+
+foreach my $param (keys %parameters) {
+    is ($new_admin->{$parameters{$param}{field}}, $parameters{$param}{new_value}, "Parameter $param has been updated in database.");
+}
+## Correct handling of privileges for owners.
+
+## When replacing a user by another one which has already the same role, the old one is removed and the other one kept the same
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+
+%parameters = (
+    visibility => {old_value => 'noconceal', new_value => 'conceal', field => 'visibility_admin'},
+    profile => {old_value => 'normal', new_value => 'privileged', field => 'profile_admin'},
+    reception => {old_value => 'mail', new_value => 'nomail', field => 'reception_admin'},
+    gecos => {old_value => 'Dude', new_value => 'New Dude', field => 'comment_admin'},
+    info => {old_value => 'an info', new_value => 'another info', field => 'info_admin'},
+);
+
+$list->add_list_admin('owner', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add editor';
+
+$list->add_list_admin('owner', {
+    email       => 'new'.$test_user,
+    visibility  => $parameters{visibility}{new_value},
+    profile     => $parameters{profile}{new_value},
+    reception   => $parameters{reception}{new_value},
+    gecos       => $parameters{gecos}{new_value},
+    info        => $parameters{info}{new_value},
+}) or die 'Unable to add editor';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context         => $list,
+    action          => 'update_list_admin',
+    current_email           => $test_user,
+    new_email       => 'new'.$test_user,
+    role            => 'owner',
+    sender          => $test_listmaster,
+    visibility      => $parameters{visibility}{old_value},
+    profile         => $parameters{profile}{old_value},
+    reception       => $parameters{reception}{old_value},
+    gecos           => $parameters{gecos}{old_value},
+    info            => $parameters{info}{old_value},
+    stash           => $stash,
+);
+
+$spindle->spin();
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote('new'.$test_user),
+);
+
+$new_admin = $sth->fetchrow_hashref();
+
+## When replacing a user by another one which has already the same role, the old one keeps all its parameters (safe privileges, see below).
+
+foreach my $param (keys %parameters) {
+    is ($new_admin->{$parameters{$param}{field}}, $parameters{$param}{new_value}, "Parameter $param for pre-existing admin has been kept the same in database.");
+}
+
+my $old_admin = $sth->fetchrow_hashref();
+
+is($old_admin, undef, 'Old admin has been deleted when replaced by an user that existed already with the same role in the same list.');
+
+## When replacing a user by another one which has already the same role, if "profile" is given with value "privileged", it is applied if the pre-existing owner was "normal".
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+
+%parameters = (
+    profile => {old_value => 'normal', new_value => 'privileged', field => 'profile_admin'},
+);
+
+$list->add_list_admin('owner', {
+    email       => $test_user,
+    profile     => $parameters{profile}{old_value},
+}) or die 'Unable to add editor';
+
+$list->add_list_admin('owner', {
+    email       => 'new'.$test_user,
+    profile     => $parameters{profile}{old_value},
+}) or die 'Unable to add editor';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context         => $list,
+    action          => 'update_list_admin',
+    current_email           => $test_user,
+    new_email       => 'new'.$test_user,
+    role            => 'owner',
+    sender          => $test_listmaster,
+    profile         => $parameters{profile}{new_value},
+    stash           => $stash,
+);
+
+$spindle->spin();
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote('new'.$test_user),
+);
+
+$new_admin = $sth->fetchrow_hashref();
+
+is ($new_admin->{$parameters{profile}{field}}, $parameters{profile}{new_value}, 'Parameter profile for pre-existing admin has been upgraded to higher privilege in database.');
+
+## List editor replacement by a new editor
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+$list->add_list_admin('editor', $user) or die 'Unable to add editor';
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('editor'),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 1, 'Test editor is correctly stored in database.');
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'update_list_admin',
+    current_email            => $test_user,
+    new_email        => 'new'.$test_user,
+    role             => 'editor',
+    stash            => $stash,
+);
+
+ok ($spindle->spin(), 'List editor replacement succeeds.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('editor'),
+    $sdm->quote('new'.$test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 1, 'new list test editor has been added to the database.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('editor'),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 0, 'former test editor has been removed from database.');
+
+## Replacement of all roles in a single list
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+$list->add_list_admin('owner', $user) or die 'Unable to add owner';
+$list->add_list_admin('editor', $user) or die 'Unable to add owner';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $list,
+    action           => 'update_list_admin',
+    current_email            => $test_user,
+    new_email        => 'new'.$test_user,
+    stash            => $stash,
+);
+
+ok ($spindle->spin(), 'List admin replacement succeeds.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 0, 'test user got all his roles in test list removed from database.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+);
+
+@stored_admins = ();
+
+my ($found_editor, $found_owner, $too_much_data);
+
+while (my $row = $sth->fetchrow_hashref()) {
+    if ($row->{user_admin} eq 'new'.$test_user and $row->{role_admin} eq 'editor') {
+        $found_editor = 1;
+    } elsif ($row->{user_admin} eq 'new'.$test_user and $row->{role_admin} eq 'owner') {
+        $found_owner = 1;
+    }else {
+        $too_much_data = 1;
+    }
+}
+
+ok(($found_owner and $found_editor), 'The new user has gathered all roles from previous user.');
+ok(!$too_much_data, 'The database contains the wanted data and them only.');
+
+## Replacement of one role for a whole domain.
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+
+my $list2 = {name => $test_list_name.'2', domain => $test_robot_name, dir => $pseudo_list_directory.'2'};
+bless $list2,'Sympa::List';
+
+my $list3 = {name => $test_list_name.'3', domain => $test_robot_name, dir => $pseudo_list_directory.'3'};
+bless $list3,'Sympa::List';
+
+$list->add_list_admin('owner', $user) or die 'Unable to add owner';
+$list2->add_list_admin('owner', $user) or die 'Unable to add owner';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $test_robot_name,
+    action           => 'update_list_admin',
+    role             => 'owner',
+    current_email            => $test_user,
+    new_email        => 'new'.$test_user,
+    stash            => $stash,
+);
+
+ok ($spindle->spin(), 'List owner replacement succeeds for a whole domain.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 0, 'test user got removed ownership for all lists in the domain.');
+
+## Replacement of all roles for a whole domain.
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+
+$list->add_list_admin('owner', $user) or die 'Unable to add owner';
+$list2->add_list_admin('owner', $user) or die 'Unable to add owner';
+$list->add_list_admin('editor', $user) or die 'Unable to add editor';
+$list2->add_list_admin('editor', $user) or die 'Unable to add editor';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context          => $test_robot_name,
+    action           => 'update_list_admin',
+    current_email            => $test_user,
+    new_email        => 'new'.$test_user,
+    stash            => $stash,
+);
+
+ok ($spindle->spin(), 'List admin replacement succeeds for a whole domain.');
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `robot_admin` LIKE %s and user_admin like %s',
+    $sdm->quote($test_robot_name),
+    $sdm->quote($test_user),
+);
+
+@stored_admins = ();
+
+while (my $row = $sth->fetchrow_hashref()) {
+    push @stored_admins, $row;
+}
+
+is(scalar @stored_admins, 0, 'test user got removed all adminships for all lists in the domain.');
+
+## When the email and new_email parameters are the same, it leads to an update of the old admin in the list only for the given role.
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+
+%parameters = (
+    visibility => {old_value => 'noconceal', new_value => 'conceal', field => 'visibility_admin'},
+    profile => {old_value => 'normal', new_value => 'privileged', field => 'profile_admin'},
+    reception => {old_value => 'mail', new_value => 'nomail', field => 'reception_admin'},
+    gecos => {old_value => 'Dude', new_value => 'New Dude', field => 'comment_admin'},
+    info => {old_value => 'an info', new_value => 'another info', field => 'info_admin'},
+);
+
+$list->add_list_admin('owner', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add editor';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context         => $list,
+    action          => 'update_list_admin',
+    current_email           => $test_user,
+    new_email       => $test_user,
+    role            => 'owner',
+    sender          => $test_listmaster,
+    visibility      => $parameters{visibility}{new_value},
+    profile         => $parameters{profile}{new_value},
+    reception       => $parameters{reception}{new_value},
+    gecos           => $parameters{gecos}{new_value},
+    info            => $parameters{info}{new_value},
+    stash           => $stash,
+);
+
+$spindle->spin();
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote($test_user),
+);
+
+$new_admin = $sth->fetchrow_hashref();
+
+foreach my $param (keys %parameters) {
+    is ($new_admin->{$parameters{$param}{field}}, $parameters{$param}{new_value}, "Parameter $param for updated admin has been kept the same in database.");
+}
+
+## When no new_email parameter is given, it leads to an update of the old admin.
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+
+%parameters = (
+    visibility => {old_value => 'noconceal', new_value => 'conceal', field => 'visibility_admin'},
+    profile => {old_value => 'normal', new_value => 'privileged', field => 'profile_admin'},
+    reception => {old_value => 'mail', new_value => 'nomail', field => 'reception_admin'},
+    gecos => {old_value => 'Dude', new_value => 'New Dude', field => 'comment_admin'},
+    info => {old_value => 'an info', new_value => 'another info', field => 'info_admin'},
+);
+
+$list->add_list_admin('owner', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add editor';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context         => $list,
+    action          => 'update_list_admin',
+    current_email           => $test_user,
+    role            => 'owner',
+    sender          => $test_listmaster,
+    visibility      => $parameters{visibility}{new_value},
+    profile         => $parameters{profile}{new_value},
+    reception       => $parameters{reception}{new_value},
+    gecos           => $parameters{gecos}{new_value},
+    info            => $parameters{info}{new_value},
+    stash           => $stash,
+);
+
+$spindle->spin();
+
+$sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+    $sdm->quote($test_list_name),
+    $sdm->quote($test_robot_name),
+    $sdm->quote('owner'),
+    $sdm->quote($test_user),
+);
+
+$new_admin = $sth->fetchrow_hashref();
+
+foreach my $param (keys %parameters) {
+    is ($new_admin->{$parameters{$param}{field}}, $parameters{$param}{new_value}, "Parameter $param for updated admin has been kept the same in database.");
+}
+
+## When no new_email and no role parameters are given, parameters are used to update the old admin for all roles in the list.
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+
+%parameters = (
+    visibility => {old_value => 'noconceal', new_value => 'conceal', field => 'visibility_admin'},
+    profile => {old_value => 'normal', new_value => 'privileged', field => 'profile_admin'},
+    reception => {old_value => 'mail', new_value => 'nomail', field => 'reception_admin'},
+    gecos => {old_value => 'Dude', new_value => 'New Dude', field => 'comment_admin'},
+    info => {old_value => 'an info', new_value => 'another info', field => 'info_admin'},
+);
+
+$list->add_list_admin('owner', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add editor';
+
+$list->add_list_admin('editor', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add editor';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context         => $list,
+    action          => 'update_list_admin',
+    current_email           => $test_user,
+    sender          => $test_listmaster,
+    visibility      => $parameters{visibility}{new_value},
+    profile         => $parameters{profile}{new_value},
+    reception       => $parameters{reception}{new_value},
+    gecos           => $parameters{gecos}{new_value},
+    info            => $parameters{info}{new_value},
+    stash           => $stash,
+);
+
+$spindle->spin();
+
+foreach my $role ('owner', 'editor') {
+    $sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+        $sdm->quote($test_list_name),
+        $sdm->quote($test_robot_name),
+        $sdm->quote($role),
+        $sdm->quote($test_user),
+    );
+
+    my $new_admin = $sth->fetchrow_hashref();
+
+    foreach my $param (keys %parameters) {
+        if ($param eq 'profile' && $role eq 'editor') {
+            is ($new_admin->{$parameters{$param}{field}}, 'normal', "Parameter $param for old admin has been ignored while updating database for role $role.");
+        }else{
+            is ($new_admin->{$parameters{$param}{field}}, $parameters{$param}{new_value}, "Parameter $param for old admin has been updated in database for role $role.");
+        }
+    }
+}
+
+## When no new_email and no list parameters are given, parameters are used to update the old admin for the given role on the whole robot.
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+
+%parameters = (
+    visibility => {old_value => 'noconceal', new_value => 'conceal', field => 'visibility_admin'},
+    profile => {old_value => 'normal', new_value => 'privileged', field => 'profile_admin'},
+    reception => {old_value => 'mail', new_value => 'nomail', field => 'reception_admin'},
+    gecos => {old_value => 'Dude', new_value => 'New Dude', field => 'comment_admin'},
+    info => {old_value => 'an info', new_value => 'another info', field => 'info_admin'},
+);
+
+$list->add_list_admin('owner', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add editor';
+
+$list2->add_list_admin('owner', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add editor';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context         => $test_robot_name,
+    action          => 'update_list_admin',
+    current_email           => $test_user,
+    role            => 'owner',
+    sender          => $test_listmaster,
+    visibility      => $parameters{visibility}{new_value},
+    profile         => $parameters{profile}{new_value},
+    reception       => $parameters{reception}{new_value},
+    gecos           => $parameters{gecos}{new_value},
+    info            => $parameters{info}{new_value},
+    stash           => $stash,
+);
+
+$spindle->spin();
+
+foreach my $list ('testlist', 'testlist2') {
+    $sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+        $sdm->quote($list),
+        $sdm->quote($test_robot_name),
+        $sdm->quote('owner'),
+        $sdm->quote($test_user),
+    );
+
+    my $new_admin = $sth->fetchrow_hashref();
+
+    foreach my $param (keys %parameters) {
+        is ($new_admin->{$parameters{$param}{field}}, $parameters{$param}{new_value}, "Parameter $param for old admin has been updated in database for list $list.");
+    }
+}
+
+
+## When no new_email, no list and no role parameters are given, parameters are used to update the old admin for all roles in the whole robot.
+
+$sdm->do_query('DELETE FROM `admin_table` WHERE 1');
+
+%parameters = (
+    visibility => {old_value => 'noconceal', new_value => 'conceal', field => 'visibility_admin'},
+    profile => {old_value => 'normal', new_value => 'privileged', field => 'profile_admin'},
+    reception => {old_value => 'mail', new_value => 'nomail', field => 'reception_admin'},
+    gecos => {old_value => 'Dude', new_value => 'New Dude', field => 'comment_admin'},
+    info => {old_value => 'an info', new_value => 'another info', field => 'info_admin'},
+);
+
+$list->add_list_admin('owner', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add owner';
+
+$list2->add_list_admin('owner', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add owner';
+
+$list->add_list_admin('editor', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add editor';
+
+$list2->add_list_admin('editor', {
+    email       => $test_user,
+    visibility  => $parameters{visibility}{old_value},
+    profile     => $parameters{profile}{old_value},
+    reception   => $parameters{reception}{old_value},
+    gecos       => $parameters{gecos}{old_value},
+    info        => $parameters{info}{old_value},
+}) or die 'Unable to add editor';
+
+$stash = [];
+$spindle = Sympa::Spindle::ProcessRequest->new(
+    context         => $test_robot_name,
+    action          => 'update_list_admin',
+    current_email           => $test_user,
+    sender          => $test_listmaster,
+    visibility      => $parameters{visibility}{new_value},
+    profile         => $parameters{profile}{new_value},
+    reception       => $parameters{reception}{new_value},
+    gecos           => $parameters{gecos}{new_value},
+    info            => $parameters{info}{new_value},
+    stash           => $stash,
+);
+
+$spindle->spin();
+
+foreach my $role ('owner', 'editor') {
+    foreach my $list ('testlist', 'testlist2') {
+        $sth = $sdm->do_query('SELECT * from `admin_table` WHERE `list_admin` LIKE %s and `robot_admin` LIKE %s and role_admin LIKE %s and user_admin like %s',
+            $sdm->quote($list),
+            $sdm->quote($test_robot_name),
+            $sdm->quote($role),
+            $sdm->quote($test_user),
+        );
+
+        my $new_admin = $sth->fetchrow_hashref();
+
+        foreach my $param (keys %parameters) {
+            if ($param eq 'profile' && $role eq 'editor') {
+                is ($new_admin->{$parameters{$param}{field}}, 'normal', "Parameter $param for old admin has been ignored while updating database for list $list and role $role.");
+            }else{
+                is ($new_admin->{$parameters{$param}{field}}, $parameters{$param}{new_value}, "Parameter $param for old admin has been updated in database for list $list and role $role.");
+            }
+        }
+    }
+}
+
+rmtree $test_directory;
+
+done_testing();


### PR DESCRIPTION
See Issue #524 for discussion.

The aim of this PR is to give administrators the possibility to update list administrators (owners or editors) through the command line. The idea here is to be able to change details of a list administrator (visibility, privileges, etc.) in one operation, witout having to delete, then add it. It alos allows to replace a user by another one, keeping all previous details except if told otherwise.
As it is based on a Request handler, it also introduces the possibility to do so through the Sympa API (SOAP, and later REST).
It is complemented by two other PR, allowing deletion and addition of list admins.

Adding :
    - a Request handler dedicated to list admin update,
    - a sympa.pl command line option to update a list admin, based on this handler,
    - tests for the handler module.

The command line allows the following options:

```--update_list_admin --current_email=user@example.com (--list=list@domain | --robot=robot ) [ --new_email=new_user@example.com --role=role --profile=privileged|normal --info=<description> --visibility=conceal|noconceal --reception=mail|nomail --gecos=<a gecos> ]```

Updates a list admin, either replacing it with a new user (if "--new_email" is given and is different from "--current_email") or simply updating her informations.

    - "--current_email" is the list admin's email address. It is mandatory.
    - Either "--list" or "--robot" is mandatory.
    - If no "--role" is given, all administrative roles will be updated (both editor and owner).

