### PR TITLE
Fix to #1287

### DIFF
--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -40,6 +40,9 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install automake
+          # For Crypt::OpenSSL::X509: It needs openssl@1.1 while openssl@3 is
+          # detected by default.
+          brew uninstall --ignore-dependencies openssl@3 || true
       #XXX This doesn't work, though I don't know why.
       #- name: Workaround for rt.perl.org#116989
       #  if: runner.os == 'Linux' && matrix.perl == '5.20'
@@ -49,7 +52,7 @@ jobs:
       #    >> $GITHUB_ENV
       - name: Workaround for macOS
         if: runner.os == 'macOS'
-        # For Crypt::SMIME
+        # For Crypt::SMIME: Cannot find libcrypto.pc
         run: >
           echo "PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig"
           >> $GITHUB_ENV
@@ -59,6 +62,7 @@ jobs:
           perl-version: ${{ matrix.perl }}
           install-modules-with: cpanm
           install-modules-args: >
+            --verbose --no-interactive
             --with-develop
             --with-feature=Data::Password --with-feature=ldap
             --with-feature=safe-unicode --with-feature=smime


### PR DESCRIPTION
Fix to #1287.

macOS: Crypt::OpenSSL::X509 has not yet supported openssl@3.