### PR TITLE
Adjust compose_mail template to the obsolescence of the merge_feature configuration parameter

### DIFF
--- a/default/web_tt2/compose_mail.tt2
+++ b/default/web_tt2/compose_mail.tt2
@@ -53,7 +53,7 @@
             <textarea name="body" id="body" cols="80" rows="25">[% body %]</textarea>
             <br />
 
-            [% IF listconf.personalization_feature == 'on' %]
+            [% IF listconf.personalization_feature == 'on' && listconf.personalization.web_apply_on == 'all' %]
                 <br />
                 <b>[%|loc%]Messages customization: use the template syntax:[%END%] <a href="http://www.tt2.org">TT2</a></b>
                 <br />

--- a/default/web_tt2/compose_mail.tt2
+++ b/default/web_tt2/compose_mail.tt2
@@ -53,7 +53,7 @@
             <textarea name="body" id="body" cols="80" rows="25">[% body %]</textarea>
             <br />
 
-            [% IF listconf.merge_feature == 'on' %]
+            [% IF listconf.personalization_feature == 'on' %]
                 <br />
                 <b>[%|loc%]Messages customization: use the template syntax:[%END%] <a href="http://www.tt2.org">TT2</a></b>
                 <br />


### PR DESCRIPTION
Otherwise the legend describing the available TT2 parameter doesn't show up. This needs to be mentioned in the upgrade documentation as well.

