### PR TITLE
✨ — Add "bouncers reset", "bouncers del" and "bouncers [--status] review" commands to sympa.pl

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -30,6 +30,9 @@ nobase_dist_modules_DATA = \
 	Sympa/Internals/Workflow.pod
 CLI_modules = \
 	Sympa/CLI/add.pm \
+	Sympa/CLI/bouncers.pm \
+	Sympa/CLI/bouncers/del.pm \
+	Sympa/CLI/bouncers/reset.pm \
 	Sympa/CLI/check.pm \
 	Sympa/CLI/close.pm \
 	Sympa/CLI/conf_2_db.pm \
@@ -49,6 +52,7 @@ CLI_modules = \
 	Sympa/CLI/rebuildarc.pm \
 	Sympa/CLI/reload_list_config.pm \
 	Sympa/CLI/restore.pm \
+	Sympa/CLI/review.pm \
 	Sympa/CLI/send_digest.pm \
 	Sympa/CLI/show_pending_lists.pm \
 	Sympa/CLI/sync_list_db.pm \

--- a/src/lib/Sympa/CLI/bouncers.pm
+++ b/src/lib/Sympa/CLI/bouncers.pm
@@ -1,0 +1,76 @@
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+
+# Sympa - SYsteme de Multi-Postage Automatique
+#
+# Copyright 2021 The Sympa Community. See the
+# AUTHORS.md file at the top-level directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package Sympa::CLI::bouncers;
+
+use strict;
+use warnings;
+
+use parent qw(Sympa::CLI);
+
+use constant _options   => qw();
+use constant _args      => qw();
+use constant _need_priv => 0;
+
+sub _run {
+    my $class   = shift;
+    my $options = shift;
+    my @argv    = @_;
+
+    Sympa::CLI->run(qw(help bouncers));
+}
+
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+sympa-bouncers - Manipulate list bounced users
+
+=head1 SYNOPSIS
+
+C<sympa bouncers> I<sub-command> ...
+
+=head1 DESCRIPTION
+
+TBD.
+
+=head1 SUB-COMMANDS
+
+Currently following sub-commands are available.
+To see detail of each sub-command, run 'C<sympal.pl help bouncers> I<sub-command>'.
+
+=over
+
+=item L<"sympa bouncers del ..."|sympa-bouncers-del(1)>
+
+Unsubscribe bounced users from a list
+
+=item L<"sympa bouncers reset ..."|sympa-bouncers-reset(1)>
+
+Reset the bounce status of all bounced users of a list
+
+=back
+
+=cut

--- a/src/lib/Sympa/CLI/bouncers/del.pm
+++ b/src/lib/Sympa/CLI/bouncers/del.pm
@@ -1,0 +1,91 @@
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+
+# Sympa - SYsteme de Multi-Postage Automatique
+#
+# Copyright 2021 The Sympa Community. See the
+# AUTHORS.md file at the top-level directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package Sympa::CLI::bouncers::del;
+
+use strict;
+use warnings;
+
+use Sympa;
+use Sympa::List;
+use Sympa::Spindle::ProcessRequest;
+
+use parent qw(Sympa::CLI::bouncers);
+
+use constant _options   => qw();
+use constant _args      => qw(list);
+use constant _need_priv => 1;
+
+sub _run {
+    my $class   = shift;
+    my $options = shift;
+    my $list    = shift;
+
+    my @bounced;
+    for (
+        my $i = $list->get_first_bouncing_list_member();
+        $i;
+        $i = $list->get_next_bouncing_list_member()
+    ) {
+        push @bounced, $i->{email};
+    }
+
+    unless (scalar @bounced) {
+        printf STDERR "No bounced users in list %s.\n", $list->get_id;
+        exit 1;
+    }
+
+    my $spindle = Sympa::Spindle::ProcessRequest->new(
+        context          => $list,
+        action           => 'del',
+        role             => 'member',
+        email            => [@bounced],
+        sender           => Sympa::get_address($list, 'listmaster'),
+        scenario_context => {skip => 1},
+    );
+    unless ($spindle and $spindle->spin and $class->_report($spindle)) {
+        printf STDERR "Failed to delete email addresses from %s.\n",
+            $list->get_id;
+        exit 1;
+    }
+
+    exit 0;
+}
+
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+sympa-bouncers-del - Unsubscribe bounced users from a list
+
+=head1 SYNOPSIS
+
+C<sympa bouncers del> I<list>[ C<@>I<domain> ]
+
+=head1 DESCRIPTION
+
+Unsubscribe bounced users from a list.
+
+=cut

--- a/src/lib/Sympa/CLI/bouncers/reset.pm
+++ b/src/lib/Sympa/CLI/bouncers/reset.pm
@@ -1,0 +1,93 @@
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+
+# Sympa - SYsteme de Multi-Postage Automatique
+#
+# Copyright 2021 The Sympa Community. See the
+# AUTHORS.md file at the top-level directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package Sympa::CLI::bouncers::reset;
+
+use strict;
+use warnings;
+
+use Sympa;
+use Sympa::List;
+use Sympa::Spindle::ProcessRequest;
+
+use parent qw(Sympa::CLI::bouncers);
+
+use constant _options   => qw();
+use constant _args      => qw(list);
+use constant _need_priv => 1;
+
+sub _run {
+    my $class   = shift;
+    my $options = shift;
+    my $list    = shift;
+
+    my ($errors, $users) = (0, 0);
+    for (
+        my $i = $list->get_first_bouncing_list_member();
+        $i;
+        $i = $list->get_next_bouncing_list_member()
+    ) {
+        if ($list->update_list_member(
+                $i->{email},
+                bounce       => undef,
+                update_date  => time,
+                bounce_score => 0
+            )
+        ) {
+            $users++;
+        } else {
+            printf STDERR "Unable to cancel bounce error for %s.\n", $i->{email};
+        }
+        $errors++;
+    }
+
+    if ($errors) {
+        my $text =
+            ($users > 1)
+            ? "Canceled %i bounce errors on %i.\n"
+            : "Canceled %i bounce error on %i.\n";
+        printf $text, $users, $errors;
+    } else {
+        print "No bounce errors to cancel.\n";
+    }
+
+    exit 0;
+}
+
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+sympa-bouncers-reset - Reset the bounce status of all bounced users of a list
+
+=head1 SYNOPSIS
+
+C<sympa bouncers reset> I<list>[ C<@>I<domain> ]
+
+=head1 DESCRIPTION
+
+Reset the bounce status of all bounced users of a list
+
+=cut

