### PR TITLE
Add actual error to the log if connection to LDAP server fails.

### DIFF
--- a/src/lib/Sympa/DatabaseDriver/LDAP.pm
+++ b/src/lib/Sympa/DatabaseDriver/LDAP.pm
@@ -121,8 +121,8 @@ sub _connect {
     $self->{_error_string} = $EVAL_ERROR;
 
     unless ($connection) {
-        $log->syslog('err', 'Unable to connect to the LDAP server %s',
-            $self->{host});
+        $log->syslog('err', 'Unable to connect to the LDAP server %s: %s',
+            $self->{host}, $self->{_error_string});
         return undef;
     }
 


### PR DESCRIPTION
This is really helpful to figure out what went wrong with the connection to the LDAP server.