### PR TITLE
move pinfo operations in _load_edit_list_conf

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -6081,11 +6081,6 @@ sub _load_edit_list_conf {
 
     my $robot = $self->{'domain'};
 
-    my $pinfo = {
-        %{Sympa::Robot::list_params($self->{'domain'})},
-        %Sympa::ListDef::user_info
-    };
-
     # Load edit_list.conf: Track by file, not domain (file may come from
     # server, robot, family or list context).
     my $last_path_config  = $self->{_path}{edit_list} // '';
@@ -6105,6 +6100,11 @@ sub _load_edit_list_conf {
         $self->{_edit_list} = {};
         return;
     }
+
+    my $pinfo = {
+        %{Sympa::Robot::list_params($self->{'domain'})},
+        %Sympa::ListDef::user_info
+    };
 
     my $conf;
     my $error_in_conf;


### PR DESCRIPTION
In Sympa 6.2.62, there was an update made to move the decision for whether or not to reload edit_list.conf from Sympa::List::may_edit -> Sympa::List::new which seems to be in response to reports of slow list configuration saves happening via https://github.com/sympa-community/sympa/issues/1090

Due to this change, the subroutine _load_edit_list_conf is being called much more frequently. 

We ran some profiling data against our Sympa installation and noticed that inside _load_edit_list_conf, there is the pinfo hash which gathers list config data and is an expensive operation for an install containing ~6000 lists.

With that being said, when we upgraded to 6.2.64 from 6.2.60 (we skipped 6.2.62), we noticed our baseline CPU usage increased by about 5x from ~4% to about 25% over a 24hr period. This change was noticed in our qual environment which has a stale copy of our production data but NO customer traffic.

In production, when we upgraded to 6.2.64, we saw an average CPU usage of about ~50% throughout a 24hr period. Which is significantly higher than the CPU usage average we saw in 6.2.60 of ~16%.

The patch provided is very simple and moves the data gathering for the pinfo hash to *after* the decision being made for whether or not the edit_list.conf needs to be reloaded. With this update, our CPU usage over a 24hr period has returned to a nominal state of what we saw in 6.2.60.

We've tested this patch against 6.2.64 with no issues to mention. Please do let us know if this seems workable. Thanks y'all!