### PR TITLE
[SA 2020-002] Security flaws in setuid wrappers (#943)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -608,6 +608,30 @@ AC_ARG_WITH(
 )
 AC_SUBST(POSTMAP_ARG)
 
+AC_MSG_CHECKING([whether we install setuid wrappers for web interface])
+AC_ARG_ENABLE(
+    setuid_fcgi,
+    AS_HELP_STRING(
+        [--disable-setuid_fcgi],
+        [do not install setuid wrappers for web interface]
+    ), ,
+    [enable_setuid_fcgi="yes"],
+)
+AC_MSG_RESULT([$enable_setuid_fcgi])
+AM_CONDITIONAL(SETUID_FCGI, [test "x$enable_setuid_fcgi" = "xyes"])
+
+AC_MSG_CHECKING([whether we set setuid bit of queue programs])
+AC_ARG_ENABLE(
+    setuid_queue,
+    AS_HELP_STRING(
+        [--disable-setuid_queue],
+        [do not set setuid bit of queue programs]
+    ), ,
+    [enable_setuid_queue="yes"],
+)
+AC_MSG_RESULT([$enable_setuid_queue])
+AM_CONDITIONAL(SETUID_QUEUE, [test "x$enable_setuid_queue" = "xyes"])
+
 AC_CONFIG_FILES([
     Makefile
     sympa.conf

--- a/src/cgi/Makefile.am
+++ b/src/cgi/Makefile.am
@@ -21,12 +21,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 execcgi_SCRIPTS = wwsympa.fcgi sympa_soap_server.fcgi
+if SETUID_FCGI
 execcgi_PROGRAMS = wwsympa-wrapper.fcgi sympa_soap_server-wrapper.fcgi
 wwsympa_wrapper_fcgi_SOURCES = wwsympa-wrapper.fcgi.c
 wwsympa_wrapper_fcgi_CPPFLAGS = -DWWSYMPA=\"$(execcgidir)/wwsympa.fcgi\"
 sympa_soap_server_wrapper_fcgi_SOURCES = sympa_soap_server-wrapper.fcgi.c
 sympa_soap_server_wrapper_fcgi_CPPFLAGS = \
 			-DSYMPASOAP=\"$(execcgidir)/sympa_soap_server.fcgi\"
+endif
 
 man8_MANS = \
 	wwsympa.8 \
@@ -36,6 +38,7 @@ EXTRA_DIST = wwsympa.fcgi.in sympa_soap_server.fcgi.in
 
 CLEANFILES = $(execcgi_SCRIPTS) $(man8_MANS)
 
+if SETUID_FCGI
 install-exec-hook:
 	-chown $(USER) $(DESTDIR)$(execcgidir)/wwsympa-wrapper.fcgi
 	-chgrp $(GROUP) $(DESTDIR)$(execcgidir)/wwsympa-wrapper.fcgi
@@ -43,6 +46,7 @@ install-exec-hook:
 	-chown $(USER) $(DESTDIR)$(execcgidir)/sympa_soap_server-wrapper.fcgi
 	-chgrp $(GROUP) $(DESTDIR)$(execcgidir)/sympa_soap_server-wrapper.fcgi
 	chmod 6755 $(DESTDIR)$(execcgidir)/sympa_soap_server-wrapper.fcgi
+endif
 
 wwsympa.fcgi sympa_soap_server.fcgi: Makefile
 	@rm -f $@

--- a/src/cgi/sympa_soap_server-wrapper.fcgi.c
+++ b/src/cgi/sympa_soap_server-wrapper.fcgi.c
@@ -6,6 +6,9 @@
   Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
   2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
   Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
+  Copyright 2020 The Sympa Community. See the AUTHORS.md
+  file at the top-level directory of this distribution and at
+  <https://github.com/sympa-community/sympa.git>.
  
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -24,8 +27,10 @@
 #include <unistd.h>
 
 int main(int argn, char **argv, char **envp) {
+    char *myenvp[] = { "IFS= \t\n", "PATH=/bin:/usr/bin", NULL };
+
     setreuid(geteuid(),geteuid());
     setregid(getegid(),getegid());
     argv[0] = SYMPASOAP;
-    return execve(SYMPASOAP,argv,envp);
+    return execve(SYMPASOAP, argv, myenvp);
 }

--- a/src/cgi/wwsympa-wrapper.fcgi.c
+++ b/src/cgi/wwsympa-wrapper.fcgi.c
@@ -6,6 +6,9 @@
   Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
   2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
   Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
+  Copyright 2020 The Sympa Community. See the AUTHORS.md
+  file at the top-level directory of this distribution and at
+  <https://github.com/sympa-community/sympa.git>.
  
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -24,8 +27,10 @@
 #include <unistd.h>
 
 int main(int argn, char **argv, char **envp) {
+    char *myenvp[] = { "IFS= \t\n", "PATH=/bin:/usr/bin", NULL };
+
     setreuid(geteuid(),geteuid()); // Added to fix the segfault
     setregid(getegid(),getegid()); // Added to fix the segfault
     argv[0] = WWSYMPA;
-    return execve(WWSYMPA,argv,envp);
+    return execve(WWSYMPA, argv, myenvp);
 }

--- a/src/libexec/Makefile.am
+++ b/src/libexec/Makefile.am
@@ -57,15 +57,28 @@ sympa_newaliases_wrapper_CPPFLAGS = $(AM_CPPFLAGS) \
 install-exec-hook:
 	-chown $(USER) $(DESTDIR)$(libexecdir)/queue
 	-chgrp $(GROUP) $(DESTDIR)$(libexecdir)/queue
+if SETUID_QUEUE
 	chmod 4755 $(DESTDIR)$(libexecdir)/queue
+else
+	chmod 0755 $(DESTDIR)$(libexecdir)/queue
+endif
 
 	-chown $(USER) $(DESTDIR)$(libexecdir)/bouncequeue
 	-chgrp $(GROUP) $(DESTDIR)$(libexecdir)/bouncequeue
+if SETUID_QUEUE
 	chmod 4755 $(DESTDIR)$(libexecdir)/bouncequeue
+else
+	chmod 0755 $(DESTDIR)$(libexecdir)/bouncequeue
+endif
 
 	-chown $(USER) $(DESTDIR)$(libexecdir)/familyqueue
 	-chgrp $(GROUP) $(DESTDIR)$(libexecdir)/familyqueue
+if SETUID_QUEUE
 	chmod 4755 $(DESTDIR)$(libexecdir)/familyqueue
+else
+	chmod 0755 $(DESTDIR)$(libexecdir)/familyqueue
+endif
+
 if SMRSH
 	@echo 'Installing symbolic links for Sendmail smrsh'
 	$(INSTALL) -d -m 755 $(DESTDIR)$(smrshdir)

--- a/src/libexec/sympa_newaliases-wrapper.c
+++ b/src/libexec/sympa_newaliases-wrapper.c
@@ -6,6 +6,9 @@
   Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
   2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
   Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
+  Copyright 2020 The Sympa Community. See the AUTHORS.md
+  file at the top-level directory of this distribution and at
+  <https://github.com/sympa-community/sympa.git>.
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -24,8 +27,10 @@
 #include <unistd.h>
 
 int main(int argn, char **argv, char **envp) {
+    char *myenvp[] = { "IFS= \t\n", "PATH=/bin:/usr/bin", NULL };
+
     setreuid(geteuid(),geteuid());
     setregid(getegid(),getegid());
     argv[0] = SYMPA_NEWALIASES;
-    return execve(SYMPA_NEWALIASES, argv, envp);
+    return execve(SYMPA_NEWALIASES, argv, myenvp);
 }


### PR DESCRIPTION
This may fix #943 .

- Setuid wrappers should clear environment variables to avoid exploits. Clear environment varialbes.
- configure: Add options --disable-setuid_fcgi & --disable-setuid_queue.
 