### PR TITLE
Hide archive download link from users without proper permissions

### DIFF
--- a/default/web_tt2/info.tt2
+++ b/default/web_tt2/info.tt2
@@ -134,13 +134,14 @@
                             <li>
                                 <i class="fa-li fa fa-arrow-right"></i><a href="[% 'edit_list_request' | url_rel([list,'archives']) %]">[%|loc%]Change settings for who can view archives[%END%]</a>
                             </li>
+                            [% IF is_user_allowed_to('archive_web_access', list) %]
                             <li>
                                 <i class="fa-li fa fa-arrow-right"></i><a href="[% 'arc_manage' | url_rel([list]) %]">[%|loc%]Download archives[%END%]</a>
                             </li>
+                            [% END %]
                         </ul>
                     </div>
                 </div>
-
                 <div class="item">
                     <div class="item_content">
                         <a class="item_title" href="[% 'edit_list_request' | url_rel([list,'data_source']) %]">


### PR DESCRIPTION
Don't show this link on the list info page when access would be denied anyway.