### PR TITLE
Skip execution of aliases_program in newaliases script if value is "none"

### DIFF
--- a/src/lib/Sympa/Config/Schema.pm
+++ b/src/lib/Sympa/Config/Schema.pm
@@ -479,11 +479,12 @@ our %pinfo = (
         context    => [qw(domain site)],
         order      => 4.04,
         group      => 'mta',
-        format     => 'makemap|newaliases|postalias|postmap|/.+',
+        format     => 'makemap|newaliases|postalias|postmap|/.+|none',
         default    => 'newaliases',
         gettext_id => 'Program used to update alias database',
         gettext_comment =>
             'This may be "makemap", "newaliases", "postalias", "postmap" or full path to custom program.',
+        # Option "none" was added on 6.2.61b
     },
     aliases_wrapper => {
         context    => [qw(domain site)],

--- a/src/sbin/sympa_newaliases.pl.in
+++ b/src/sbin/sympa_newaliases.pl.in
@@ -140,6 +140,9 @@ if ($aliases_program =~ m{\A/}) {
         q{--POSTMAP--}, $aliases_db_type, $aliases_file);
 
     exec q{--POSTMAP--}, "$aliases_db_type:$aliases_file";
+} elsif ($aliases_program eq 'none') {
+    $log->syslog('debug2', 'Skipping execution of aliases_program');
+    exit 0;
 } else {
     $log->syslog('err', 'Invalid aliases_program "%s"', $aliases_program);
     exit 1;


### PR DESCRIPTION
This fixes an annoying error message. The problem is more or less cosmetic as the aliases are already probably updated.

```
~$ sympa --close_list test
err main::#144 Invalid aliases_program "none"
close_list [notice] List has been closed

```
Sympa version:  6.2.59b.2

Relevant configuration:
```
sendmail_aliases /etc/mail/sympa/aliases
alias_manager Template
aliases_program none
aliases_wrapper off
```
