### PR TITLE
Mail loop with sympa-request address because of misconfiguration (#957)

### DIFF
--- a/src/lib/Sympa.pm
+++ b/src/lib/Sympa.pm
@@ -610,7 +610,9 @@ sub get_address {
             return $that->{'name'} . '-subscribe' . '@' . $that->{'domain'};
         } elsif ($type eq 'unsubscribe') {
             return $that->{'name'} . '-unsubscribe' . '@' . $that->{'domain'};
-        } elsif ($type eq 'sympa' or $type eq 'listmaster') {
+        } elsif ($type eq 'sympa'
+            or $type eq 'sympaowner'
+            or $type eq 'listmaster') {
             # robot address, for convenience.
             return Sympa::get_address($that->{'domain'}, $type);
         }
@@ -624,7 +626,10 @@ sub get_address {
         } elsif ($type eq 'sympa') {    # same as above, for convenience
             return Conf::get_robot_conf($that, 'email') . '@'
                 . Conf::get_robot_conf($that, 'domain');
-        } elsif ($type eq 'owner' or $type eq 'request') {
+        } elsif (
+            $type eq 'owner' or $type eq 'request'    # for convenience
+            or $type eq 'sympaowner'
+        ) {
             return
                   Conf::get_robot_conf($that, 'email')
                 . '-request' . '@'
@@ -1006,7 +1011,8 @@ These are accessors derived from configuration parameters.
 
 Site or robot:
 Returns the site or robot email address of type $type: email command address
-(default, <sympa> address), "owner" (<sympa-request> address) or "listmaster".
+(default, <sympa> address), "sympaowner" (<sympa-request> address) or
+"listmaster".
 
 List:
 Returns the list email address of type $type: posting address (default),
@@ -1014,9 +1020,21 @@ Returns the list email address of type $type: posting address (default),
 (<LIST-owner> address), "subscribe" or "unsubscribe".
 
 Note:
+
+=over
+
+=item *
+
 %Conf::Conf or Conf::get_robot_conf() may return <sympa> and
 <sympa-request> addresses by "sympa" and "request" arguments, respectively.
 They are obsoleted.  Use this function instead.
+
+=item *
+
+C<"sympaowner"> with robot context was introduced on 6.2.57b.2.
+C<"owner"> and C<"request"> may also be used for convenience.
+
+=back
 
 =item get_listmasters_email ( $that )
 

--- a/src/lib/Sympa/Spindle/ProcessIncoming.pm
+++ b/src/lib/Sympa/Spindle/ProcessIncoming.pm
@@ -232,7 +232,15 @@ sub _twist {
         : undef;
 
     my $list_address;
-    if ($message->{'listtype'} and $message->{'listtype'} eq 'listmaster') {
+    if ($message->{'listtype'} and $message->{'listtype'} eq 'sympaowner') {
+        # Discard messages for sympa-request address to avoid loop caused by
+        # misconfiguration.
+        $log->syslog('err',
+            'Don\'t forward sympa-request to Sympa. Check configuration of MTA'
+        );
+        return undef;
+    } elsif ($message->{'listtype'}
+        and $message->{'listtype'} eq 'listmaster') {
         $list_address = Sympa::get_address($robot, 'listmaster');
     } elsif ($message->{'listtype'} and $message->{'listtype'} eq 'sympa') {
         $list_address = Sympa::get_address($robot);

--- a/src/lib/Sympa/Spool.pm
+++ b/src/lib/Sympa/Spool.pm
@@ -361,7 +361,13 @@ sub split_listname {
         my $type;
 
         if ($suffix eq 'request') {                         # -request
-            $type = 'owner';
+            if (   $name eq Conf::get_robot_conf($robot_id, 'email')
+                or $robot_id eq $Conf::Conf{'domain'}
+                and $name eq $Conf::Conf{'email'}) {        # sympa-request
+                ($name, $type) = (undef, 'sympaowner');
+            } else {
+                $type = 'owner';
+            }
         } elsif ($suffix eq 'editor') {
             $type = 'editor';
         } elsif ($suffix eq 'subscribe') {
@@ -425,10 +431,12 @@ sub unmarshal_metadata {
     if (exists $data->{'priority'}) {
         # Priority was given by metadata.
         ;
+    } elsif ($type and $type eq 'sympaowner') {    # sympa-request
+        $priority = 0;
     } elsif ($type and $type eq 'listmaster') {
         ## highest priority
         $priority = 0;
-    } elsif ($type and $type eq 'owner') {    # -request
+    } elsif ($type and $type eq 'owner') {         # -request
         $priority = Conf::get_robot_conf($robot_id, 'request_priority');
     } elsif ($type and $type eq 'return_path') {    # -owner
         $priority = Conf::get_robot_conf($robot_id, 'owner_priority');


### PR DESCRIPTION
<sympa-request> address should not be forwarded to any functions of Sympa.  To avoid mail loop by such misconfiguration, discard messages bound for this address.

This may fix #957 .
