### PR TITLE
Improvements on anonymized messages

### DIFF
--- a/src/lib/Sympa.pm
+++ b/src/lib/Sympa.pm
@@ -46,6 +46,7 @@ use Sympa::Log;
 use Sympa::Regexps;
 use Sympa::Spindle::ProcessTemplate;
 use Sympa::Tools::Text;
+use Sympa::Tools::Time;
 
 my $log = Sympa::Log->instance;
 
@@ -763,16 +764,13 @@ sub is_listmaster {
 sub unique_message_id {
     my $that = shift;
 
-    my $domain;
-    if (ref $that eq 'Sympa::List') {
-        $domain = Conf::get_robot_conf($that->{'domain'}, 'domain');
-    } elsif ($that and $that ne '*') {
-        $domain = Conf::get_robot_conf($that, 'domain');
-    } else {
-        $domain = $Conf::Conf{'domain'};
-    }
-
-    return sprintf '<sympa.%d.%d.%d@%s>', time, $PID, (int rand 999), $domain;
+    my ($time, $usec) = Sympa::Tools::Time::gettimeofday();
+    my $domain =
+          (ref $that eq 'Sympa::List') ? $that->{'domain'}
+        : ($that and $that ne '*') ? $that
+        :                            $Conf::Conf{'domain'};
+    return sprintf '<sympa.%d.%d.%d.%d@%s>', $time, $usec, $PID,
+        (int rand 999), $domain;
 }
 
 1;
@@ -1110,7 +1108,8 @@ Is the user listmaster?
 
 =item unique_message_id ( $that )
 
-TBD
+Generates a unique message ID enclosed by C<E<lt>> and C<E<gt>>,
+then returns it.
 
 =back
 

--- a/src/lib/Sympa/Config/Schema.pm
+++ b/src/lib/Sympa/Config/Schema.pm
@@ -1165,8 +1165,11 @@ our %pinfo = (
             'Header fields removed when a mailing list is setup in anonymous mode',
         gettext_comment =>
             "See \"anonymous_sender\" list parameter.\nDefault value prior to Sympa 6.1.19 is:\n  Sender,X-Sender,Received,Message-id,From,X-Envelope-To,Resent-From,Reply-To,Organization,Disposition-Notification-To,X-Envelope-From,X-X-Sender",
+        # These were aded on 6.2.68:
+        #   Fax, Mailer, Originating-Client, Phone, Telefax, User-Agent,
+        #   X-Face, X-Mailer, X-MimeOLE, X-Newsreader.
         default =>
-            'Authentication-Results,Disposition-Notification-To,DKIM-Signature,Injection-Info,Organisation,Organization,Original-Recipient,Originator,Path,Received,Received-SPF,Reply-To,Resent-Reply-To,Return-Receipt-To,X-Envelope-From,X-Envelope-To,X-Sender,X-X-Sender',
+            'Authentication-Results,Disposition-Notification-To,DKIM-Signature,Fax,Injection-Info,Mailer,Organisation,Organization,Original-Recipient,Originating-Client,Originator,Path,Phone,Received,Received-SPF,Reply-To,Resent-Reply-To,Return-Receipt-To,Telefax,User-Agent,X-Envelope-From,X-Envelope-To,X-Face,X-Mailer,X-MimeOLE,X-Newsreader,X-Sender,X-X-Sender',
         split_char => ',',
     },
 

--- a/src/lib/Sympa/Message/Template.pm
+++ b/src/lib/Sympa/Message/Template.pm
@@ -187,8 +187,13 @@ sub new {
             $data->{'fromlist'} = Sympa::get_address($list, 'owner');
         }
     }
-    $data->{'boundary'} = '----------=_' . Sympa::unique_message_id($robot_id)
+    my $unique_id = Sympa::unique_message_id($robot_id);
+    $data->{'boundary'} = sprintf '----------=_%s', $unique_id
         unless $data->{'boundary'};
+    $data->{'boundary1'} = sprintf '---------=1_%s', $unique_id
+        unless $data->{'boundary1'};
+    $data->{'boundary2'} = sprintf '---------=2_%s', $unique_id
+        unless $data->{'boundary2'};
 
     my $self = $class->_new_from_template($that, $tpl . '.tt2',
         $who, $data, %options);

