### PR TITLE
Included members would remain in a list after data source was removed

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -10613,7 +10613,7 @@ sub do_edit_list {
     }
 
     my $data_source_updated_member = 1
-        if grep { $config->get_change($_) }
+		if grep { exists $config->{_changes}{$_} }
         grep { $_ =~ /\Ainclude_/ or $_ eq 'member_include' } $config->keys;
     my $data_source_updated_owner = 1
         if $config->get_change('owner_include');

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -4165,10 +4165,6 @@ sub sync_include {
 
     $role ||= 'member';    # Compat.<=6.2.54
 
-    return 0
-        unless $self->has_data_sources($role)
-        or $self->has_included_users($role);
-
     my $spindle = Sympa::Spindle::ProcessRequest->new(
         context          => $self,
         action           => 'include',

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -4165,7 +4165,11 @@ sub sync_include {
 
     $role ||= 'member';    # Compat.<=6.2.54
 
-    my $spindle = Sympa::Spindle::ProcessRequest->new(
+ 	return 0
+    	unless $self->has_data_sources($role)
+ 		or $self->has_included_users($role);
+
+ my $spindle = Sympa::Spindle::ProcessRequest->new(
         context          => $self,
         action           => 'include',
         role             => $role,

--- a/src/lib/Sympa/Request/Handler/include.pm
+++ b/src/lib/Sympa/Request/Handler/include.pm
@@ -131,10 +131,6 @@ sub _twist {
     die 'bug in logic. Ask developer'
         unless $role and grep { $role eq $_ } qw(member owner editor);
 
-    return 0
-        unless $list->has_data_sources($role)
-        or $list->has_included_users($role);
-
     my $dss = _get_data_sources($list, $role);
 
     # Get an Exclusive lock.


### PR DESCRIPTION
If an include_xx parameter was removed, sync_include() was not triggered. If no other include_xx remained, included members would remain in the list with no way to cleanup list members because sync_include() cannot be run on a list with no include_xx parameter.