### PR TITLE
Count messages in moderation queue for each list

### DIFF
--- a/default/web_tt2/my.tt2
+++ b/default/web_tt2/my.tt2
@@ -39,6 +39,14 @@
                                 [% l.value.status | optdesc('status') %]
                             </span>
                         [%~ END %]
+                        [% IF l.value.is_owner || l.value.is_editor ~%]
+                            [% IF l.value.mod_count ~%]
+                        <a href="[% 'modindex' | url_rel([l.key]) %]">
+                        [%|loc%]Messages held for moderation: [%END%]
+                        [% l.value.mod_count %]
+                        </a>
+                            [% END ~%]
+                        [% END ~%]
                         <p class="list_subject">[% l.value.subject %]</p>
                         [% IF l.value.listsuspend %]
                             [% IF l.value.listenddate %]

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -14295,6 +14295,12 @@ sub _set_my_lists_info {
                     if $r_action =~ /do_it/i;
             }
         }
+
+        # Count messages in moderation queue for each list
+        foreach my $list (values %all_lists) {
+            $which->{$list->{'name'}}{mod_count} =
+                Sympa::Spool::Moderation->new(context => $list)->size;
+        }
     }
 
     $param->{'which'} = $which;


### PR DESCRIPTION
If _set_my_lists_info() counts outstanding moderation requests for each list, then this information can be displayed by the my.tt2 template.

![1](https://user-images.githubusercontent.com/1552579/128135685-cf391d77-ebf2-4481-8dc7-406caca490eb.jpg)
