### PR TITLE
Deprecate implicit sync_include in Sympa::List constructor

### DIFF
--- a/default/Makefile.am
+++ b/default/Makefile.am
@@ -383,6 +383,7 @@ nobase_default_DATA = \
 	mail_tt2/request_auth.tt2 \
 	mail_tt2/report.tt2 \
 	mail_tt2/review.tt2 \
+	mail_tt2/shared_moderate.tt2 \
 	mail_tt2/send_auth.tt2 \
 	mail_tt2/sendpasswd.tt2 \
 	mail_tt2/sendssopasswd.tt2 \

--- a/default/mail_tt2/delivery_status_notification.tt2
+++ b/default/mail_tt2/delivery_status_notification.tt2
@@ -11,7 +11,7 @@ Subject: [%"List unknown"|loc|qencode%]
 Subject: [%"List unknown"|loc|qencode%]
 [% ELSIF status == '5.2.3' -%]
 Subject: [%"Too large message"|loc|qencode%]
-[% ELSIF status == '5.3.0' -%]
+[% ELSIF status == '5.2.4' || status == '5.3.0' -%]
 Subject: [%"Message distribution: Internal server error"|loc|qencode%]
 [% ELSIF status == '5.3.5' -%]
 Subject: [%"Message distribution: User error"|loc|qencode%]
@@ -59,12 +59,13 @@ Content-Description: Notification
 
 Note: Because binary files have to be encoded in less-efficient ASCII format before being sent over email, the final size of an attachment is often significantly larger that the original file.[%END%]
 
-[%   ELSIF status == '5.3.0' -%]
-[% IF entry == 'forward' -%]
+[%   ELSIF status == '5.2.4' -%]
 [%|loc(list.name,function)%]Impossible to forward your message to '%1-%2' because of an internal server error.[%END%]
-[% ELSE -%]
+
+[%|loc(list.name,domain)%]For further information, please contact %1-request@%2[%END -%]
+
+[%   ELSIF status == '5.3.0' -%]
 [%|loc(list.name)%]Impossible to distribute your message for list '%1' because of an internal server error.[%END%]
-[% END -%]
 
 [%|loc(list.name,domain)%]For further information, please contact %1-request@%2[%END -%]
 

