### PR TITLE
Show subjects of archived mails before deletion’s confirmation

### DIFF
--- a/default/mhonarc-ressources.tt2
+++ b/default/mhonarc-ressources.tt2
@@ -235,7 +235,12 @@ IDXPGEND
 <LITEMPLATE>
         <li>
             ($tag$% IF is_owner %$tag$)
-                <input type="checkbox" name="msgid" value="$MSGID$" />
+                ($tag$% msgidx = msgidx || 0; msgidx = msgidx + 1 ~%$tag$)
+                <input type="checkbox" name="msgid" value="$MSGID$"
+                 id="msgid($tag$% msgidx %$tag$)"/>
+                <input type="hidden" name="msg_subject" value="$SUBJECTNA$"
+                 class="disableUnlessChecked"
+                 data-selector="#msgid($tag$% msgidx %$tag$)" />
             ($tag$%END%$tag$)
             <b>$SUBJECT$</b>, <em>$FROMNAME$</em>
         </li>
@@ -367,7 +372,12 @@ TIDXPGEND
 <TSINGLETXT>
         <li>
             ($tag$% IF is_owner %$tag$)
-                <input type="checkbox" name="msgid" value="$MSGID$" />
+                ($tag$% msgidx = msgidx || 0; msgidx = msgidx + 1 ~%$tag$)
+                <input type="checkbox" name="msgid" value="$MSGID$"
+                 id="msgid($tag$% msgidx %$tag$)"/>
+                <input type="hidden" name="msg_subject" value="$SUBJECTNA$"
+                 class="disableUnlessChecked"
+                 data-selector="#msgid($tag$% msgidx %$tag$)" />
             ($tag$%END%$tag$)
                 <b>$SUBJECT$</b>,
                 <em>$FROMNAME$, ($tag$%|locdt("$YYYYMMDD$")%$tag$)%m/%d/%Y($tag$%END%$tag$)</em>
@@ -376,7 +386,12 @@ TIDXPGEND
 <TTOPBEGIN>
         <li>
             ($tag$% IF is_owner %$tag$)
-                <input type="checkbox" name="msgid" value="$MSGID$" />
+                ($tag$% msgidx = msgidx || 0; msgidx = msgidx + 1 ~%$tag$)
+                <input type="checkbox" name="msgid" value="$MSGID$"
+                 id="msgid($tag$% msgidx %$tag$)"/>
+                <input type="hidden" name="msg_subject" value="$SUBJECTNA$"
+                 class="disableUnlessChecked"
+                 data-selector="#msgid($tag$% msgidx %$tag$)" />
             ($tag$%END%$tag$)
             <b>$SUBJECT$</b>,
             <em>$FROMNAME$, ($tag$%|locdt("$YYYYMMDD$")%$tag$)%m/%d/%Y($tag$%END%$tag$)</em>
@@ -385,7 +400,12 @@ TIDXPGEND
 <TLITXT>
         <li>
             ($tag$% IF is_owner %$tag$)
-                <input type="checkbox" name="msgid" value="$MSGID$" />
+                ($tag$% msgidx = msgidx || 0; msgidx = msgidx + 1 ~%$tag$)
+                <input type="checkbox" name="msgid" value="$MSGID$"
+                 id="msgid($tag$% msgidx %$tag$)"/>
+                <input type="hidden" name="msg_subject" value="$SUBJECTNA$"
+                 class="disableUnlessChecked"
+                 data-selector="#msgid($tag$% msgidx %$tag$)" />
             ($tag$%END%$tag$)
             <b>$SUBJECT$</b>,
             <em>$FROMNAME$, ($tag$%|locdt("$YYYYMMDD$")%$tag$)%m/%d/%Y($tag$%END%$tag$)</em>
@@ -588,6 +608,7 @@ $POWERED_BY$
                 <input type="hidden" name="yyyy" value="$yyyy$" />
                 <input type="hidden" name="month" value="$mois$" />
                 <input type="hidden" name="msgid" value="$MSGID$" />
+                <input type="hidden" name="msg_subject" value="$SUBJECTNA$" />
                 <input type="hidden" name="action" value="" />
                 ($tag$% from_addr = BLOCK ~%$tag$)
                     ($tag$% '$FROMADDRNAME:J$@$FROMADDRDOMAIN$' | canonic_email %$tag$)

--- a/default/web_tt2/confirm_action.tt2
+++ b/default/web_tt2/confirm_action.tt2
@@ -495,6 +495,11 @@
         [% FOREACH m = msgid ~%]
             <input type="hidden" name="msgid" value="[% m %]" />
         [%~ END %]
+        <ul class="styled-list">
+            [% FOREACH m = msg_subject ~%]
+                <li>[% m %]</li>
+            [%~ END %]
+        </ul>
         [% IF is_listmaster || is_owner %]
             <input type="checkbox" name="signal_as_spam"
                    [% IF signal_as_spam %]checked[% END %] />

--- a/default/web_tt2/css.tt2
+++ b/default/web_tt2/css.tt2
@@ -103,6 +103,9 @@ body {
 ol, ul {
     list-style: none;
 }
+ul.styled-list {
+    list-style: disc;
+}
 
 blockquote, q {
     quotes: none;

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -889,6 +889,7 @@ our %in_regexp = (
     'msgid'       => '[^\\\*\"\'\`\^\|\n]+',
     'in_reply_to' => '[^\\\*\"\'\`\^\|\n]+',
     'message_id'  => '[^\\\*\"\'\`\^\|\n]+',
+    'msg_subject' => '.*',
 
     ## Password
     'passwd'       => '.+',
@@ -8955,7 +8956,8 @@ sub do_remove_arc {
         $in{'list'}, $in{'yyyy'}, $in{'month'});
 
     # $in{'msgid'} = Sympa::Tools::Text::unescape_chars($in{'msgid'});
-    my @msgids = split /\0/, $in{'msgid'};
+    my @msgids       = split /\0/, $in{'msgid'};
+    my @msg_subjects = split /\0/, $in{'msg_subject'};
 
     unless (@msgids) {
         Sympa::WWW::Report::reject_report_web('user', 'may_not_remove_arc',
@@ -8975,6 +8977,7 @@ sub do_remove_arc {
     $param->{'month'}          = $in{'month'};
     $param->{'signal_as_spam'} = $in{'signal_as_spam'};
     $param->{'msgid'}          = [@msgids];
+    $param->{'msg_subject'}    = [@msg_subjects];
 
     # Action confirmed?
     my $next_action = $session->confirm_action(


### PR DESCRIPTION
I think it would be good to have a reminder of which archived mails are about to be deleted (just like the reminder of the subscribers who are about to be unsubscribed), so here it is.