### PR TITLE
Upgrade: some parameters in list config files may be removed

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -5353,6 +5353,8 @@ sub _load_include_admin_user_postprocess {
                 listname => $listname,
                 filter   => $filter,
                 };
+            delete $config_hash->{'defaults'}{'include_sympa_list'}
+                if $config_hash->{'defaults'};
         }
         delete $config_hash->{'include_list'};
         delete $config_hash->{'defaults'}{'include_list'}

--- a/src/lib/Sympa/Upgrade.pm
+++ b/src/lib/Sympa/Upgrade.pm
@@ -1287,6 +1287,7 @@ sub upgrade {
             if ($list->{'admin'}{'archive'}{'access'}) {
                 $list->{'admin'}{'archive'}{'mail_access'} =
                     {'name' => $list->{'admin'}{'archive'}{'access'}};
+                delete $list->{'admin'}{'defaults'}{'archive'};
             }
             delete $list->{'admin'}{'archive'}{'access'};
 
@@ -1305,6 +1306,7 @@ sub upgrade {
                 $list->{'admin'}{'archive'}{'max_month'} =
                     $list->{'admin'}{'web_archive'}{'max_month'}
                     if $list->{'admin'}{'web_archive'}{'max_month'};
+                delete $list->{'admin'}{'defaults'}{'archive'};
             }
             delete $list->{'admin'}{'web_archive'};
 


### PR DESCRIPTION
During upgrade from Sympa prior to 6.2b.1, some parameters in list config files can be removed: `include_file` (supposed to be converted to `include_sympa_list`, though) and po9ssiblly `archive`.

---
This PR may fix #1321.
