### PR TITLE
🐛 — Fix confirmation for reporting as spam while deleting an archived mail

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -8978,11 +8978,8 @@ sub do_remove_arc {
 
     # Action confirmed?
     my $next_action = $session->confirm_action(
-        $in{'action'},
-        $in{'response_action'},
-        arg => join(
-            ',', $in{'yyyy'}, $in{'month'}, $in{signal_as_spam}, @msgids
-        ),
+        $in{'action'}, $in{'response_action'},
+        arg             => join(',', $in{'yyyy'}, $in{'month'}, @msgids),
         previous_action => 'arc'
     );
     unless ($next_action eq '1') {


### PR DESCRIPTION
Currently, if you want to report archived mail(s) as spam while asking for deletion, the confirmation page is shown twice (only once if not reporting as spam). It appears like a bug to users.
This commit remove the confirmation when reporting as spam (there is still the confirmation for the deletion).