### PR TITLE
Listmaster Admin's menu entry "Edit Robot Config" missing when in "Skins, CSS and colors" (#1291)

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -6971,6 +6971,8 @@ sub do_edit_template {
 sub do_skinsedit {
     wwslog('info', '(%s)', $in{'subaction'});
 
+    get_server_details();
+
     my @std_color_names = map { 'color_' . $_ } (0 .. 15);
     my @obs_color_names = qw(dark_color light_color text_color bg_color
         error_color selected_color shaded_color);


### PR DESCRIPTION
This may fix #1291.
