### PR TITLE
Fix optimize lists command

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -4183,6 +4183,10 @@ sub do_lists {
     my @lists;
     wwslog('info', '(%s, %s)', $in{'topic'}, $in{'subtopic'});
 
+    ## Init List cache to save DB requests
+    Sympa::List::init_admin_cache($robot);
+    Sympa::List::init_is_member_cache($robot, $param->{'user'}{'email'}) if ($param->{'user'}{'email'});
+
     # Get member/owner/editor data used to avoid lookups in the loop
     my $which = {member => {}, owner => {}, editor => {}};
     if ($param->{'user'}{'email'}) {

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -683,7 +683,7 @@ sub _cache_get {
     $self->{_mtime}{$type} = $mtime;
 
     return undef unless defined $lasttime and defined $mtime;
-    return undef if $lasttime <= $mtime;
+    return undef if $lasttime < $mtime;
     return $self->{_cached}{$type};
 }
 
@@ -691,6 +691,14 @@ sub _cache_put {
     my $self  = shift;
     my $type  = shift;
     my $value = shift;
+
+    my $mtime;
+    if ($type eq 'total' or $type eq 'is_list_member') {
+        $mtime = $self->_cache_read_expiry('member');
+    } else {
+        $mtime = $self->_cache_read_expiry($type);
+    }
+    $self->{_mtime}{$type} = $mtime;
 
     return $self->{_cached}{$type} = $value;
 }


### PR DESCRIPTION
Two commits in this branch, the second one depending on the first:

1. Fix List.pm cache management. _cache_put() did not set '_mtime' ; it prevented the cache from being used by _cache_get(). PR #583 introduced a bug: most of the time  equals  ; _cache_get() returned undef whereas the data was in cache.
2. Optimize the do_lists() function. Profiling analysis reveals that the cost of this subroutine is related to SQL queries for each list in admin_table and subscriber_table. The trick here is to do a single SQL query to initialize List.pm's cache. Subsequent is-subscriber() or is_owner() checks are performed with no additionnal SQL queries.

I think (1) shoud really be applied upstream.
For (2), it's up to you since I didn't observe significant response time progress on our staging server with 2.400 mailing lists. Given our discussion in #584, I know that you want to remove caching in Sympa, so you might not like to add more of it.

For the records, here are the profiling results before and after these changes. You'll notice that do_prepared_query() is much less called afterward:

Profiling before the code changes:
![profiler-global-branch-6 2-asis](https://user-images.githubusercontent.com/4091149/81702478-9f1b4f00-946b-11ea-9787-9234551c98a6.png)
![profiler-sql-queries-branch-6 2-asis](https://user-images.githubusercontent.com/4091149/81702488-a3476c80-946b-11ea-9b02-e0fa577e7b6d.png)


Profiling after the code changes:
![profiler-global-branch-6 2-limit-sql-queries](https://user-images.githubusercontent.com/4091149/81702502-a93d4d80-946b-11ea-9a08-a2521628edd4.png)
![profiler-sql-queries-branch-6 2-limit-sql-queries](https://user-images.githubusercontent.com/4091149/81702517-ac383e00-946b-11ea-8346-1c00acd460c4.png)
