### PR TITLE
MySQL: (42000) Invalid default value

### DIFF
--- a/src/lib/Sympa/DatabaseDriver/MySQL.pm
+++ b/src/lib/Sympa/DatabaseDriver/MySQL.pm
@@ -62,11 +62,16 @@ sub connect {
     #   when the processes are running under mod_perl or CGI environment
     #   so that "SET NAMES utf8" will be skipped.
     # - Set client-side character set to "utf8" or "utf8mb4".
+    # - Reset SQL mode that is given various default by versions of MySQL.
     $self->__dbh->{'mysql_auto_reconnect'} = 0;
     unless (defined $self->__dbh->do("SET NAMES 'utf8mb4'")
         or defined $self->__dbh->do("SET NAMES 'utf8'")) {
         $log->syslog('err', 'Cannot set client-side character set: %s',
             $self->error);
+    }
+    unless (defined $self->__dbh->do("SET SESSION sql_mode=''")) {
+        $log->syslog('err', 'Cannot reset SQL mode: %s', $self->error);
+        return undef;
     }
 
     return 1;

--- a/src/lib/Sympa/DatabaseDriver/MySQL.pm
+++ b/src/lib/Sympa/DatabaseDriver/MySQL.pm
@@ -8,8 +8,8 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2018 The Sympa Community. See the AUTHORS.md file at the
-# top-level directory of this distribution and at
+# Copyright 2018, 2020 The Sympa Community. See the AUTHORS.md
+# file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
MySQL: With MySQL 5.6, 5.7.6 and later versions, `sql_mode` system variable contains `STRICT_TRANS_TABLES` by which some obsoleted columns such as `date_admin` causes "(42000) Invalid default value for '_column name_'" error.  Fixed by resetting `sql_mode` to be empty, the default on 5.5.x or earlier.

This may fix #1028 .


