### PR TITLE
🐛 — Bulk.pl didn't deliver mails if failed to personalize (#1174 followup)

### DIFF
--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -1625,11 +1625,11 @@ sub personalize_text {
         )
     ) {
         $log->syslog(
-            'err',
+            'info',
             'Failed parsing template: %s',
             $template->{last_error}
         );
-        return undef;
+        return $body;
     }
 
     return $message_output;


### PR DESCRIPTION
I encountered a similar issue than #1174, there is a similar fix (untested but I don’t see why it should not work).

Log (split to make it more easily readable):
```
Jun 24 12:40:13 my_server bulk[2387]: err main::#160 > Sympa::Spindle::spin#83 > 
  Sympa::Spindle::ProcessOutgoing::_twist#285 > Sympa::Message::personalize#1410 > 
  Sympa::Message::_merge_msg#1464 > Sympa::Message::_merge_msg#1522 > 
  Sympa::Message::personalize_text#1620 Failed parsing template: file error - parse error - input text line 1509-1551: unexpected token  […]
```