--- a/src/lib/Sympa/CLI/review.pm
+++ b/src/lib/Sympa/CLI/review.pm
@@ -1,0 +1,104 @@
+# -*- indent-tabs-mode: nil; -*-
+# vim:ft=perl:et:sw=4
+
+# Sympa - SYsteme de Multi-Postage Automatique
+#
+# Copyright 2021 The Sympa Community. See the
+# AUTHORS.md file at the top-level directory of this distribution and at
+# <https://github.com/sympa-community/sympa.git>.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package Sympa::CLI::review;
+
+use strict;
+use warnings;
+use English qw(-no_match_vars);
+
+use Sympa;
+use Sympa::List;
+
+use parent qw(Sympa::CLI);
+
+use constant _options => qw(status);
+use constant _args    => qw(list);
+
+sub _run {
+    my $class   = shift;
+    my $options = shift;
+    my $list    = shift;
+
+    if ($list) {
+        my @members = $list->get_members(
+            'unconcealed_member',
+            order => 'email'
+        );
+        my @bounced   = ();
+        my @suspended = ();
+
+        printf "%i member(s) in list %s.\n",
+            scalar(@members), $list->get_id;
+        for my $member (@members) {
+            printf "%s\n", $member->{email};
+            push @bounced,   $member->{'email'}
+                if defined $member->{'bounce'};
+            push @suspended, $member->{'email'}
+                if defined $member->{'suspend'};
+        }
+
+        if ($options->{'status'}) {
+            print "------------------\n";
+
+            printf "%i bounced member(s) in list %s.\n",
+                scalar(@bounced), $list->get_id;
+            for my $member (@bounced) {
+                printf "%s\n", $member;
+            }
+
+            printf "%i suspended member(s) in list %s.\n",
+                scalar(@suspended), $list->get_id;
+            for my $member (@suspended) {
+                printf "%s\n", $member;
+            }
+        }
+
+        exit 0;
+    } else {
+        printf STDERR "Error : please provide the name of a list\n";
+        exit 1;
+    }
+}
+
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+sympa-review - Show subscribers of the list.
+
+=head1 SYNOPSIS
+
+C<sympa review> S<[ C<--status> ]> I<list>[ C<@>I<domain> ]
+
+=head1 DESCRIPTION
+
+Show subscribers of the list.
+
+=head1 HISTORY
+
+This option was added on Sympa 6.2.69b.
+
+=cut

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -6418,6 +6418,12 @@ I<Instance method>.
 Returns the number of messages sent to the list.
 FIXME
 
+=item get_first_bouncing_list_member ( )
+
+I<Instance method>.
+Get first bouncing user.
+FIXME
+
 =item get_next_bouncing_list_member ( )
 
 I<Instance method>.

--- a/src/lib/Sympa/Request/Handler/del.pm
+++ b/src/lib/Sympa/Request/Handler/del.pm
@@ -126,7 +126,8 @@ sub _report_member {
                 $who);
         }
     }
-    $self->add_stash($request, 'notice', 'removed', {'email' => $who});
+    $self->add_stash($request, 'notice', 'removed',
+        {'email' => $who, 'listname' => $list->get_id});
     $log->syslog(
         'info',
         'DEL %s %s from %s accepted (%.2f seconds, %d subscribers)',

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -426,6 +426,9 @@ S<[ C<--dump_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
 S<[ C<--restore_users> C<--list>=I<list>@I<domain>|ALL [ C<--role>=I<roles> ] ]>
 S<[ C<--show_pending_lists>=I<robot> ]>
 S<[ C<--rebuildarc>=I<list>[I<@robot>] ]>
+S<[ C<review> [C<--status>] I<list>[I<@robot>] ]>
+S<[ C<bouncers> C<reset> I<list>[I<@robot>] ]>
+S<[ C<bouncers> C<del> I<list>[I<@robot>] ]>
 
 =head2 Options
 
@@ -753,6 +756,18 @@ Rebuild the archives of the list.
 New command line format:
 
 TBD.
+
+=item C<review> [C<--status>] I<list>[I<@robot>]
+
+Show the subscribers of the list.
+
+=item C<bouncers> C<reset> I<list>[I<@robot>]
+
+Cancel the errors of the subscribers of the list.
+
+=item C<bouncers> C<del> I<list>[I<@robot>]
+
+Unsubscribe the users of the list who are in error status
 
 =item C<--reload_list_config>
 [ C<--list=>I<mylist>@I<mydom> ] [ C<--robot=>I<mydom> ]


### PR DESCRIPTION
Fix #1058 

I’m not sure about the `--show_status_of_members`: I print differently users with `bounce` attribute, users with `suspend` attribute and all the others. Is `suspend` attribute a sign of an error? Should I just print the `ok` and `bounce` users?

What are your thoughts about it?