--- a/default/mail_tt2/listeditor_notification.tt2
+++ b/default/mail_tt2/listeditor_notification.tt2
@@ -1,25 +1,12 @@
 [%# listeditor_notification.tt2 ~%]
-To: [% to %]
+[%# As of 6.2.57b, this template will no longer be used. It is left for
+    compatibility. ~%]
 [% IF type == 'shared_moderated' -%]
-Subject: [%"Shared document to be approved for %1"|loc(list.name)|qencode%]
-
-[% IF many_files -%]
-[%|loc(list.name,filename,who)%]There are new shared documents in list %1: 
-    %2
-    from %3
-
-To moderate these documents: [%END%]
+[% PROCESS shared_moderate.tt2 %] 
 [%- ELSE -%]
-[%|loc(list.name,filename,who)%]There is a new shared document in list %1: 
-    %2
-    from %3
-
-To moderate this document: [%END%]
-[%- END %]
-[% 'docindex' | url_abs([list.name]) %]
-
-[% ELSE -%]
+From: [% fromlist %]
+To: [%"Moderator"|loc|mailbox("${list.name}-editor@${domain}",list.name)%]
 Subject: [%"Moderators List %1 / %2"|loc(list.name,type)|qencode%]
 
 [% param0 %]
-[% END %]
+[%- END %]

--- a/default/mail_tt2/shared_moderate.tt2
+++ b/default/mail_tt2/shared_moderate.tt2
@@ -1,0 +1,11 @@
+[%# shared_moderate.tt2 ~%]
+From: [% fromlist %]
+To: [%"Moderator"|loc|mailbox("${list.name}-editor@${domain}",list.name)%]
+Subject: [%"Shared document to be approved for %1"|loc(list.name)|qencode%]
+
+[%|loc(list.name,filename,who)%]There is a new shared document in list %1: 
+    %2
+    from %3
+
+To moderate this document: [%END%]
+[% 'docindex' | url_abs([list.name]) %]

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -10631,8 +10631,7 @@ sub do_edit_list {
     }
 
     ## Reload config to clean some empty entries in $list->{'admin'}
-    $list = Sympa::List->new($list->{'name'}, $robot,
-        {'reload_config' => 1, 'force_sync_admin' => 1});
+    $list = Sympa::List->new($list->{'name'}, $robot, {reload_config => 1});
 
     unless (defined $list) {
         Sympa::WWW::Report::reject_report_web('intern', 'list_reload', {},

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -13315,7 +13315,7 @@ sub do_d_create_child {
                 # listmasters.
                 $log->syslog(
                     'notice',
-                    'Warning: No editor and owner defined at all in list %s',
+                    'No editor and owner defined at all in list %s; notification is sent to listmasters',
                     $list
                 );
                 @rcpt = Sympa::get_listmasters_email($list);

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -13323,11 +13323,9 @@ sub do_d_create_child {
 
             Sympa::send_file(
                 $list,
-                'listeditor_notification',
+                'shared_moderate',
                 \@rcpt,
-                {   to             => join(',', @rcpt),
-                    type           => 'shared_moderated',
-                    auto_submitted => 'auto-generated',
+                {   auto_submitted => 'auto-generated',
                     filename       => join('/', @{$new_child->{paths}}),
                     who            => $param->{'user'}{'email'},
                 }

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -13307,10 +13307,29 @@ sub do_d_create_child {
     if ($access{may}{edit} == 0.5 and $type ne 'directory') {
         unless ($child and $child->{moderate}) {
             # Moderated at first time
-            $list->send_notify_to_editor(
-                'shared_moderated',
-                {   'filename' => join('/', @{$new_child->{paths}}),
-                    'who'      => $param->{'user'}{'email'}
+            my @rcpt = $list->get_admins_email('receptive_editor');
+            @rcpt = $list->get_admins_email('actual_editor') unless @rcpt;
+            unless (@rcpt) {
+                # Since shared document has already been marked moderated,
+                # notification to editors should not fail. Fallback to
+                # listmasters.
+                $log->syslog(
+                    'notice',
+                    'Warning: No editor and owner defined at all in list %s',
+                    $list
+                );
+                @rcpt = Sympa::get_listmasters_email($list);
+            }
+
+            Sympa::send_file(
+                $list,
+                'listeditor_notification',
+                \@rcpt,
+                {   to             => join(',', @rcpt),
+                    type           => 'shared_moderated',
+                    auto_submitted => 'auto-generated',
+                    filename       => join('/', @{$new_child->{paths}}),
+                    who            => $param->{'user'}{'email'},
                 }
             );
         }

--- a/src/lib/Sympa.pm
+++ b/src/lib/Sympa.pm
@@ -261,6 +261,8 @@ my %diag_messages = (
     '5.1.2' => 'Bad destination system address',
     # too large
     '5.2.3' => 'Message length exceeds administrative limit',
+    # no owners defined in list at all, no listmasters defined at all
+    '5.2.4' => 'Mailing list expansion problem',
     # could not store message into spool or mailer
     '5.3.0' => 'Other or undefined mail system status',
     # misconfigured family list

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -1627,10 +1627,11 @@ sub send_notify_to_owner {
     die 'bug in logic. Ask developer' unless defined $operation;
 
     my @rcpt = $self->get_admins_email('receptive_owner');
+    @rcpt = $self->get_admins_email('owner') unless @rcpt;
     unless (@rcpt) {
         $log->syslog(
             'notice',
-            'No owner defined or all of them use nomail option in list %s; using listmasters as default',
+            'No owner defined at all in list %s; notification is sent to listmasters',
             $self
         );
         @rcpt = Sympa::get_listmasters_email($self);

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -622,12 +622,8 @@ sub _cache_publish_expiry {
     my $stat_file;
     if ($type eq 'member') {
         $stat_file = $self->{'dir'} . '/.last_change.member';
-    } elsif ($type eq 'last_sync') {
-        $stat_file = $self->{'dir'} . '/.last_sync.member';
     } elsif ($type eq 'admin_user') {
         $stat_file = $self->{'dir'} . '/.last_change.admin';
-    } elsif ($type eq 'last_sync_admin_user') {
-        $stat_file = $self->{'dir'} . '/.last_sync.admin';
     } else {
         die 'bug in logic. Ask developer';
     }
@@ -647,19 +643,11 @@ sub _cache_read_expiry {
         my $stat_file = $self->{'dir'} . '/.last_change.member';
         $self->_cache_publish_expiry('member') unless -e $stat_file;
         return [stat $stat_file]->[9];
-    } elsif ($type eq 'last_sync') {
-        # If syncs have never been done, earliest time is assumed.
-        return Sympa::Tools::File::get_mtime(
-            $self->{'dir'} . '/.last_sync.member');
     } elsif ($type eq 'admin_user') {
         # If changes have never been done, just now is assumed.
         my $stat_file = $self->{'dir'} . '/.last_change.admin';
         $self->_cache_publish_expiry('admin_user') unless -e $stat_file;
         return [stat $stat_file]->[9];
-    } elsif ($type eq 'last_sync_admin_user') {
-        # If syncs have never been done, earliest time is assumed.
-        return Sympa::Tools::File::get_mtime(
-            $self->{'dir'} . '/.last_sync.admin');
     } elsif ($type eq 'edit_list_conf') {
         return [stat Sympa::search_fullpath($self, 'edit_list.conf')]->[9];
     } else {
@@ -4756,6 +4744,7 @@ sub _load_include_admin_user_file {
 #sub purge_ca;
 # -> Never used.
 
+# FIXME: Use Sympa::Request::Handler::include handler.
 sub sync_include {
     $log->syslog('debug2', '(%s, %s)', @_);
     my $self    = shift;
@@ -4788,12 +4777,6 @@ sub sync_include {
         }
         return undef;
     }
-
-    # Get and save total of subscribers.
-    $self->_cache_publish_expiry(
-        ($role eq 'member') ? 'member' : 'admin_user');
-    $self->_cache_publish_expiry(
-        ($role eq 'member') ? 'last_sync' : 'last_sync_admin_user');
 
     return 1;
 }

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -968,74 +968,26 @@ sub load {
 
 ## Return a list of hash's owners and their param
 #OBSOLETED.  Use get_admins().
-sub get_owners {
-    $log->syslog('debug3', '(%s)', @_);
-    my $self = shift;
-
-    # owners are in the admin_table ; they might come from an include data
-    # source
-    return [$self->get_admins('owner')];
-}
+#sub get_owners;
 
 # OBSOLETED: No longer used.
-sub get_nb_owners {
-    $log->syslog('debug3', '(%s)', @_);
-    my $self = shift;
-
-    return scalar @{$self->get_admins('owner')};
-}
+#sub get_nb_owners;
 
 ## Return a hash of list's editors and their param(empty if there isn't any
 ## editor)
 #OBSOLETED. Use get_admins().
-sub get_editors {
-    $log->syslog('debug3', '(%s)', @_);
-    my $self = shift;
-
-    # editors are in the admin_table ; they might come from an include data
-    # source
-    return [$self->get_admins('editor')];
-}
+#sub get_editors;
 
 ## Returns an array of owners' email addresses
 #OBSOLETED: Use get_admins_email('receptive_owner') or
 #           get_admins_email('owner').
-sub get_owners_email {
-    $log->syslog('debug3', '(%s, %s)', @_);
-    my $self  = shift;
-    my $param = shift;
-
-    my @rcpt;
-
-    if ($param->{'ignore_nomail'}) {
-        @rcpt = map { $_->{'email'} } $self->get_admins('owner');
-    } else {
-        @rcpt = map { $_->{'email'} } $self->get_admins('receptive_owner');
-    }
-    unless (@rcpt) {
-        $log->syslog('notice', 'Warning: No owner found for list %s', $self);
-    }
-    return @rcpt;
-}
+#sub get_owners_email;
 
 ## Returns an array of editors' email addresses
 #  or owners if there isn't any editors' email addresses
 #OBSOLETED: Use get_admins_email('receptive_editor') or
 #           get_admins_email('actual_editor').
-sub get_editors_email {
-    $log->syslog('debug3', '(%s, %s)', @_);
-    my $self  = shift;
-    my $param = shift;
-
-    my @rcpt;
-
-    if ($param->{'ignore_nomail'}) {
-        @rcpt = map { $_->{'email'} } $self->get_admins('actual_editor');
-    } else {
-        @rcpt = map { $_->{'email'} } $self->get_admins('receptive_editor');
-    }
-    return @rcpt;
-}
+#sub get_editors_email;
 
 ## Returns an object Sympa::Family if the list belongs to a family or undef
 sub get_family {
@@ -1855,89 +1807,8 @@ sub delete_list_member_picture {
     return $ret;
 }
 
-####################################################
-# send_notify_to_editor
-####################################################
-# Sends a notice to list editor(s) or owner (if no editor)
-# by parsing listeditor_notification.tt2 template
-#
-# IN : -$self (+): ref(List)
-#      -$operation (+): notification type
-#      -$param(+) : ref(HASH) | ref(ARRAY)
-#       values for template parsing
-#
-# OUT : 1 | undef
-#
-######################################################
-#FIXME: Used only once.
-sub send_notify_to_editor {
-    $log->syslog('debug2', '(%s, %s, %s)', @_);
-    my ($self, $operation, $param) = @_;
-
-    my @rcpt = $self->get_admins_email('receptive_editor');
-    @rcpt = $self->get_admins_email('actual_editor') unless @rcpt;
-
-    my $robot = $self->{'domain'};
-    $param->{'auto_submitted'} = 'auto-generated';
-
-    unless (@rcpt) {
-        # Since shared document has already been stored into moderation spool,
-        # notification to editors should not fail. Fallback to listmasters.
-        $log->syslog('notice',
-            'Warning: No editor and owner defined at all in list %s', $self);
-        @rcpt = Sympa::get_listmasters_email($self);
-    }
-    unless (defined $operation) {
-        die 'missing incoming parameter "$operation"';
-    }
-    if (ref($param) eq 'HASH') {
-
-        $param->{'to'} = join(',', @rcpt);
-        $param->{'type'} = $operation;
-
-        unless (
-            Sympa::send_file(
-                $self, 'listeditor_notification', \@rcpt, $param
-            )
-        ) {
-            $log->syslog(
-                'notice',
-                'Unable to send template "listeditor_notification" to %s list editor',
-                $self
-            );
-            return undef;
-        }
-
-    } elsif (ref($param) eq 'ARRAY') {
-
-        my $data = {
-            'to'   => join(',', @rcpt),
-            'type' => $operation
-        };
-
-        foreach my $i (0 .. $#{$param}) {
-            $data->{"param$i"} = $param->[$i];
-        }
-        unless (
-            Sympa::send_file($self, 'listeditor_notification', \@rcpt, $data))
-        {
-            $log->syslog('notice',
-                'Unable to send template "listeditor_notification" to %s list editor'
-            );
-            return undef;
-        }
-
-    } else {
-        $log->syslog(
-            'err',
-            '(%s, %s) Error on incoming parameter "$param", it must be a ref on HASH or a ref on ARRAY',
-            $self,
-            $operation
-        );
-        return undef;
-    }
-    return 1;
-}
+#No longer used.
+#sub send_notify_to_editor;
 
 # Moved to Sympa::send_notify_to_user().
 #sub send_notify_to_user;

--- a/src/lib/Sympa/Request/Handler/create_automatic_list.pm
+++ b/src/lib/Sympa/Request/Handler/create_automatic_list.pm
@@ -227,12 +227,8 @@ sub _twist {
 
     ## Create list object
     my $list;
-    unless (
-        $list = Sympa::List->new(
-            $listname, $robot_id,
-            {skip_sync_admin => 1, no_check_family => 1}
-        )
-    ) {
+    unless ($list =
+        Sympa::List->new($listname, $robot_id, {no_check_family => 1})) {
         $log->syslog('err', 'Unable to create list %s', $listname);
         $self->add_stash($request, 'intern');
         return undef;

--- a/src/lib/Sympa/Request/Handler/create_list.pm
+++ b/src/lib/Sympa/Request/Handler/create_list.pm
@@ -210,8 +210,7 @@ sub _twist {
 
     # Create list object.
     my $list;
-    unless ($list =
-        Sympa::List->new($listname, $robot_id, {skip_sync_admin => 1})) {
+    unless ($list = Sympa::List->new($listname, $robot_id)) {
         $log->syslog('err', 'Unable to create list %s', $listname);
         $self->add_stash($request, 'intern');
         return undef;

--- a/src/lib/Sympa/Request/Handler/include.pm
+++ b/src/lib/Sympa/Request/Handler/include.pm
@@ -126,6 +126,8 @@ sub _twist {
     my $list = $request->{context};
     my $role = $request->{role};
 
+    my $delay = $request->{delay};
+
     die 'bug in logic. Ask developer'
         unless $role and grep { $role eq $_ } qw(member owner editor);
 
@@ -163,6 +165,17 @@ sub _twist {
     if (defined $last_start_time and $start_time < $last_start_time) {
         # Avoid retrace of clock e.g. by outage of NTP server.
         $log->syslog('info', '%s: Clock got behind, skip inclusion', $list);
+        $self->add_stash($request, 'notice', 'include_skip',
+            {listname => $list->{'name'}, role => $role});
+        return 0;
+    }
+    if (    defined $last_start_time
+        and defined $delay
+        and $start_time < $last_start_time + $delay) {
+        # Skip inclusion if the last inclusion has not taken configured
+        # duration.
+        $log->syslog('info',
+            '%s: The last inclusion is recent, skip inclusion', $list);
         $self->add_stash($request, 'notice', 'include_skip',
             {listname => $list->{'name'}, role => $role});
         return 0;

--- a/src/lib/Sympa/Request/Handler/include.pm
+++ b/src/lib/Sympa/Request/Handler/include.pm
@@ -345,6 +345,19 @@ sub _twist {
             {listname => $list->{'name'}, role => $role, result => {%result}}
         );
     }
+
+    # Compatibility to Sympa::List::_cache_*() that will be removed in near
+    # future: If inclusion succeeded, reset cache.
+    if ($succeeded == scalar @$dss or $succeeded) {
+        my $stat_file;
+        if ($role eq 'owner' or $role eq 'editor') {
+            $stat_file = $list->{'dir'} . '/.last_change.admin';
+        } else {
+            $stat_file = $list->{'dir'} . '/.last_change.member';
+        }
+        unlink $stat_file;
+    }
+
     return 1;
 }
 

--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -530,8 +530,7 @@ sub _copy {
 
     my $new_list;
     # Now switch List object to new list, update some values.
-    unless ($new_list =
-        Sympa::List->new($listname, $robot_id, {skip_sync_admin => 1})) {
+    unless ($new_list = Sympa::List->new($listname, $robot_id)) {
         $log->syslog('info', 'Unable to load %s while renamming', $listname);
         $self->add_stash($request, 'intern');
         return undef;

--- a/src/lib/Sympa/Request/Handler/review.pm
+++ b/src/lib/Sympa/Request/Handler/review.pm
@@ -54,17 +54,9 @@ sub _twist {
     my $robot    = $list->{'domain'};
     my $sender   = $request->{sender};
 
-    my $user;
-
     $language->set_lang($list->{'admin'}{'lang'});
 
-    # Members list synchronization if include is in use.
-    unless (defined $list->on_the_fly_sync_include(use_ttl => 1)) {
-        $log->syslog('notice', 'Unable to synchronize list %s', $list);
-        #FIXME: Abort if synchronization failed.
-    }
-
-    my @users;
+    my (@users, $user);
 
     my $is_owner = $list->is_admin('owner', $sender)
         || Sympa::is_listmaster($list, $sender);

--- a/src/lib/Sympa/Request/Handler/update_automatic_list.pm
+++ b/src/lib/Sympa/Request/Handler/update_automatic_list.pm
@@ -230,12 +230,8 @@ sub _twist {
 
     ## Create list object
     my $listname = $list->{'name'};
-    unless (
-        $list = Sympa::List->new(
-            $listname, $robot_id,
-            {skip_sync_admin => 1, no_check_family => 1}
-        )
-    ) {
+    unless ($list =
+        Sympa::List->new($listname, $robot_id, {no_check_family => 1})) {
         $log->syslog('err', 'Unable to create list %s', $listname);
         $self->add_stash($request, 'intern');
         return undef;

--- a/src/lib/Sympa/Spindle/DoForward.pm
+++ b/src/lib/Sympa/Spindle/DoForward.pm
@@ -125,6 +125,7 @@ sub _twist {
     }
 
     # Did we find a recipient?
+    # If not, send back DSN to original sender to notify failure.
     unless (@rcpt) {
         $log->syslog('err',
             'Message for %s function %s ignored, %s undefined in list %s',

--- a/src/lib/Sympa/Spindle/DoForward.pm
+++ b/src/lib/Sympa/Spindle/DoForward.pm
@@ -108,28 +108,30 @@ sub _twist {
 
     if ($function eq 'listmaster') {
         @rcpt = Sympa::get_listmasters_email($robot);
-        $log->syslog('notice', 'Warning: No listmaster defined in sympa.conf')
+        $log->syslog('notice',
+            'No listmaster defined; incoming message is rejected')
             unless @rcpt;
     } elsif ($function eq 'owner') {    # -request
         @rcpt = $list->get_admins_email('receptive_owner');
         @rcpt = $list->get_admins_email('owner') unless @rcpt;
-        $log->syslog('notice', 'Warning: No owner defined at all in list %s',
-            $name)
-            unless @rcpt;
+        $log->syslog(
+            'notice',
+            'No owner defined at all in list %s; incoming message is rejected',
+            $name
+        ) unless @rcpt;
     } elsif ($function eq 'editor') {
         @rcpt = $list->get_admins_email('receptive_editor');
         @rcpt = $list->get_admins_email('actual_editor') unless @rcpt;
-        $log->syslog('notice',
-            'Warning: No owner and editor defined at all in list %s', $name)
-            unless @rcpt;
+        $log->syslog(
+            'notice',
+            'No owner and editor defined at all in list %s; incoming message is rejected',
+            $name
+        ) unless @rcpt;
     }
 
     # Did we find a recipient?
     # If not, send back DSN to original sender to notify failure.
     unless (@rcpt) {
-        $log->syslog('err',
-            'Message for %s function %s ignored, %s undefined in list %s',
-            $name, $function, $function, $name);
         Sympa::send_notify_to_listmaster(
             $message->{context} || '*',
             'mail_intern_error',
@@ -143,7 +145,10 @@ sub _twist {
                 function => $function,
             }
         );
-        Sympa::send_dsn($message->{context} || '*', $message, {}, '5.3.0');
+        Sympa::send_dsn(
+            $message->{context} || '*', $message,
+            {function => $function}, '5.2.4'
+        );
         $log->db_log(
             'robot'        => $robot,
             'list'         => $list->{'name'},

--- a/src/lib/Sympa/Spindle/ToEditor.pm
+++ b/src/lib/Sympa/Spindle/ToEditor.pm
@@ -121,12 +121,29 @@ sub _send_confirm_to_editor {
         unless @rcpt;
 
     # Did we find a recipient?
+    # If not, send back DSN to notify failure to original sender.
     unless (@rcpt) {
-        $log->syslog(
-            'err',
-            'Impossible to send the moderation request for message %s to editors of list %s. Neither editor nor owner defined!',
-            $message,
-            $list
+        $log->syslog('err', 'Message for editor of %s ignored', $list);
+        Sympa::send_notify_to_listmaster(
+            $message->{context} || '*',
+            'mail_intern_error',
+            {   error =>
+                    sprintf(
+                    'Impossible to forward a message to editor of %s: undefined in this list',
+                    $list->{'name'}),
+                who    => $message->{sender},
+                msg_id => $message->{message_id},
+            }
+        );
+        Sympa::send_dsn($message->{context} || '*', $message, {}, '5.3.0');
+        $log->db_log(
+            'robot'      => $list->{'domain'},
+            'list'       => $list->{'name'},
+            'action'     => 'ToEditor',
+            'msg_id'     => $message->{message_id},
+            'status'     => 'error',
+            'error_type' => 'internal',
+            'user_email' => $message->{sender}
         );
         return undef;
     }

--- a/src/lib/Sympa/Spindle/ToList.pm
+++ b/src/lib/Sympa/Spindle/ToList.pm
@@ -193,7 +193,9 @@ sub _send_msg {
     unless ($resent_by) {    # Not in ResendArchive spindle.
         # Synchronize list members, required if list uses include sources
         # unless sync_include has been performed recently.
-        unless (defined $list->on_the_fly_sync_include(use_ttl => 1)) {
+        my $delay = $list->{'admin'}{'distribution_ttl'}
+            // $list->{'admin'}{'ttl'};
+        unless (defined $list->sync_include('member', delay => $delay)) {
             $log->syslog('notice', 'Unable to synchronize list %s', $list);
             #FIXME: Might be better to abort if synchronization failed.
         }

--- a/src/lib/Sympa/Spindle/ToModeration.pm
+++ b/src/lib/Sympa/Spindle/ToModeration.pm
@@ -124,7 +124,6 @@ sub _send_confirm_to_editor {
 
     my $modkey;
     # Keeps a copy of the message.
-    #XXXif ($method eq 'md5') {
     # Move message to mod spool.
     # If crypted, store the crypted form of the message (keep decrypted
     # form for HTML view).
@@ -136,23 +135,15 @@ sub _send_confirm_to_editor {
             $message, $list);
         return undef;
     }
-    #XXX}
 
     @rcpt = $list->get_admins_email('receptive_editor');
     @rcpt = $list->get_admins_email('actual_editor') unless @rcpt;
-    $log->syslog('notice',
-        'Warning: No owner and editor defined at all in list %s', $list)
-        unless @rcpt;
-
-    # Did we find a recipient?
     unless (@rcpt) {
-        $log->syslog(
-            'err',
-            'Impossible to send the moderation request for message %s to editors of list %s. Neither editor nor owner defined!',
-            $message,
-            $list
-        );
-        return undef;
+        # Since message has already been stored into moderation spool,
+        # notification to editors should not fail. Fallback to listmasters.
+        $log->syslog('notice',
+            'Warning: No editor and owner defined at all in list %s', $list);
+        @rcpt = Sympa::get_listmasters_email($list);
     }
 
     my $param = {

--- a/src/lib/Sympa/Spindle/ToModeration.pm
+++ b/src/lib/Sympa/Spindle/ToModeration.pm
@@ -141,8 +141,11 @@ sub _send_confirm_to_editor {
     unless (@rcpt) {
         # Since message has already been stored into moderation spool,
         # notification to editors should not fail. Fallback to listmasters.
-        $log->syslog('notice',
-            'Warning: No editor and owner defined at all in list %s', $list);
+        $log->syslog(
+            'notice',
+            'No editor and owner defined at all in list %s; notification is sent to listmasters',
+            $list
+        );
         @rcpt = Sympa::get_listmasters_email($list);
     }
 

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -135,7 +135,7 @@ sub upgrade {
         $log->syslog('notice',
             'Restoring users of ALL lists...it may take a while...');
 
-        my $all_lists = Sympa::List::get_lists('*', skip_sync_admin => 1);
+        my $all_lists = Sympa::List::get_lists('*');
         foreach my $list (@{$all_lists || []}) {
             next unless $list;
             my $dir = $list->{'dir'};
@@ -169,9 +169,8 @@ sub upgrade {
     # This is especially useful for character encoding reasons.
     $log->syslog('notice',
         'Rebuilding config.bin files for ALL lists...it may take a while...');
-    my $all_lists =
-        Sympa::List::get_lists('*', reload_config => 1, skip_sync_admin => 1);
-    # Recreate admin_table entries.
+    my $all_lists = Sympa::List::get_lists('*', reload_config => 1);
+    # Recreate admin_table entries. #FIXME: Is this needed here?
     $log->syslog('notice',
         'Rebuilding the admin_table...it may take a while...');
     foreach my $list (@{$all_lists || []}) {    # See GH #71
@@ -311,8 +310,7 @@ sub upgrade {
         );
 
         foreach my $r (keys %{$Conf::Conf{'robots'}}) {
-            my $all_lists =
-                Sympa::List::get_lists($r, 'skip_sync_admin' => 1);
+            my $all_lists = Sympa::List::get_lists($r);
             foreach my $list (@$all_lists) {
                 my $sdm = Sympa::DatabaseManager->instance;
                 foreach my $table ('subscriber', 'admin') {
@@ -337,11 +335,6 @@ sub upgrade {
                         return undef;
                     }
                 }
-
-                ## Force Sync_admin
-                $list =
-                    Sympa::List->new($list->{'name'}, $list->{'domain'},
-                    {'force_sync_admin' => 1});
             }
         }
 

--- a/src/lib/Sympa/WWW/SOAP.pm
+++ b/src/lib/Sympa/WWW/SOAP.pm
@@ -978,11 +978,6 @@ sub review {
         my $is_owner = $list->is_admin('owner', $sender)
             || Sympa::is_listmaster($list, $sender);
 
-        ## Members list synchronization if include is in use
-        unless (defined $list->on_the_fly_sync_include(use_ttl => 1)) {
-            $log->syslog('notice', 'Unable to synchronize list %s', $list);
-        }
-
         unless ($user = $list->get_first_list_member({'sortby' => 'email'})) {
             $log->syslog('err', 'No subscribers in list "%s"',
                 $list->{'name'});
@@ -1052,11 +1047,6 @@ sub fullReview {
         die SOAP::Fault->faultcode('Client')
             ->faultstring('Not enough privileges')
             ->faultdetail('Listmaster or listowner required');
-    }
-
-    # Members list synchronization if include is in use
-    unless (defined $list->on_the_fly_sync_include(use_ttl => 1)) {
-        $log->syslog('notice', 'Unable to synchronize list %s', $list);
     }
 
     my $members;

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -782,7 +782,7 @@ if ($main::options{'dump'} or $main::options{'dump_users'}) {
     }
     if ($err >= 0) {
         print STDERR "@{$result{'errors'}}";
-	exit 1;
+        exit 1;
     }
 
     exit 0;
@@ -889,7 +889,7 @@ if ($main::options{'dump'} or $main::options{'dump_users'}) {
         $log->syslog('notice', 'Loading list %s...', $main::options{'list'});
         my $list =
             Sympa::List->new($main::options{'list'}, '',
-            {'reload_config' => 1, 'force_sync_admin' => 1});
+            {reload_config => 1});
         unless (defined $list) {
             printf STDERR "Error : incorrect list name '%s'\n",
                 $main::options{'list'};
@@ -897,11 +897,7 @@ if ($main::options{'dump'} or $main::options{'dump_users'}) {
         }
     } else {
         $log->syslog('notice', "Loading ALL lists...");
-        my $all_lists = Sympa::List::get_lists(
-            '*',
-            'reload_config'    => 1,
-            'force_sync_admin' => 1
-        );
+        my $all_lists = Sympa::List::get_lists('*', reload_config => 1);
     }
     $log->syslog('notice', '...Done.');
 


### PR DESCRIPTION
  - review: Won't process sync_include in advance so that processing will be faster.
    sync_include just before message delivery will be performed as in the past.

  - sync_include will no longer be invoked during Sympa::List->new():
      - No owner defined in a list is no longer treated as error_config.
      - Instead, if no owner defined and something has to be sent to owners,
          - If possible, discard incoming message and send back DSN to original sender,
          - or, notifications to owners will be redirected to listmaster(s).

This may improve speed of "review" page and so on.
Also, this may fix #92 .
