### PR TITLE
Skip approval for owner subscription and unsubscription

### DIFF
--- a/default/scenari/subscribe.owner
+++ b/default/scenari/subscribe.owner
@@ -3,4 +3,5 @@ title.gettext owners approval
 
 !equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
 is_subscriber([listname],[email])  smtp,dkim,md5,smime -> do_it
+is_owner([listname],[email])       smtp,dkim,smime,md5 -> do_it
 true()                             smtp,dkim,md5,smime -> owner

--- a/default/scenari/unsubscribe.owner
+++ b/default/scenari/unsubscribe.owner
@@ -3,4 +3,5 @@ title.gettext owners approval
 
 !equal([sender],[email])           smtp,dkim,md5,smime -> request_auth([email])
 !is_subscriber([listname],[email]) smtp,dkim,smime,md5 -> do_it
+is_owner([listname],[email])       smtp,dkim,smime,md5 -> do_it
 true()                             smtp,dkim,md5,smime -> owner


### PR DESCRIPTION
There is no point to force the list owner to approve its own subscription and unsubscription to a list.
