### PR TITLE
Included owners won't be removed even if they have been removed from the data source (#1272)

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -1618,16 +1618,17 @@ sub delete_list_member {
 ## Delete the indicated admin users from the list.
 sub delete_list_admin {
     $log->syslog('debug2', '(%s, %s, ...)', @_);
-    my $self = shift;
-    my $role = shift;
-    my @u    = @_;
+    my $self  = shift;
+    my $role  = shift;
+    my $users = shift;
 
     my $total = 0;
 
     my $sdm = Sympa::DatabaseManager->instance;
     $sdm->begin;
 
-    foreach my $who (@u) {
+    $users = [$users] unless ref $users;    # compat.
+    foreach my $who (@$users) {
         next unless defined $who and length $who;
         $who = Sympa::Tools::Text::canonic_email($who);
 
@@ -6221,7 +6222,7 @@ FIXME @todo doc
 
 Note: Since Sympa 6.1.18, this returns an array under array context.
 
-=item delete_list_admin ( ROLE, ARRAY )
+=item delete_list_admin ( $role, \@users )
 
 Delete the indicated admin user with the predefined role from the list.
 ROLE may be C<'owner'> or C<'editor'>.

--- a/src/lib/Sympa/Request/Handler/close_list.pm
+++ b/src/lib/Sympa/Request/Handler/close_list.pm
@@ -172,7 +172,7 @@ sub _close {
 
     # Remove entries from admin_table.
     foreach my $role (qw(editor owner)) {
-        $list->delete_list_admin($role, $list->get_admins_email($role));
+        $list->delete_list_admin($role, [$list->get_admins_email($role)]);
     }
 
     # Change status & save config.


### PR DESCRIPTION
Change calling convention of Sympa::List::delete_list_admin() to avoid misuse.

This may fix #1272.
