### PR TITLE
Workaround for mail loop for sympa-request address (#1018)

### DIFF
--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -134,6 +134,9 @@ sub new {
         my $addr = $1;
         if ($addr =~ /<>/) {    # special: null envelope sender
             $self->{'envelope_sender'} = '<>';
+        } elsif ($addr =~ /<MAILER-DAEMON>/) {
+            # Same as above, but a workaround for pipe(8) of Postfix 2.3+.
+            $self->{'envelope_sender'} = '<>';
         } else {
             my @addrs = Mail::Address->parse($addr);
             if (@addrs
@@ -4376,6 +4379,10 @@ Prepending C<Return-Path:> is available by default.
 =item pipe(8)
 
 Add C<R> to the C<flags=> attributes in master.cf.
+
+Additionally with Postfix 2.3 or later, add an empty C<null_sender=>
+attribute.
+Or "null envelope sender" would be replaced with C<E<lt>MAILER-DAEMONE<gt>>.
 
 =back
 


### PR DESCRIPTION
As of Postfix 2.3, Content of Return-Path: pseudo-header field added by pipe(8) for null envelope sender became "MAILER-DAEMON".  Empty `null_sender` option will prevent this behavior.
As a workaround, the uppercase "<MAILER-DAEMON>" will be treated as null envelope sender.

This is a workaround for #1018 .

