### PR TITLE
Data source synchronization performance improvement

### DIFF
--- a/src/lib/Sympa/Database.pm
+++ b/src/lib/Sympa/Database.pm
@@ -406,6 +406,27 @@ sub prepare_query_log_values {
 # DEPRECATED: Use tools::eval_in_time() and fetchall_arrayref().
 #sub fetch();
 
+sub begin {
+    my $self = shift;
+    my $dbh = $self->__dbh;
+    return $dbh->begin_work if $dbh;
+    return undef;
+}
+
+sub commit {
+    my $self = shift;
+    my $dbh = $self->__dbh;
+    return $dbh->commit if $dbh;
+    return undef;
+}
+
+sub rollback {
+    my $self = shift;
+    my $dbh = $self->__dbh;
+    return $dbh->rollback if $dbh;
+    return undef;
+}
+
 sub disconnect {
     my $self = shift;
 
@@ -534,6 +555,16 @@ TBD.
 I<Constructor>.
 Creates new database instance.
 
+=item begin ( )
+
+I<Instance method>, I<only for SQL>.
+Begin transaction.
+
+=item commit ( )
+
+I<Instance method>, I<only for SQL>.
+Commit transaction.
+
 =item do_operation ( $operation, options... )
 
 I<Instance method>, I<only for LDAP>.
@@ -563,6 +594,11 @@ $statement and parameters will be fed to sprintf().
 Returns:
 
 Statement handle (L<DBI::st> object or such), or C<undef>.
+
+=item rollback ( )
+
+I<Instance method>, I<only for SQL>.
+Rollback transaction.
 
 =back
 

--- a/src/lib/Sympa/DatabaseDriver.pm
+++ b/src/lib/Sympa/DatabaseDriver.pm
@@ -539,6 +539,14 @@ provided by L<Sympa::Database> class:
 
 =over
 
+=item begin ( )
+
+I<Overridable>, I<only for SQL driver>.
+
+=item commit ( )
+
+I<Overridable>, I<only for SQL driver>.
+
 =item do_operation ( $operation, $parameters, ...)
 
 I<Overridable>, I<only for LDAP driver>.
@@ -548,6 +556,10 @@ I<Overridable>, I<only for LDAP driver>.
 I<Overridable>, I<only for SQL driver>.
 
 =item do_prepared_query ( $query, $parameters, ... )
+
+I<Overridable>, I<only for SQL driver>.
+
+=item rollback ( )
 
 I<Overridable>, I<only for SQL driver>.
 

--- a/src/lib/Sympa/DatabaseDriver/SQLite.pm
+++ b/src/lib/Sympa/DatabaseDriver/SQLite.pm
@@ -520,10 +520,50 @@ sub translate_type {
     return $type;
 }
 
+# As SQLite does not support nested transactions, these are not effective
+# during when {_transaction_level} attribute is positive, i.e. only the
+# outermost transaction will be available.
+sub begin {
+    my $self = shift;
+
+    $self->{_transaction_level} //= 0;
+
+    if ($self->{_transaction_level}++) {
+        return 1;
+    }
+    return $self->SUPER::begin;
+}
+
+sub commit {
+    my $self = shift;
+
+    unless ($self->{_transaction_level}) {
+        die 'bug in logic. Ask developer';
+    }
+    if (--$self->{_transaction_level}) {
+        return 1;
+    }
+    return $self->SUPER::commit;
+}
+
+sub rollback {
+    my $self = shift;
+
+    unless ($self->{_transaction_level}) {
+        die 'bug in logic. Ask developer';
+    }
+    if (--$self->{_transaction_level}) {
+        return 1;
+    }
+    return $self->SUPER::rollback;
+}
+
 # Note:
-# To prevent "database is locked" error, acquire "immediate" lock
-# by each query.  Most queries excluding "SELECT" need to lock in this
-# manner.
+# - To prevent "database is locked" error, acquire "immediate" lock
+#   by each query.  Most queries excluding "SELECT" need to lock in this
+#   manner.
+# - If a transaction has been begun, lock is not needed, because SQLite
+#   does not support nested transactions.
 sub do_query {
     my $self = shift;
     my $sth;
@@ -531,8 +571,8 @@ sub do_query {
 
     my $need_lock =
         ($_[0] =~
-            /^\s*(ALTER|CREATE|DELETE|DROP|INSERT|REINDEX|REPLACE|UPDATE)\b/i
-        );
+            /^\s*(ALTER|CREATE|DELETE|DROP|INSERT|REINDEX|REPLACE|UPDATE)\b/i)
+        unless $self->{_transaction_level};
 
     ## acquire "immediate" lock
     unless (!$need_lock or $self->__dbh->begin_work) {
@@ -571,8 +611,8 @@ sub do_prepared_query {
 
     my $need_lock =
         ($_[0] =~
-            /^\s*(ALTER|CREATE|DELETE|DROP|INSERT|REINDEX|REPLACE|UPDATE)\b/i
-        );
+            /^\s*(ALTER|CREATE|DELETE|DROP|INSERT|REINDEX|REPLACE|UPDATE)\b/i)
+        unless $self->{_transaction_level};
 
     ## acquire "immediate" lock
     unless (!$need_lock or $self->__dbh->begin_work) {

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -1547,7 +1547,7 @@ sub delete_list_member {
     my $total = 0;
 
     my $sdm = Sympa::DatabaseManager->instance;
-    $sdm->__dbh->begin_work;
+    $sdm->begin;
 
     foreach my $who (@u) {
         $who = Sympa::Tools::Text::canonic_email($who);
@@ -1602,13 +1602,12 @@ sub delete_list_member {
     $self->_cache_publish_expiry('member');
     delete_list_member_picture($self, shift(@u));
 
-    unless ($sdm->__dbh->{AutoCommit}) {
-        my $rc = $sdm->__dbh->commit;
+        my $rc = $sdm->commit;
         unless ($rc) {
             $log->syslog('err', 'Error at delete member commit: %s', $sdm->errstr);
-            $sdm->__dbh->rollback;
+            $sdm->rollback;
         }
-    }
+
     return (-1 * $total);
 
 }
@@ -3226,7 +3225,7 @@ sub add_list_member {
 
     my $sdm = Sympa::DatabaseManager->instance;
 
-    $sdm->__dbh->begin_work;
+    $sdm->begin;
 
     foreach my $new_user (@new_users) {
         my $who = Sympa::Tools::Text::canonic_email($new_user->{'email'});
@@ -3373,13 +3372,12 @@ sub add_list_member {
         $self->{'add_outcome'}{'remaining_member_to_add'}--;
         $current_list_members_count++;
     }
-    unless ($sdm->__dbh->{AutoCommit}) {
-        my $rc = $sdm->__dbh->commit;
+        my $rc = $sdm->commit;
         unless ($rc) {
             $log->syslog('err', 'Error at add member commit: %s', $sdm->errstr);
-            $sdm->__dbh->rollback;
+            $sdm->rollback;
         }
-    }
+
 
     $self->_cache_publish_expiry('member');
     $self->_create_add_error_string() if ($self->{'add_outcome'}{'errors'});

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -1989,55 +1989,8 @@ sub get_exclusion {
     return $data_exclu;
 }
 
-sub is_member_excluded {
-    my $self  = shift;
-    my $email = shift;
-
-    return undef unless defined $email and length $email;
-    $email = Sympa::Tools::Text::canonic_email($email);
-
-    my $sdm = Sympa::DatabaseManager->instance;
-    my $sth;
-
-    if (defined $self->{'admin'}{'family_name'}
-        and length $self->{'admin'}{'family_name'}) {
-        unless (
-            $sdm
-            and $sth = $sdm->do_prepared_query(
-                q{SELECT COUNT(*)
-                  FROM exclusion_table
-                  WHERE (list_exclusion = ? OR family_exclusion = ?) AND
-                        robot_exclusion = ? AND
-                        user_exclusion = ?},
-                $self->{'name'}, $self->{'admin'}{'family_name'},
-                $self->{'domain'},
-                $email
-            )
-        ) {
-            #FIXME: report error
-            return undef;
-        }
-    } else {
-        unless (
-            $sdm
-            and $sth = $sdm->do_prepared_query(
-                q{SELECT COUNT(*)
-                  FROM exclusion_table
-                  WHERE list_exclusion = ? AND robot_exclusion = ? AND
-                        user_exclusion = ?},
-                $self->{'name'}, $self->{'domain'},
-                $email
-            )
-        ) {
-            #FIXME: report error
-            return undef;
-        }
-    }
-    my ($count) = $sth->fetchrow_array;
-    $sth->finish;
-
-    return $count || 0;
-}
+# DEPRECATED. No longer used.
+#sub is_member_excluded;
 
 # Mapping between var and field names.
 sub _map_list_member_cols {
@@ -6605,7 +6558,7 @@ Returns true if the indicated user is member of the list.
 =item is_member_excluded ( $email )
 
 I<Instance method>.
-FIXME @todo doc
+B<Deprecated>.
 
 =item is_moderated ()
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -1603,8 +1603,7 @@ sub delete_list_member {
         $total--;
     }
 
-    my $rc = $sdm->commit;
-    unless ($rc) {
+    unless ($sdm->commit) {
         $log->syslog('err', 'Error at delete member commit: %s', $sdm->error);
         $sdm->rollback;
         return 0;
@@ -1623,8 +1622,10 @@ sub delete_list_admin {
     my @u    = @_;
 
     my $total = 0;
+
     my $sdm = Sympa::DatabaseManager->instance;
     $sdm->begin;
+
     foreach my $who (@u) {
         next unless defined $who and length $who;
         $who = Sympa::Tools::Text::canonic_email($who);
@@ -1648,8 +1649,7 @@ sub delete_list_admin {
         $total--;
     }
 
-    my $rc = $sdm->commit;
-    unless ($rc) {
+    unless ($sdm->commit) {
         $log->syslog('err', 'Error at add member commit: %s', $sdm->error);
         $sdm->rollback;
         return 0;
@@ -3187,7 +3187,6 @@ sub add_list_member {
     }
 
     my $sdm = Sympa::DatabaseManager->instance;
-
     $sdm->begin;
 
     foreach my $new_user (@new_users) {
@@ -3335,11 +3334,10 @@ sub add_list_member {
         $self->{'add_outcome'}{'remaining_member_to_add'}--;
         $current_list_members_count++;
     }
-    my $rc = $sdm->commit;
-    unless ($rc) {
+
+    unless ($sdm->commit) {
         $log->syslog('err', 'Error at add member commit: %s', $sdm->error);
         $sdm->rollback;
-        return 0;
     }
 
     $self->_cache_publish_expiry('member');
@@ -3378,14 +3376,15 @@ sub add_list_admin {
     my @users = @_;
 
     my $total = 0;
+
     my $sdm = Sympa::DatabaseManager->instance;
     $sdm->begin;
+
     foreach my $user (@users) {
         $total++ if $self->_add_list_admin($role, $user);
     }
 
-    my $rc = $sdm->commit;
-    unless ($rc) {
+    unless ($sdm->commit) {
         $log->syslog('err', 'Error at add admin commit: %s', $sdm->error);
         $sdm->rollback;
         return 0;

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -1603,16 +1603,16 @@ sub delete_list_member {
         $total--;
     }
 
-    $self->_cache_publish_expiry('member');
-
     my $rc = $sdm->commit;
     unless ($rc) {
         $log->syslog('err', 'Error at delete member commit: %s', $sdm->error);
         $sdm->rollback;
+        return 0;
     }
 
-    return (-1 * $total);
+    $self->_cache_publish_expiry('member');
 
+    return (-1 * $total);
 }
 
 ## Delete the indicated admin users from the list.
@@ -1652,6 +1652,7 @@ sub delete_list_admin {
     unless ($rc) {
         $log->syslog('err', 'Error at add member commit: %s', $sdm->error);
         $sdm->rollback;
+        return 0;
     }
 
     $self->_cache_publish_expiry('admin_user');
@@ -3338,8 +3339,8 @@ sub add_list_member {
     unless ($rc) {
         $log->syslog('err', 'Error at add member commit: %s', $sdm->error);
         $sdm->rollback;
+        return 0;
     }
-
 
     $self->_cache_publish_expiry('member');
     $self->_create_add_error_string() if ($self->{'add_outcome'}{'errors'});
@@ -3383,13 +3384,15 @@ sub add_list_admin {
         $total++ if $self->_add_list_admin($role, $user);
     }
 
-    $self->_cache_publish_expiry('admin_user') if $total;
-
     my $rc = $sdm->commit;
     unless ($rc) {
         $log->syslog('err', 'Error at add admin commit: %s', $sdm->error);
         $sdm->rollback;
+        return 0;
     }
+
+    $self->_cache_publish_expiry('admin_user') if $total;
+
     return $total;
 }
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -1605,11 +1605,11 @@ sub delete_list_member {
 
     $self->_cache_publish_expiry('member');
 
-        my $rc = $sdm->commit;
-        unless ($rc) {
-            $log->syslog('err', 'Error at delete member commit: %s', $sdm->errstr);
-            $sdm->rollback;
-        }
+    my $rc = $sdm->commit;
+    unless ($rc) {
+        $log->syslog('err', 'Error at delete member commit: %s', $sdm->error);
+        $sdm->rollback;
+    }
 
     return (-1 * $total);
 
@@ -3376,11 +3376,11 @@ sub add_list_member {
         $self->{'add_outcome'}{'remaining_member_to_add'}--;
         $current_list_members_count++;
     }
-        my $rc = $sdm->commit;
-        unless ($rc) {
-            $log->syslog('err', 'Error at add member commit: %s', $sdm->errstr);
-            $sdm->rollback;
-        }
+    my $rc = $sdm->commit;
+    unless ($rc) {
+        $log->syslog('err', 'Error at add member commit: %s', $sdm->error);
+        $sdm->rollback;
+    }
 
 
     $self->_cache_publish_expiry('member');

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -3424,11 +3424,19 @@ sub add_list_admin {
     my @users = @_;
 
     my $total = 0;
+    my $sdm = Sympa::DatabaseManager->instance;
+    $sdm->begin;
     foreach my $user (@users) {
         $total++ if $self->_add_list_admin($role, $user);
     }
 
     $self->_cache_publish_expiry('admin_user') if $total;
+
+    my $rc = $sdm->commit;
+    unless ($rc) {
+        $log->syslog('err', 'Error at add admin commit: %s', $sdm->error);
+        $sdm->rollback;
+    }
     return $total;
 }
 

--- a/src/lib/Sympa/Request/Handler/include.pm
+++ b/src/lib/Sympa/Request/Handler/include.pm
@@ -416,7 +416,7 @@ sub _update_users {
 
     my %to_be_inserted;
 
-    $sdm->__dbh->begin_work;
+    $sdm->begin;
 
     while (my $entry = $ds->next) {
         my ($email, $gecos) = @$entry;
@@ -453,7 +453,7 @@ sub _update_users {
             unless (%res) {
                 $ds->close;
                 $log->syslog('info', '%s: Aborted update', $ds);
-                $sdm->__dbh->rollback;
+                $sdm->rollback;
                 return;
             }
             foreach my $res (keys %res) {
@@ -465,13 +465,12 @@ sub _update_users {
         }
     }
 
-    unless ($sdm->__dbh->{AutoCommit}) {
-        my $rc = $sdm->__dbh->commit;
+        my $rc = $sdm->commit;
         unless ($rc) {
             $log->syslog('err', 'Error at update user commit: %s', $sdm->errstr);
-            $sdm->__dbh->rollback;
+            $sdm->rollback;
         }
-    }
+
 
     my @list_of_new_users;
     for (keys %to_be_inserted) {

--- a/src/lib/Sympa/Request/Handler/include.pm
+++ b/src/lib/Sympa/Request/Handler/include.pm
@@ -465,11 +465,11 @@ sub _update_users {
         }
     }
 
-        my $rc = $sdm->commit;
-        unless ($rc) {
-            $log->syslog('err', 'Error at update user commit: %s', $sdm->errstr);
-            $sdm->rollback;
-        }
+    my $rc = $sdm->commit;
+    unless ($rc) {
+        $log->syslog('err', 'Error at update user commit: %s', $sdm->error);
+        $sdm->rollback;
+    }
 
 
     my @list_of_new_users;


### PR DESCRIPTION
**[Note by admin]** Please visit #1186 for discussion.

----
I've been looking into improving the performance of synchronizing members from data sources. I moved a couple of queries outside of loops and enabled transactions for the insert/update/remove loops.

This PR currently work in progress. It is lacking some error handling and it fails with SQLite, because of the current SQLite locking workaround.

I would like comments if this type of changes would be acceptable and suggestions for improvements!

# Benchmarks
### add 20 000, remove 20 000 update 20 000 members
| |Before | After |
|-|-------|-------|
|Time (sec)| 263 | 67.2 |
| Calls to do_prepared_query |240 032 | 120 032  |


### add 60 000, update 40 000 members
| |Before | After |
|-|-------|-------|
|Time (sec)| 569| 141|
| Calls to do_prepared_query |580 032 | 260 032 |
