### PR TITLE
Remind name of the opened list in the notification

### DIFF
--- a/default/mail_tt2/report.tt2
+++ b/default/mail_tt2/report.tt2
@@ -487,7 +487,7 @@
   [%|loc%]List name has been lowercased[%END%]
 
 [%~ ELSIF report_entry == 'auto_aliases' ~%]
-  [%|loc%]Aliases have been installed.[%END%]
+  [%|loc%]Aliases have been installed.[%END%] ([% report_param.listname %])
 
 [%~ ELSIF report_entry == 'user_notified' ~%]
   [%|loc(report_param.notified_user)%]User %1 has been notified[%END%]

--- a/src/lib/Sympa/Request/Handler/open_list.pm
+++ b/src/lib/Sympa/Request/Handler/open_list.pm
@@ -94,7 +94,8 @@ sub _twist {
     my $aliases = Sympa::Aliases->new(
         Conf::get_robot_conf($list->{'domain'}, 'alias_manager'));
     if ($aliases and $aliases->add($list)) {
-        $self->add_stash($request, 'notice', 'auto_aliases');
+        $self->add_stash($request, 'notice', 'auto_aliases',
+            { listname => $list->{'name'} .'@' . $list->{'domain'} });
     } else {
         ;
     }


### PR DESCRIPTION
When opening pending list, we have a notification `Aliases have been installed.` but it may be useful to have a reminder of the list we opened (when mass opening the pending lists, for ex.).