### PR TITLE
PERL5LIB environment variable was overwritten

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,13 +91,13 @@ MSGFMT=@MSGFMT@
 check-local: $(check_DATA)
 	if test -d t; then \
 		[ -z "$(TEST_FILES)" ] && TEST_FILES="$(check_SCRIPTS)"; \
-		PERL5LIB=src/lib; export PERL5LIB; \
+		PERL5LIB=src/lib:$(PERL5LIB); export PERL5LIB; \
 		$(PERL) -MTest::Harness -e 'runtests @ARGV' $$TEST_FILES; \
 	fi
 
 authorcheck:
 	[ -z "$(TEST_FILES)" ] && TEST_FILES="$(noinst_SCRIPTS)"; \
-	PERL5LIB=src/lib; export PERL5LIB; \
+	PERL5LIB=src/lib:$(PERL5LIB); export PERL5LIB; \
 	$(PERL) -MTest::Harness -e 'runtests @ARGV' $$TEST_FILES
 
 install-data-hook: installdir installconfig nextstep


### PR DESCRIPTION
PERL5LIB environment variable is overwritten when test harness is called so that customized module path (e.g. by local::lib) became unavailable.