### PR TITLE
Update List.pm

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -6037,7 +6037,7 @@ sub _update_list_db {
 
     my $name = $self->{'name'};
     my $searchkey =
-        Sympa::Tools::Text::foldcase($self->{'admin'}{'subject'} || '');
+        substr( Sympa::Tools::Text::foldcase($self->{'admin'}{'subject'} || ''), 0, 255);
     my $status = $self->{'admin'}{'status'};
     my $robot  = $self->{'domain'};
 


### PR DESCRIPTION
Upgrade process may fail inserting records in the `list_table` table, due to the `searchkey_list` value overflowing that column size (`varchar(255)`).
Truncates that field, to ensure upgrade doesn't skip anything.

Wild guess / maybe there's other places we could do this.
Found out a mention of that issue over there: https://listes.renater.fr/sympa/arc/sympa-fr/2019-10/msg00017.html
As of patching that file on my server, I can re-run the upgrade (from 5.4.7 to 6.2.40),  without any mention of such failures.