### PR TITLE
Additional fix to #946 (#1015)

### DIFF
--- a/src/lib/Sympa/Aliases/Template.pm
+++ b/src/lib/Sympa/Aliases/Template.pm
@@ -233,7 +233,8 @@ sub alias_wrapper {
     my $list = shift;
     my $command;
 
-    if (Conf::get_robot_conf($list->{'domain'}, 'aliases_wrapper') eq 'on') {
+    if (Conf::get_robot_conf($list->{'domain'}, 'aliases_wrapper') eq 'on'
+        and -e Sympa::Constants::LIBEXECDIR . '/sympa_newaliases-wrapper') {
         return Sympa::Constants::LIBEXECDIR . '/sympa_newaliases-wrapper';
     }
 


### PR DESCRIPTION
Additional fix to #1015. 

Don't try to invoke the setuid wrapper sympa_newaliases-wrapper if it has been removed.
