### PR TITLE
Obsolete escape_chars() / unescape_chars()

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -8948,7 +8948,6 @@ sub do_remove_arc {
     wwslog('info', 'List %s, yyyy %s, mm %s, #message %s',
         $in{'list'}, $in{'yyyy'}, $in{'month'});
 
-    # $in{'msgid'} = Sympa::Tools::Text::unescape_chars($in{'msgid'});
     my @msgids       = split /\0/, $in{'msgid'};
     my @msg_subjects = split /\0/, $in{'msg_subject'};
 
@@ -9467,7 +9466,6 @@ sub do_arcsearch_id {
         return undef;
     }
 
-    #$in{'msgid'} = Sympa::Tools::Text::unescape_chars($in{'msgid'});
     $param->{'msgid'} = $in{'msgid'};
 
     $search->limit(1);

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -10073,10 +10073,11 @@ sub do_viewbounce {
 
     my $html_relpath;
     if ($in{'email'}) {
-        my $escaped_email = Sympa::Tools::Text::escape_chars($in{'email'});
+        my $escaped_email =
+            Sympa::Tools::Text::encode_filesystem_safe($in{'email'});
         $html_relpath =
             $in{'envid'}
-            ? sprintf('%s_%08s', $escaped_email, $in{'envid'})
+            ? sprintf('%s__%08s', $escaped_email, $in{'envid'})
             : $escaped_email;
     } elsif ($in{'dir'} and $in{'file'}) {
         $html_relpath = $in{'dir'};
@@ -10310,7 +10311,8 @@ sub do_resetbounce {
 
     foreach my $email (@emails) {
 
-        my $escaped_email = Sympa::Tools::Text::escape_chars($email);
+        my $escaped_email =
+            Sympa::Tools::Text::encode_filesystem_safe($email);
 
         unless ($list->is_list_member($email)) {
             Sympa::WWW::Report::reject_report_web('user',

--- a/src/lib/Sympa/Archive.pm
+++ b/src/lib/Sympa/Archive.pm
@@ -405,14 +405,6 @@ sub html_remove {
         '-rmm'    => $msgid
     );
 
-    # Remomve urlized message.
-    my $url_dir =
-          $list->{'dir'}
-        . '/urlized/'
-        . Sympa::Tools::Text::escape_chars($msgid);
-    my $error;
-    File::Path::remove_tree($url_dir, {error => \$error});
-
     return 1;
 }
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -1208,37 +1208,6 @@ sub get_recipients_per_mode {
             next;
         }
 
-        #XXX Following will be done by ProcessOutgoing spindle.
-        # # Message should be re-encrypted, however, user certificate is
-        # # missing.
-        # if ($message->{'smime_crypted'}
-        #     and not -r $Conf::Conf{'ssl_cert_dir'} . '/'
-        #     . Sympa::Tools::Text::escape_chars($user->{'email'})
-        #     and not -r $Conf::Conf{'ssl_cert_dir'} . '/'
-        #     . Sympa::Tools::Text::escape_chars($user->{'email'} . '@enc')) {
-        #     my $subject = $message->{'decoded_subject'};
-        #     my $sender  = $message->{'sender'};
-        #     unless (
-        #         Sympa::send_file(
-        #             $self,
-        #             'x509-user-cert-missing',
-        #             $user->{'email'},
-        #             {   'mail' =>
-        #                     {'subject' => $subject, 'sender' => $sender},
-        #                 'auto_submitted' => 'auto-generated'
-        #             }
-        #         )
-        #         ) {
-        #         $log->syslog(
-        #             'notice',
-        #             'Unable to send template "x509-user-cert-missing" to %s',
-        #             $user->{'email'}
-        #         );
-        #     }
-        #     next;
-        # }
-        # # Otherwise it may be shelved encryption.
-
         if ($user->{'reception'} eq 'txt') {
             if ($user->{'bounce_address'}) {
                 push @tabrcpt_txt_verp, $user->{'email'};

--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -1114,9 +1114,9 @@ sub smime_encrypt {
     my $certfile;
     my $entity;
 
-    my $base =
-        $Conf::Conf{'ssl_cert_dir'} . '/'
-        . Sympa::Tools::Text::escape_chars($email);
+    my $base = sprintf '%s/%s',
+        $Conf::Conf{'ssl_cert_dir'},
+        Sympa::Tools::Text::encode_filesystem_safe($email);
     if (-f $base . '@enc') {
         $certfile = $base . '@enc';
     } else {
@@ -1350,8 +1350,8 @@ sub check_smime_signature {
     # or a pair of single-purpose. save them, as email@addr if combined,
     # or as email@addr@sign / email@addr@enc for split certs.
     foreach my $c (keys %certs) {
-        my $filename = "$Conf::Conf{ssl_cert_dir}/"
-            . Sympa::Tools::Text::escape_chars(lc($sender));
+        my $filename = sprintf '%s/%s', $Conf::Conf{ssl_cert_dir},
+            Sympa::Tools::Text::encode_filesystem_safe(lc $sender);
         if ($c ne 'both') {
             unlink $filename;    # just in case there's an old cert left...
             $filename .= "\@$c";

--- a/src/lib/Sympa/Tools/Text.pm
+++ b/src/lib/Sympa/Tools/Text.pm
@@ -249,32 +249,8 @@ sub encode_uri {
 }
 
 # Old name: tools::escape_chars().
-sub escape_chars {
-    my $s          = shift;
-    my $except     = shift;                            ## Exceptions
-    my $ord_except = ord $except if defined $except;
-
-    ## Escape chars
-    ##  !"#$%&'()+,:;<=>?[] AND accented chars
-    ## escape % first
-    foreach my $i (
-        0x25,
-        0x20 .. 0x24,
-        0x26 .. 0x2c,
-        0x3a .. 0x3f,
-        0x5b, 0x5d,
-        0x80 .. 0x9f,
-        0xa0 .. 0xff
-    ) {
-        next if defined $ord_except and $i == $ord_except;
-        my $hex_i = sprintf "%lx", $i;
-        $s =~ s/\x$hex_i/%$hex_i/g;
-    }
-    ## Special traetment for '/'
-    $s =~ s/\//%a5/g unless defined $except and $except eq '/';
-
-    return $s;
-}
+# Moved to: Sympa::Upgrade::_escape_chars()
+#sub escape_chars;
 
 # Old name: tt2::escape_url().
 # DEPRECATED.  Use Sympa::Tools::Text::escape_uri() or
@@ -539,19 +515,8 @@ sub _gc_length {
 }
 
 # Old name: tools::unescape_chars().
-sub unescape_chars {
-    my $s = shift;
-
-    $s =~ s/%a5/\//g;    ## Special traetment for '/'
-    foreach my $i (0x20 .. 0x2c, 0x3a .. 0x3f, 0x5b, 0x5d, 0x80 .. 0x9f,
-        0xa0 .. 0xff) {
-        my $hex_i = sprintf "%lx", $i;
-        my $hex_s = sprintf "%c",  $i;
-        $s =~ s/%$hex_i/$hex_s/g;
-    }
-
-    return $s;
-}
+# Moved to: Sympa::Upgrade::_unescape_chars().
+#sub unescape_chars;
 
 # Old name: tools::valid_email().
 sub valid_email {
@@ -770,10 +735,10 @@ Encoded string, stripped C<utf8> flag if any.
 
 =item escape_chars ( $str )
 
-Escape weird characters.
+B<Deprecated>.
+Use L</encode_filesystem_safe>.
 
-ToDo: This should be obsoleted in the future release: Would be better to use
-L</encode_filesystem_safe>.
+Escape weird characters.
 
 =item escape_url ( $str )
 
@@ -906,10 +871,10 @@ C<$file> is the path to text file.
 
 =item unescape_chars ( $str )
 
-Unescape weird characters.
+B<Deprecated>.
+Use L</decode_filesystem_safe>.
 
-ToDo: This should be obsoleted in the future release: Would be better to use
-L</decode_filesystem_safe>.
+Unescape weird characters.
 
 =item valid_email ( $string )
 

--- a/src/lib/Sympa/Tracking.pm
+++ b/src/lib/Sympa/Tracking.pm
@@ -264,8 +264,8 @@ sub store {
         unless (_db_insert_notification($rcpt, %options)) {
             return undef;
         }
-        $filename = sprintf '%s_%08s',
-            Sympa::Tools::Text::escape_chars($rcpt),
+        $filename = sprintf '%s__%08s',
+            Sympa::Tools::Text::encode_filesystem_safe($rcpt),
             $options{envid};
     } else {
         unless (
@@ -275,7 +275,7 @@ sub store {
                 $rcpt, $self->{context});
             return undef;
         }
-        $filename = Sympa::Tools::Text::escape_chars($rcpt);
+        $filename = Sympa::Tools::Text::encode_filesystem_safe($rcpt);
     }
     unless (open $ofh, '>', $bounce_dir . '/' . $filename) {
         $log->syslog('err', 'Unable to write %s/%s', $bounce_dir, $filename);
@@ -479,7 +479,7 @@ sub remove_message_by_email {
     return undef unless $email;
 
     my $bounce_dir    = $self->{directory};
-    my $escaped_email = Sympa::Tools::Text::escape_chars($email);
+    my $escaped_email = Sympa::Tools::Text::encode_filesystem_safe($email);
     my $ret           = unlink sprintf('%s/%s', $bounce_dir, $escaped_email);
 
     # Remove HTML view.
@@ -540,9 +540,9 @@ sub remove_message_by_id {
     while (my $info = $sth->fetchrow_hashref('NAME_lc')) {
         my $bounce_dir = $self->{directory};
         my $escaped_email =
-            Sympa::Tools::Text::escape_chars($info->{'recipient'});
+            Sympa::Tools::Text::encode_filesystem_safe($info->{'recipient'});
         my $envid = $info->{'envid'};
-        unlink sprintf('%s/%s_%08s', $bounce_dir, $escaped_email, $envid);
+        unlink sprintf('%s/%s__%08s', $bounce_dir, $escaped_email, $envid);
     }
     $sth->finish;
 
@@ -619,9 +619,9 @@ sub remove_message_by_period {
     while (my $info = $sth->fetchrow_hashref('NAME_lc')) {
         my $bounce_dir = $self->{directory};
         my $escaped_email =
-            Sympa::Tools::Text::escape_chars($info->{'recipient'});
+            Sympa::Tools::Text::encode_filesystem_safe($info->{'recipient'});
         my $envid = $info->{'envid'};
-        unlink sprintf('%s/%s_%08s', $bounce_dir, $escaped_email, $envid);
+        unlink sprintf('%s/%s__%08s', $bounce_dir, $escaped_email, $envid);
     }
     $sth->finish;
 


### PR DESCRIPTION
Since escape_chars() / unescape_chars() in Sympa::Tools::Text are wierd conversions and they are not filesystem safe, they'd be better to be replaced with encode_filesystem_safe() / decode_filesystem_safe().  This PR will do it.
