### PR TITLE
Renaming of lists which members are included in other lists 

### DIFF
--- a/default/web_tt2/admin.tt2
+++ b/default/web_tt2/admin.tt2
@@ -56,7 +56,7 @@
             </form>
         [%~ ELSIF is_included ~%]
             <p>
-                [%|loc%]Closing or renaming this list is impossible, because it is included by other mailing list(s).[%END%]
+                [%|loc%]This list is included by other lists and cannot be closed.[%END%]
                 <br />
                 <a class="button" href="[% 'including_lists' | url_rel([list]) %]">
                     [%|loc(list)%]View lists including %1[%END%]
@@ -71,11 +71,11 @@
                 </div>
             </form>
         [%~ END %]
-        [% IF may_create_list && ! is_included ~%]
+        [% IF may_create_list ~%]
             <form name="manage_list_name" action="[% path_cgi %]" method="post">
                 <fieldset>
                     <input class="MainMenuLinks" type="submit" name="action_rename_list_request" value="[%|loc%]Rename List[%END%]"/>
-                    [%|loc%]Allows you to change this list's name. Everything related to the list will be renamed, including the mail aliases and the web archives.[%END%]
+                    [%|loc%]Allows you to change this list's name. Everything related to the list will be renamed, including the mail aliases and the web archives. If members of this list are included as members in other lists, these inclusions will be updates too. However inclusions through data_sources cannot be treated.[%END%]
                     <input type="hidden" name="list" value="[% list %]"/>
                 </fieldset>
             </form>


### PR DESCRIPTION
This was foridden. This commit changes this behavior. 

After renaming is done, the new code goes through ->get_including_lists('member') and updates config of these lists to include members with the new listname. Note however that inclusions through data_sources (member_include, owner_include or editor_include parameters) are not updated; too hazardious to perform source_parameters changes without knowing the semantics.