### PR TITLE
Drop support for Perl prior to 5.16 (#1030)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,6 @@
     - coverage-install
     - coverage-setup
     - cpanm --quiet --notest --installdeps --with-develop --with-feature=Data::Password --with-feature=ldap --with-feature=safe-unicode --with-feature=smime --with-feature=soap --with-feature=sqlite .
-    - cpanm --notest --quiet Unicode::CaseFold
     - autoreconf -i
     - ./configure
     - cd src; make; cd ..
@@ -17,12 +16,6 @@
     - coverage-report
     - make clean
 
-"5.10":
-  <<: *job
-"5.12":
-  <<: *job
-"5.14":
-  <<: *job
 "5.16":
   <<: *job
   variables:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ perl:
   - "5.20"
   - "5.18"
   - "5.16"
-  - "5.14"
-  - "5.12"
-  - "5.10"
 
 matrix:
   include:
@@ -29,7 +26,6 @@ before_install:
 install:
   - cpan-install --coverage
   - cpanm --installdeps --notest --with-develop --with-feature=Data::Password --with-feature=ldap --with-feature=safe-unicode --with-feature=smime --with-feature=soap --with-feature=sqlite .
-  - cpanm --notest --quiet Unicode::CaseFold
 
 before_script:
   - coverage-setup

--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,7 @@
 
 # Minimum version of Perl required.
 # Notation suggested on https://metacpan.org/pod/Carton#PERL-VERSIONS
-requires 'perl', '5.10.1';
+requires 'perl', '5.16.0';
 
 # This module provides zip/unzip for archive and shared document download/upload
 requires 'Archive::Zip', '>= 1.05';

--- a/src/lib/Sympa/Tools/Text.pm
+++ b/src/lib/Sympa/Tools/Text.pm
@@ -29,6 +29,7 @@ package Sympa::Tools::Text;
 
 use strict;
 use warnings;
+use feature qw(fc);
 use Encode qw();
 use English qw(-no_match_vars);
 use Encode::MIME::Header;    # 'MIME-Q' encoding.
@@ -37,8 +38,6 @@ use MIME::EncWords;
 use Text::LineFold;
 use Unicode::GCString;
 use URI::Escape qw();
-use if ($] < 5.016), qw(Unicode::CaseFold fc);
-use if (5.016 <= $]), qw(feature fc);
 BEGIN { eval 'use Unicode::Normalize qw()'; }
 BEGIN { eval 'use Unicode::UTF8 qw()'; }
 
@@ -286,7 +285,6 @@ sub foldcase {
     my $str = shift;
 
     return '' unless defined $str and length $str;
-    # Perl 5.16.0 and later have built-in fc(). Earlier uses Unicode::CaseFold.
     return Encode::encode_utf8(fc(Encode::decode_utf8($str)));
 }
 


### PR DESCRIPTION
This may fix #1030 .
