### PR TITLE
Make it clear that wwsympa_url needs to include the protocol

### DIFF
--- a/src/lib/Sympa/Config/Schema.pm
+++ b/src/lib/Sympa/Config/Schema.pm
@@ -4810,7 +4810,7 @@ our %pinfo = (
         group           => 'www_basic',
         sample          => 'https://web.example.org/sympa',
         gettext_id      => 'URL prefix of web interface',
-        gettext_comment => 'This is used to construct URLs of web interface.',
+        gettext_comment => 'This is used to construct URLs of web interface. The protocol (either https:// or http://) is required.',
     },
     wwsympa_url_local => {
         context    => [qw(domain site)],


### PR DESCRIPTION
This prevents confusion seen at:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=929157#15
https://github.com/sympa-community/sympa/issues/876#issuecomment-590156276

Even better to have a format that checks whether it is a valid URL.
E.g. by feeding it to the URI module and verify that all vital parts
are present.