### PR TITLE
workflow/make-check.yml: Jobs for macOS are tentatively disabled

### DIFF
--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - 'macos-latest'
+          #- 'macos-latest' # Crypt::OpenSSL::X509 doesn't support openssl@3
           - 'ubuntu-latest'
         perl:
           - '5.34'
@@ -59,6 +59,7 @@ jobs:
           perl-version: ${{ matrix.perl }}
           install-modules-with: cpanm
           install-modules-args: >
+            --verbose --no-interactive
             --with-develop
             --with-feature=Data::Password --with-feature=ldap
             --with-feature=safe-unicode --with-feature=smime


### PR DESCRIPTION
Crypt::OpenSSL::X509 has not supported openssl@3 that is installed on recent macOS by default.

Fix to #1287.