### PR TITLE
`web_archive_spam_protection gecos` didn't work as expected

### DIFF
--- a/src/lib/Sympa/Config/Schema.pm
+++ b/src/lib/Sympa/Config/Schema.pm
@@ -1725,11 +1725,12 @@ our %pinfo = (
         group   => 'archives',
         #gettext_id => "email address protection method",
         gettext_id => 'Protect web archive against spam harvesters',
-        gettext_comment =>
-            'Idem spam_protection is provided but it can be used only for web archives. Access requires a cookie, and users must submit a small form in order to receive a cookie before browsing the archives. This blocks all robot, even google and co.',
         #gettext_comment =>
-        #    "The same as \"spam_protection\", but restricted to the web archive.\nIn addition to it:\ncookie: users must submit a small form in order to receive a cookie before browsing the web archive.\ngecos: \nonly gecos is displayed.",
-        format     => ['cookie', 'javascript', 'at', 'gecos', 'none'],
+        #    'Idem spam_protection is provided but it can be used only for web archives. Access requires a cookie, and users must submit a small form in order to receive a cookie before browsing the archives. This blocks all robot, even google and co.',
+        gettext_comment =>
+            "The same as \"spam_protection\", but restricted to the web archive.\nIn addition to it:\ncookie: users must submit a small form in order to receive a cookie before browsing the web archive.\nconcealed: e-mail addresses will never be displayed.",
+        format     => ['cookie', 'javascript', 'at', 'concealed', 'none'],
+        synonym    => {'gecos' => 'concealed'},
         occurrence => '1',
         default    => 'cookie',
     },

--- a/src/lib/Sympa/HTMLDecorator.pm
+++ b/src/lib/Sympa/HTMLDecorator.pm
@@ -249,6 +249,7 @@ sub decorate_email_concealed {
         } elsif ($item->{event} eq 'start'
             and $item->{attr}
             and 0 == index(lc($item->{attr}->{href} // ''), 'mailto:')) {
+            # Empties mailto URL in link target
             my $text = $item->{text};
             $text =~ s{(?<=\bhref=)[^\s>]+}{"mailto:"}gi;
             $decorated .= $text;

--- a/src/lib/Sympa/HTMLDecorator.pm
+++ b/src/lib/Sympa/HTMLDecorator.pm
@@ -182,13 +182,12 @@ sub decorate {
 
     return $html unless defined $html and length $html;
 
-    if ($options{email}) {
-        $self->{_shdEmailFunc} =
-              $options{email} eq 'at'         ? \&decorate_email_at
-            : $options{email} eq 'gecos'      ? \&decorate_email_gecos
-            : $options{email} eq 'javascript' ? \&decorate_email_js
-            :                                   undef;
-    }
+    $self->{_shdEmailFunc} = {
+        at         => \&decorate_email_at,
+        concealed  => \&decorate_email_concealed,
+        gecos      => \&decorate_email_concealed,    # compat.<=6.2.61b
+        javascript => \&decorate_email_js
+    }->{$options{email} // ''};
     # No decoration needed.
     return $html unless $self->{_shdEmailFunc};
 
@@ -232,7 +231,7 @@ sub decorate_email_at {
     return $decorated;
 }
 
-sub decorate_email_gecos {
+sub decorate_email_concealed {
     my $self = shift;
 
     my $decorated = '';
@@ -247,12 +246,16 @@ sub decorate_email_gecos {
             } else {
                 $decorated .= $item->{text};
             }
+        } elsif ($item->{event} eq 'start'
+            and $item->{attr}
+            and 0 == index(lc($item->{attr}->{href} // ''), 'mailto:')) {
+            my $text = $item->{text};
+            $text =~ s{(?<=\bhref=)[^\s>]+}{"mailto:"}gi;
+            $decorated .= $text;
         } else {
             $decorated .= $item->{text};
         }
     }
-
-    $decorated .= $language->gettext('No gecos') if ($decorated eq ': ');
 
     return $decorated;
 }

--- a/src/lib/Sympa/ListOpt.pm
+++ b/src/lib/Sympa/ListOpt.pm
@@ -213,8 +213,8 @@ our %list_option = (
     'year'    => {'gettext_id' => 'yearly'},
 
     # web_archive_spam_protection
-    'cookie' => {'gettext_id' => 'use HTTP cookie'},
-    'gecos'  => {'gettext_id' => 'only show gecos'},
+    'cookie'    => {'gettext_id' => 'use HTTP cookie'},
+    'concealed' => {'gettext_id' => 'never show address'},
 
     # verp_rate
     '100%' => {'gettext_id' => '100% - always'},

--- a/src/lib/Sympa/Template.pm
+++ b/src/lib/Sympa/Template.pm
@@ -251,7 +251,7 @@ sub _obfuscate {
     my ($context, $mode) = @_;
 
     return sub {shift}
-        unless grep { $mode eq $_ } qw(at javascript);
+        unless grep { $mode eq $_ } qw(at gecos javascript);
 
     return sub {
         my $text = shift;

--- a/src/lib/Sympa/Template.pm
+++ b/src/lib/Sympa/Template.pm
@@ -251,7 +251,7 @@ sub _obfuscate {
     my ($context, $mode) = @_;
 
     return sub {shift}
-        unless grep { $mode eq $_ } qw(at gecos javascript);
+        unless grep { $mode eq $_ } qw(at concealed javascript);
 
     return sub {
         my $text = shift;


### PR DESCRIPTION
`web_archive_spam_protection gecos` didn't work because this option was omitted.  This PR may fix #1107 .

This PR includes the other fixes:
  - Previously email addresses in HTML tags were not removed.
  - The option name "gecos" is not so generally used. "concealed" looks more common.
