### PR TITLE
macOS: t/Tools_File.t fails.

### DIFF
--- a/t/Tools_File.t
+++ b/t/Tools_File.t
@@ -136,9 +136,12 @@ ok(-d "$dir/foo/bar", 'mkdir_all second element');
 is(get_perms("$dir/foo"),     "0777", "first element, expected mode");
 is(get_perms("$dir/foo/bar"), "0777", "second element, expected mode");
 
-utime 1234567890, 123456789, $file;
+# Note: Some platforms (e.g. macOS with Perl < 5.32) miss or simply don't
+# implement futimes system call so that calling utime() on filehandle may
+# crash.
+utime 1234567890, 123456789, $file->filename;
 is(Sympa::Tools::File::get_mtime($file), 123456789);
-utime 123456789, 1234567890, $file;
+utime 123456789, 1234567890, $file->filename;
 is(Sympa::Tools::File::get_mtime($file), 1234567890);
 ok(Sympa::Tools::File::get_mtime("$dir/no-such-file") < -32768);
 chmod 0333, $file;


### PR DESCRIPTION
<!--- ↑↑ Provide a general summary of the issue in the Title above ↑↑ -->

Version
-------
Sympa 6.2 or later with some platforms (e.g. macOS with Perl prior to 5.32 and LLVM).

Installation method
-------------------
<!-- How you installed Sympa: deb, rpm, ports, ... or source package -->
Source distribution.

Expected behavior
-----------------
<!--- Tell us what should happen -->
Running `make check`, tests shouldn't fail.

Actual behavior
---------------
<!--- Tell us what happens instead of the expected behavior -->
With `t/Tools_File.t`, the test crashes with the message:
``` code
Error: The futimes function is unimplemented at t/Tools_File.t line 139.
# Looks like your test exited with 2 just after 19.
t/Tools_File.t ............... 
Dubious, test returned 2 (wstat 512, 0x200)
Failed 4/23 subtests 
```
Additional information
----------------------
<!--- You may also attach files using "selecting them" link below. -->
<!--- NOTE that you should not include sensitive information! -->
Some platforms miss or simply don't implement futimes system call so that calling utime() on filehandle may crash.

This bug affects only to the test suite: The runtime code doesn't call utime() in such way.