--- a/src/lib/Sympa/Request/Handler/get.pm
+++ b/src/lib/Sympa/Request/Handler/get.pm
@@ -101,8 +101,6 @@ sub _twist {
             $list->{'name'}, $arc
         ),
         msg_list       => [@msg_list],
-        boundary1      => Sympa::unique_message_id($list),
-        boundary2      => Sympa::unique_message_id($list),
         auto_submitted => 'auto-replied'
     };
     unless (Sympa::send_file($list, 'get_archive', $sender, $param)) {

--- a/src/lib/Sympa/Request/Handler/last.pm
+++ b/src/lib/Sympa/Request/Handler/last.pm
@@ -94,8 +94,6 @@ sub _twist {
             $list->{'name'}
         ),
         msg_list       => [@msglist],
-        boundary1      => Sympa::unique_message_id($list),
-        boundary2      => Sympa::unique_message_id($list),
         auto_submitted => 'auto-replied'
     };
     unless (Sympa::send_file($list, 'get_archive', $sender, $param)) {

--- a/src/lib/Sympa/Request/Handler/modindex.pm
+++ b/src/lib/Sympa/Request/Handler/modindex.pm
@@ -91,8 +91,6 @@ sub _twist {
             $sender,
             {   'spool' => \@spool,          #FIXME: Use msg_list.
                 'total' => scalar(@spool),
-                'boundary1' => "==main $now[6].$now[5].$now[4].$now[3]==",
-                'boundary2' => "==digest $now[6].$now[5].$now[4].$now[3]=="
             }
         )
     ) {

--- a/src/lib/Sympa/Spindle/ProcessDigest.pm
+++ b/src/lib/Sympa/Spindle/ProcessDigest.pm
@@ -164,8 +164,6 @@ sub _distribute_digest {
     my $param = {
         'replyto'   => Sympa::get_address($list, 'owner'),
         'to'        => Sympa::get_address($list),
-        'boundary1' => '----------=_' . Sympa::unique_message_id($list),
-        'boundary2' => '----------=_' . Sympa::unique_message_id($list),
     };
     # Compat. to 6.2a or earlier
     $param->{'table_of_content'} = $language->gettext("Table of contents:");

--- a/src/lib/Sympa/Spindle/TransformIncoming.pm
+++ b/src/lib/Sympa/Spindle/TransformIncoming.pm
@@ -82,9 +82,8 @@ sub _twist {
         $message->replace_header('From',
             $list->{'admin'}{'anonymous_sender'});
         $message->delete_header('Resent-From');
-        my $new_id =
-            $list->{'name'} . '.' . $message->{xsequence} . '@anonymous';
-        $message->replace_header('Message-Id', "<$new_id>");
+        my $new_id = Sympa::unique_message_id();
+        $message->replace_header('Message-Id', $new_id);
         $message->delete_header('Resent-Message-Id');
 
         # Duplicate topic file by new message ID.

--- a/src/lib/Sympa/Spool/Listmaster.pm
+++ b/src/lib/Sympa/Spool/Listmaster.pm
@@ -135,8 +135,6 @@ sub flush {
                     auto_submitted        => 'auto-generated',
                     operation             => $operation,
                     notification_messages => $messages{$rcpt},
-                    boundary              => '----------=_'
-                        . Sympa::unique_message_id($robot_id)
                 };
 
                 $log->syslog('info', 'Send messages to %s', $rcpt);

--- a/src/lib/Sympa/Spool/Topic.pm
+++ b/src/lib/Sympa/Spool/Topic.pm
@@ -53,7 +53,7 @@ sub store {
     my $topic_list = $self->{topic};
     my $method     = $self->{method};
 
-    my $msg_id = $message->{message_id};
+    my $msg_id = ($message->{message_id} =~ s/\A<(.*)>\z/$1/r);
     my $list   = $message->{context};
     return undef unless $msg_id and ref $list eq 'Sympa::List';
 


### PR DESCRIPTION
* Remove more header fields in anonymized messages, including User-Agent.
* Use more precise number in auto-generated message IDs to prevent collision more.
* Use sufficiently unique message ID above in the anonymized messages.

This may fix #1306 .
