### PR TITLE
Replace `http_host` parameter with `wwsympa_url_local` parameter (addition to #910)

### DIFF
--- a/src/lib/Sympa/ConfDef.pm
+++ b/src/lib/Sympa/ConfDef.pm
@@ -1377,10 +1377,9 @@ our @params = (
         'gettext_comment' =>
             'This is used to construct URLs of web interface.',
     },
-    {   'name'       => 'http_host',
+    {   'name'       => 'wwsympa_url_local',
         'gettext_id' => 'URL prefix of WWSympa behind proxy',
         'vhost'      => '1',
-        'file'       => 'sympa.conf',
         'optional'   => '1',
     },
     {   'name'       => 'static_content_url',
@@ -2222,6 +2221,10 @@ our @params = (
     },
     {   'name'    => 'filesystem_encoding',
         'default' => 'utf-8',
+    },
+    {   'name'     => 'http_host',    # ??? - 6.2.54
+        'vhost'    => '1',
+        'optional' => '1',
     },
 
     #FIXME: Is it currently available?

--- a/src/lib/Sympa/WWW/FastCGI.pm
+++ b/src/lib/Sympa/WWW/FastCGI.pm
@@ -36,11 +36,13 @@ sub new {
     my $self = $class->SUPER::new(@args);
 
     # Determin mail domain (a.k.a. "robot") the request is dispatched.
-    # N.B. As of 6.2.15, the http_host parameter will match with the host name
+    # N.B. As of 6.2.15, the http_host parameter (replaced with
+    # wwsympa_url_local parameter on 6.2.55b) will match with the host name
     # and path locally detected by server.  If remotely detected host name
     # and / or path should be differ, the proxy must adjust them.
     # N.B. As of 6.2.34, wwsympa_url parameter may be optional.
-    my @vars = Sympa::WWW::Tools::get_robot('http_host', 'wwsympa_url');
+    my @vars =
+        Sympa::WWW::Tools::get_robot('wwsympa_url_local', 'wwsympa_url');
     if (@vars) {
         @ENV{qw(ORIG_SCRIPT_NAME ORIG_PATH_INFO)} =
             @ENV{qw(SCRIPT_NAME PATH_INFO)};


### PR DESCRIPTION
This PR is based on #910.

Though the `http_host` parameter has been obsoleted, many site may set this parameter as the same as host part of `wwsympa_url` and they may have to remove it (e.g. see [a post on dev list](https://listes.renater.fr/sympa/arcsearch_id/sympa-developpers/2020-03/cef874de-1935-36d2-fa46-0b6ac8c309d8%40linuxia.de)).

Instead of keeping this complicating parameter, we'd be better to introduce the new `wwsympa_url_local` parameter to specify proxy upstream URL.
