### PR TITLE
Every time users were loaded via include_sql_query Sympa would raise warnings

### DIFF
--- a/src/lib/Sympa/DataSource/SQL.pm
+++ b/src/lib/Sympa/DataSource/SQL.pm
@@ -88,7 +88,7 @@ sub _open {
                     $email =~ s/[\t\r\n]+/ /g;
                     $value =~ s/[\t\r\n]+/ /g if defined $value;
 
-                    printf $tmpfh "%s\t%s\n", $email, $value;
+                    printf $tmpfh "%s\t%s\n", $email, $value // '';
                 }
             }
             $sth->finish;

--- a/src/lib/Sympa/DataSource/SQL.pm
+++ b/src/lib/Sympa/DataSource/SQL.pm
@@ -86,14 +86,9 @@ sub _open {
                     my ($email, $value) = @$row;
                     next unless defined $email and length $email;
                     $email =~ s/[\t\r\n]+/ /g;
-					
-					# The SQL query may return the user name 
-					if ($value) {
-						$value =~ s/[\t\r\n]+/ /g if defined $value;	
-                     	printf $tmpfh "%s\t%s\n", $email, $value;
-					}else {
-						printf $tmpfh "%s\n", $email;
-					}	
+                    $value =~ s/[\t\r\n]+/ /g if defined $value;
+
+                    printf $tmpfh "%s\t%s\n", $email, $value;
                 }
             }
             $sth->finish;

--- a/src/lib/Sympa/DataSource/SQL.pm
+++ b/src/lib/Sympa/DataSource/SQL.pm
@@ -86,9 +86,14 @@ sub _open {
                     my ($email, $value) = @$row;
                     next unless defined $email and length $email;
                     $email =~ s/[\t\r\n]+/ /g;
-                    $value =~ s/[\t\r\n]+/ /g if defined $value;
-
-                    printf $tmpfh "%s\t%s\n", $email, $value;
+					
+					# The SQL query may return the user name 
+					if ($value) {
+						$value =~ s/[\t\r\n]+/ /g if defined $value;	
+                     	printf $tmpfh "%s\t%s\n", $email, $value;
+					}else {
+						printf $tmpfh "%s\n", $email;
+					}	
                 }
             }
             $sth->finish;


### PR DESCRIPTION
Obviously the issue was introduced back in 2015, as mentionned in https://listes.renater.fr/sympa/arc/sympa-users/2015-12/msg00002.html.

Here is an example of the issue :
```
/usr/local/sympa/bin/sympa.pl --sync_include=mylist-with-included-members@listes.etudiant.univ-rennes1.fr
...
Use of uninitialized value $value in printf at /usr/local/sympa/bin/Sympa/DataSource/SQL.pm line 91, <GEN1> line 1.
Use of uninitialized value $value in printf at /usr/local/sympa/bin/Sympa/DataSource/SQL.pm line 91, <GEN1> line 1.
Use of uninitialized value $value in printf at /usr/local/sympa/bin/Sympa/DataSource/SQL.pm line 91, <GEN1> line 1.
include [notice] Subscribers were included from data source "mysource" into list mylist-with-included-members.
include [notice] Inclusion succeeded (69 added, 15 deleted, 2175 updated).
```