### PR TITLE
Fix get_inactive_lists

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -9622,10 +9622,10 @@ sub do_get_inactive_lists {
             'creator'       => $list->{'admin'}{'creation'}{'email'},
             'send_scenario' => $list->{'admin'}{'send'}{'name'},
             'owners'        => join(
-                ", ", map { $_->{'email'} } @{$list->{'admin'}{'owner'}}
+                ", ", map { $_->{'email'} } grep { $_->{role} eq 'owner' } @{$list->get_current_admins}
             ),
             'editors' => join(", ",
-                map { $_->{'email'} } @{$list->{'admin'}{'editor'}}),
+                map { $_->{'email'} } grep { $_->{role} eq 'editor' } @{$list->get_current_admins}),
             'subscribers_count'  => $list->get_total('nocache'),
             'subject'            => $list->{'admin'}{'subject'},
             'msg_count'          => $list->get_msg_count(),


### PR DESCRIPTION
The page was not listing the current list owners/editors because they were loaded the wrong way $list->{'admin'}{'owner'} instead of $list->get_current_admins. I was alerted by a listmaster who was surprised that this page still mentioned list owners.

I guess old list owners were loaded from a config.bin file.

