### PR TITLE
Add autocomplete="off" to all forms unless explicitly enabled.

### DIFF
--- a/default/web_tt2/login.tt2
+++ b/default/web_tt2/login.tt2
@@ -63,7 +63,7 @@
     [% END ~%]
 
     [% IF use_passwd ~%]
-        <form action="[% path_cgi %]" method="post">
+        <form action="[% path_cgi %]" method="post" autocomplete="on">
             <fieldset>
                 <input type="hidden" name="previous_action" value="[% previous_action %]" />
                 <input type="hidden" name="previous_list"   value="[% previous_list %]" />

--- a/default/web_tt2/renewpasswd.tt2
+++ b/default/web_tt2/renewpasswd.tt2
@@ -42,7 +42,7 @@
     [% END %]
 [% END %]
 [% IF SAFE_TO_REVEAL_EMAIL %]
-    <form class="bold_label" action="[% path_cgi %]" method="post">
+    <form class="bold_label" action="[% path_cgi %]" method="post" autocomplete="on">
         <fieldset>
             <input type="hidden" name="previous_action" value="[% previous_action %]" />
             <input type="hidden" name="previous_list" value="[% previous_list %]" />

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -2476,6 +2476,16 @@ sub send_html {
             $beg . $content . $end;
         }egisx;
     }
+    # Add autocomplete="off" to all forms unless explicitly enabled.
+    $output =~ s{
+        <form ( \s+ [^>]*? /? ) >
+    }{
+        my $attrs = $1;
+        $attrs =~ s/(\s*\/?)\z/ autocomplete="off"$1/
+            unless $attrs =~ /\sautocomplete="[^"]*"/i;
+        "<form$attrs>";
+    }egisx;
+
     print $output;
 }
 


### PR DESCRIPTION
### Known bug
  - However, this cannot prevent heuristics by Google Chrome: See #1033 .
