### PR TITLE
Fix missing content for listmaster admin template edits in the web interface

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -8340,6 +8340,25 @@ sub do_editfile {
 
             $param->{'filepath'} = Sympa::search_fullpath($list || $robot,
                 $file, subdir => $subdir);
+
+            $param->{'filecontent'} = Sympa::Tools::Text::slurp($param->{'filepath'});
+
+            unless (defined $param->{'filecontent'}) {
+                wwslog('err', 'Failed to open file %s: %m', $param->{'filepath'});
+                Sympa::WWW::Report::reject_report_web(
+                    'intern', 'cannot_open_file',
+                    {'file' => $param->{'file_path'}}, $param->{'action'},
+                    $list, $param->{'user'}{'email'},
+                    $robot
+                );
+                web_db_log(
+                    {   'parameters' => $in{'file'},
+                        'status'     => 'error',
+                        'error_type' => 'internal'
+                    }
+                );
+                return undef;
+            }
         }
     }
 

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -8335,30 +8335,27 @@ sub do_editfile {
             $param->{'filepath'} =
                 Sympa::search_fullpath($list || $robot, $file);
         } else {
-            #my $lang = Conf::get_robot_conf($robot, 'lang');
-            #$file =~ s/\.tpl$/\.$lang\.tpl/;
-
             $param->{'filepath'} = Sympa::search_fullpath($list || $robot,
                 $file, subdir => $subdir);
+        }
 
-            $param->{'filecontent'} = Sympa::Tools::Text::slurp($param->{'filepath'});
+        $param->{'filecontent'} = Sympa::Tools::Text::slurp($param->{'filepath'});
 
-            unless (defined $param->{'filecontent'}) {
-                wwslog('err', 'Failed to open file %s: %m', $param->{'filepath'});
-                Sympa::WWW::Report::reject_report_web(
-                    'intern', 'cannot_open_file',
-                    {'file' => $param->{'file_path'}}, $param->{'action'},
-                    $list, $param->{'user'}{'email'},
-                    $robot
-                );
-                web_db_log(
-                    {   'parameters' => $in{'file'},
-                        'status'     => 'error',
-                        'error_type' => 'internal'
-                    }
-                );
-                return undef;
-            }
+        unless (defined $param->{'filecontent'}) {
+            wwslog('err', 'Failed to open file %s: %m', $param->{'filepath'});
+            Sympa::WWW::Report::reject_report_web(
+                'intern', 'cannot_open_file',
+                {'file' => $param->{'file_path'}}, $param->{'action'},
+                $list, $param->{'user'}{'email'},
+                $robot
+            );
+            web_db_log(
+                {   'parameters' => $in{'file'},
+                    'status'     => 'error',
+                    'error_type' => 'internal'
+                }
+            );
+            return undef;
         }
     }
 


### PR DESCRIPTION
This is a simple commit to fix the issue. The code for `do_editfile` could be improved further. Especially the following code doesn't make sense as it is called *after* the file contents have been slurped:
```

  if (-f $param->{'filepath'} && (!-r $param->{'filepath'})) {
        Sympa::WWW::Report::reject_report_web('intern', 'cannot_read',
            {'filepath' => $param->{'filepath'}},
            $param->{'action'}, '', $param->{'user'}{'email'}, $robot);
        wwslog('err', 'Cannot read %s', $param->{'filepath'});
        web_db_log(
            {   'parameters' => $in{'file'},
                'status'     => 'error',
                'error_type' => 'internal'
            }
        );
        return undef;
    }
```