### PR TITLE
2 fixes related to list families

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -990,26 +990,6 @@ sub load {
                     $self->{'admin'}{'family_name'});
                 return undef;
             }
-            my $error = $family->check_param_constraint($self);
-            unless ($error) {
-                $log->syslog(
-                    'err',
-                    'Impossible to check parameters constraint for list % set in status error_config',
-                    $self->{'name'}
-                );
-                $self->set_status_error_config('no_check_rules_family',
-                    $family->{'name'});
-            }
-            if (ref($error) eq 'ARRAY') {
-                $log->syslog(
-                    'err',
-                    'The list "%s" does not respect the rules from its family %s',
-                    $self->{'name'},
-                    $family->{'name'}
-                );
-                $self->set_status_error_config('no_respect_rules_family',
-                    $family->{'name'});
-            }
         }
     }
 

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -780,8 +780,9 @@ if ($main::options{'dump'} or $main::options{'dump_users'}) {
         print STDOUT "@{$result{'info'}}";
         print STDOUT "@{$result{'warn'}}";
     }
-    if ($err) {
+    if ($err >= 0) {
         print STDERR "@{$result{'errors'}}";
+	exit 1;
     }
 
     exit 0;


### PR DESCRIPTION
One minor fix to handle errors when running `sympa.pl --instantiate_family`
The other is more important for us because it makes our Sympa GUI almost unusable because of horrible performances on global functions (/lists mainly).