### PR TITLE
fix: create a list as copy does not copy all configuration (template files)

### DIFF
--- a/src/lib/Sympa/Request/Handler/move_list.pm
+++ b/src/lib/Sympa/Request/Handler/move_list.pm
@@ -473,7 +473,7 @@ sub _copy {
 
     chmod 0775, $new_dir;
     foreach my $subdir ('etc', 'web_tt2', 'mail_tt2', 'data_sources') {
-        if (-d $new_dir . '/' . $subdir) {
+        if (-d $current_list->{'dir'} . '/' . $subdir) {
             unless (
                 Sympa::Tools::File::copy_dir(
                     $current_list->{'dir'} . '/' . $subdir,
@@ -508,7 +508,7 @@ sub _copy {
         }
     }
     # copy optional files
-    foreach my $file ('message_header', 'message_footer', 'info', 'homepage')
+    foreach my $file ('message_header', 'message_footer','message_header.mime', 'message_footer.mime', 'info', 'homepage')
     {
         if (-f $current_list->{'dir'} . '/' . $file) {
             unless (


### PR DESCRIPTION
If creating a new list as copy of an existing one then this should also 
1. copy multipart mime footer/header (*.mime files)
2. copy template directories 

The fix (PR) does this by adding both *.mime files to the list of file.
And by fixing the copy logic to also copy template directories.
