### PR TITLE
list index performance update for wwsympa.fcgi do_lists subroutine

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -4170,16 +4170,27 @@ sub do_lists {
     my @lists;
     wwslog('info', '(%s, %s)', $in{'topic'}, $in{'subtopic'});
 
+    # Get member/owner/editor data used to avoid lookups in the loop
+    my $which = {};
+    foreach my $role ('member', 'owner', 'editor') {
+        foreach my $list (
+            Sympa::List::get_which($param->{'user'}{'email'},$robot, $role)
+            ) {
+            $which->{$role}->{$list->{'name'}} = $list;
+        }
+    }
+    foreach my $list (values %{$which->{'owner'}}) {
+        $which->{'privileged_owner'}->{$list->{'name'}} =
+            $list->is_admin('privileged_owner', $param->{'user'}{'email'});
+        $which->{'actual_editor'}->{$list->{'name'}} =
+            $list->is_admin('actual_editor', $param->{'user'}{'email'});
+    }
+
     my $all_lists = [];
     if ($in{'topic'} and $in{'topic'} eq '@which') {
         my %lists = ();
         foreach my $role ('member', 'owner', 'editor') {
-            foreach my $list (
-                Sympa::List::get_which(
-                    $param->{'user'}{'email'},
-                    $robot, $role
-                )
-            ) {
+            foreach my $list ($which->{$role}) {
                 $lists{$list->{'name'}} = $list;
             }
         }
@@ -4204,6 +4215,7 @@ sub do_lists {
 
     foreach my $list (@$all_lists) {
         my $sender = $param->{'user'}{'email'} || 'nobody';
+        my $listname = $list->{'name'};
 
         my $result =
             Sympa::Scenario->new($list, 'visibility',
@@ -4229,31 +4241,28 @@ sub do_lists {
         $list_info->{'host'} = $list->{'domain'};
 
         if (    $param->{'user'}{'email'}
-            and
-            $list->is_admin('privileged_owner', $param->{'user'}{'email'})) {
+            and defined($which->{'privileged_owner'}->{$listname})) {
             $list_info->{'is_privileged_owner'} = 1;
             $list_info->{'is_owner'}            = 1;
             # Compat. < 6.2b.2.
             $list_info->{'admin'} = 1;
         }
         if (    $param->{'user'}{'email'}
-            and $list->is_admin('owner', $param->{'user'}{'email'})) {
+            and defined($which->{'owner'}->{$listname})) {
             $list_info->{'is_owner'} = 1;
             # Compat. < 6.2b.2.
             $list_info->{'admin'} = 1;
         }
         if (    $param->{'user'}{'email'}
-            and $list->is_admin('actual_editor', $param->{'user'}{'email'})) {
+            and defined($which->{'actual_editor'}->{$listname})) {
             $list_info->{'is_editor'} = 1;
             # Compat. < 6.2b.2.
             $list_info->{'admin'} = 1;
         }
         if (    $param->{'user'}{'email'}
-            and $list->is_list_member($param->{'user'}{'email'})) {
+            and defined($which->{'member'}->{$listname})) {
             $list_info->{'is_subscriber'} = 1;
         }
-
-        my $listname = $list->{'name'};
 
         $param->{'which'} ||= {};
         $param->{'which'}{$listname} = $list_info;

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -4182,6 +4182,10 @@ sub do_lists {
     foreach my $list (values %{$which->{'owner'}}) {
         $which->{'privileged_owner'}->{$list->{'name'}} =
             $list->is_admin('privileged_owner', $param->{'user'}{'email'});
+        $which->{'owner'}->{$list->{'name'}} =
+            $list->is_admin('owner', $param->{'user'}{'email'});
+    }
+    foreach my $list (values %{$which->{'editor'}}) {
         $which->{'actual_editor'}->{$list->{'name'}} =
             $list->is_admin('actual_editor', $param->{'user'}{'email'});
     }


### PR DESCRIPTION
For some background information, we're running Sympa 6.2.54 in a 
RHEL 7 environment. We've got around 6,000 lists and close to 
770,000 subscribers. 

Since upgrading to Sympa 6.2 about two years ago, we've come across 
a performance issue when an authenticated user uses the "list index" 
page (the /sympa/lists URI) to view all lists they have access to 
see. This page can take quite a while to load for an authenticated 
user (30-45 seconds). 

Digging around in the code, it appears the reason it takes a long 
time for this page to load in our environment is that there is a 
database lookup on a per list basis to check whether or not the user 
is either a privileged owner, owner, editor or subscriber. This 
lookup has become expensive for us due to the large number of active 
lists we have in our environment.

With this update, we've made some changes to the do_lists subroutine 
in wwsympa.fcgi. A hash is loaded with the user's list membership 
and we use hash lookups to check for user's list membership to avoid 
a large number of database lookups. We hope this change does not 
obviate any list visibility checking mechanisms for which we have 
not thought of but we've tried to leverage the existing list loop 
checking mechanism to avoid any unwanted visibility issues. This 
update has been vetted for Sympa 6.2.54 and we've seen a 3x 
performance improvement in our environment with load times (albeit 
long still) between 10-15 seconds.