### PR TITLE
WWSympa: "quiet" parameter for "add"/"subscribe" requests weren't handled correctly

### DIFF
--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -71,7 +71,7 @@ jobs:
             export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu
           fi
           autoreconf -i
-          ./configure
+          ./configure --with-defaultdir=`pwd`/default
           cd src; make; cd ..
           make check-local TEST_FILES='xt/perltidy.t' || true
           make check-local

--- a/default/web_tt2/confirm_action.tt2
+++ b/default/web_tt2/confirm_action.tt2
@@ -383,17 +383,20 @@
         [% FOREACH e = email ~%]
             <input type="hidden" name="email" value="[% e %]" />
         [%~ END %]
-        [% IF conf.quiet_subscription == 'optional' %]
-            <div>
-                <input type="checkbox" id="quiet" type="checkbox" name="quiet" value="1"
-                       [% IF quiet %]checked="checked"[%END%] />
-                <label for="quiet">[%|loc%]Quiet (don't send welcome email)[%END%]</label>
-            </div>
-        [%~ END %]
+        <div>
+            <input type="checkbox" id="quiet" name="quiet"
+             value="1"[% IF quiet %] checked="checked"[%END%] />
+            <label for="quiet">[%|loc%]Quiet (don't send welcome email)[%END%]</label>
+        </div>
     [%~ ELSIF confirm_action == 'add_frommod' ~%]
         [% FOREACH i = id ~%]
             <input type="hidden" name="id" value="[% i %]" />
         [%~ END %]
+        <div>
+            <input type="checkbox" id="quiet" name="quiet"
+             value="1"[% IF quiet %] checked="checked"[%END%] />
+            <label for="quiet">[%|loc%]Quiet (don't send welcome email)[%END%]</label>
+        </div>
     [%~ ELSIF confirm_action == 'arc' ~%]
         <input type="hidden" name="month" value="[% month %]" />
         <input type="hidden" name="arc_file" value="[% arc_file %]" />
@@ -536,6 +539,7 @@
     [%~ ELSIF confirm_action == 'subscribe' ~%]
         <input type="hidden" name="email" value="[% email %]" />
         <input type="hidden" name="gecos" value="[% gecos %]" />
+        <input type="hidden" name="quiet" value="[% quiet %]" />
         [% FOREACH i = custom_attribute ~%]
             <input type="hidden" name="custom_attribute.[% i.key %]"
              value="[% i.value.value.replace('\n', '&#10;') %]" />

--- a/default/web_tt2/import.tt2
+++ b/default/web_tt2/import.tt2
@@ -10,9 +10,11 @@
     </div>
     <div>
         [% IF conf.quiet_subscription == 'optional' %]
-            <input id="quiet" type="checkbox" name="quiet" value="quiet"
-                   [% IF quiet %] checked="checked"[%END%] />
+            <input id="quiet" type="checkbox" name="quiet"
+             value="1"[% IF quiet %] checked="checked"[%END%] />
             <label for="quiet">[%|loc%]quiet[%END%]</label>
+        [%~ ELSIF conf.quiet_subscription == 'on' ~%]
+            <input type="hidden" name="quiet" value="1" />
         [% END ~%]
         <input class="MainMenuLinks" type="submit" name="action_import"
                value="[%|loc%]Add subscribers[%END%]" />

--- a/default/web_tt2/review.tt2
+++ b/default/web_tt2/review.tt2
@@ -92,11 +92,14 @@
                 </div>
                 [% IF conf.quiet_subscription == 'optional' %]
                     <div>
-                        <input id="quietly" type="checkbox" name="quiet" />
+                        <input id="quietly" type="checkbox" name="quiet"
+                         value="1"[% IF quiet %] checked="checked"[% END %] />
                         <label for="quietly">
                             [%|loc%]Quiet (don't send welcome email)[%END%]
                         </label>
                     </div>
+                [%~ ELSIF conf.quiet_subscription == 'on' ~%]
+                    <input type="hidden" name="quiet" value="1" />
                 [% END ~%]
                 <div>
                     <input class="MainMenuLinks" type="submit"

--- a/default/web_tt2/show_exclude.tt2
+++ b/default/web_tt2/show_exclude.tt2
@@ -44,8 +44,15 @@
                         <div>
                             <input class="MainMenuLinks disableUnlessChecked" data-selector="input[name='email']"
                                    type="submit" name="action_add" value="[%|loc%]Restore selected email addresses[%END%]" />
-                            <input id="quiet_exclusion" type="checkbox" name="quiet"/>
-                            <label for="quiet_exclusion">[%|loc%]quiet[%END%] </label>
+                            [% IF conf.quiet_subscription == 'optional' ~%]
+                                <input id="quiet_exclusion" type="checkbox"
+                                 name="quiet" />
+                                <label for="quiet_exclusion">
+                                    [%|loc%]quiet[%END%]
+                                </label>
+                            [%~ ELSIF conf.quiet_subscription == 'on' ~%]
+                                <input type="hidden" name="quiet" value="1" />
+                            [%~ END ~%]
                             <input type="hidden" name="previous_action" value="[% action %]" />
                         </div>
                     [%~ END %]

--- a/default/web_tt2/subscribe.tt2
+++ b/default/web_tt2/subscribe.tt2
@@ -40,8 +40,13 @@
             </div>
             [% PROCESS edit_attributes.tt2 %]
             <input type="hidden" name="list" value="[% list %]" />
+            [% IF conf.quiet_subscription == 'on' ~%]
+                <input type="hidden" name="quiet" value="1" />
+            [%~ END ~%]
             <div>
-                <input class="MainMenuLinks" type="submit" name="action_subscribe" value="[%|loc(list)%]I subscribe to list %1[%END%]" />
+                <input class="MainMenuLinks" type="submit"
+                 name="action_subscribe"
+                 value="[%|loc(list)%]I subscribe to list %1[%END%]" />
             </div>
         </fieldset>
     </form>

--- a/default/web_tt2/viewmod.tt2
+++ b/default/web_tt2/viewmod.tt2
@@ -53,6 +53,17 @@
                     <i class="fa fa-user-plus fa-lg"></i>
                     [%|loc%]Add subscribers[%END%]
                 </button>
+                [% IF conf.quiet_subscription == 'optional' %]
+                    <div>
+                        <input id="quietly" type="checkbox" name="quiet"
+                         value="1"[%IF quiet%] checked="checked"[%END%] />
+                        <label for="quietly">
+                            [%|loc%]Quiet (don't send welcome email)[%END%]
+                        </label>
+                    </div>
+                [%~ ELSIF conf.quiet_subscription == 'on' ~%]
+                    <input type="hidden" name="quiet" value="1" />
+                [% END ~%]
             </p>
         [% END %]
         <div class="formError" style="display:none" id="warningSpam">

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -5459,8 +5459,8 @@ sub do_subscribe {
         $gecos  = $in{'gecos'};
     }
 
-    @{$param}{qw(email gecos custom_attribute)} =
-        ($email, $gecos, $in{'custom_attribute'});
+    @{$param}{qw(quiet email gecos custom_attribute)} =
+        ($in{'quiet'}, $email, $gecos, $in{'custom_attribute'});
 
     # Initial access. show empty form.
     unless ($in{'email'}) {
@@ -5491,6 +5491,7 @@ sub do_subscribe {
         context => $list,
         action  => 'subscribe',
         sender  => $sender,
+        quiet   => $param->{'quiet'},
         email   => $email,
         gecos   => $gecos,
         (   $in{'custom_attribute'}
@@ -7822,6 +7823,7 @@ sub do_add_frommod {
     return 'modindex' unless @users;
 
     $param->{'email'} = [@users];
+    $param->{'quiet'} = $in{'quiet'};
 
     # Action confirmed?
     my $next_action = $session->confirm_action(
@@ -7840,6 +7842,7 @@ sub do_add_frommod {
             email            => $u->{email},
             gecos            => $u->{gecos},
             sender           => $param->{'user'}{'email'},
+            quiet            => $param->{'quiet'},
             md5_check        => 1,
             scenario_context => {
                 email       => $u->{email},

--- a/src/lib/Sympa/Request/Handler/add.pm
+++ b/src/lib/Sympa/Request/Handler/add.pm
@@ -145,7 +145,7 @@ sub _report_member {
 
     ## Now send the welcome file to the user if it exists and notification
     ## is supposed to be sent.
-    $request->{quiet} = ($Conf::Conf{'quiet_subscription'} eq "on")
+    $request->{quiet} ||= ($Conf::Conf{'quiet_subscription'} eq "on")
         if $Conf::Conf{'quiet_subscription'} ne "optional";
     unless ($request->{quiet}) {
         unless ($list->send_probe_to_user('welcome', $email)) {

--- a/src/lib/Sympa/Request/Handler/add.pm
+++ b/src/lib/Sympa/Request/Handler/add.pm
@@ -32,7 +32,6 @@ use warnings;
 use Time::HiRes qw();
 
 use Sympa;
-use Conf;
 use Sympa::Language;
 use Sympa::Log;
 use Sympa::Tools::Domains;
@@ -143,10 +142,8 @@ sub _report_member {
     $user->lang($list->{'admin'}{'lang'}) unless $user->lang;
     $user->save;
 
-    ## Now send the welcome file to the user if it exists and notification
-    ## is supposed to be sent.
-    $request->{quiet} ||= ($Conf::Conf{'quiet_subscription'} eq "on")
-        if $Conf::Conf{'quiet_subscription'} ne "optional";
+    # Now send the welcome file to the user if it exists and notification
+    # is supposed to be sent.
     unless ($request->{quiet}) {
         unless ($list->send_probe_to_user('welcome', $email)) {
             $log->syslog('notice', 'Unable to send "welcome" probe to %s',
@@ -216,9 +213,7 @@ Sympa::Request::Handler::add - add request handler
 
 Adds a user to a list (requested by another user). Verifies
 the proper authorization and sends acknowledgements unless
-quiet add has been chosen (which requires the
-quiet_subscription setting to be "optional") or forced (which
-requires the quiet_subscription setting to be "on").
+quiet add has been chosen.
 
 B<Note>:
 The autharization secenario C<add.*> is applicable only when the {role}

--- a/src/lib/Sympa/Request/Handler/subscribe.pm
+++ b/src/lib/Sympa/Request/Handler/subscribe.pm
@@ -119,7 +119,7 @@ sub _twist {
     $user->save;
 
     ## Now send the welcome file to the user
-    $request->{quiet} = ($Conf::Conf{'quiet_subscription'} eq "on")
+    $request->{quiet} ||= ($Conf::Conf{'quiet_subscription'} eq "on")
         if $Conf::Conf{'quiet_subscription'} ne "optional";
     unless ($request->{quiet}) {
         unless ($list->send_probe_to_user('welcome', $email)) {

--- a/src/lib/Sympa/Request/Handler/subscribe.pm
+++ b/src/lib/Sympa/Request/Handler/subscribe.pm
@@ -118,9 +118,7 @@ sub _twist {
     $user->lang($list->{'admin'}{'lang'}) unless $user->lang;
     $user->save;
 
-    ## Now send the welcome file to the user
-    $request->{quiet} ||= ($Conf::Conf{'quiet_subscription'} eq "on")
-        if $Conf::Conf{'quiet_subscription'} ne "optional";
+    # Now send the welcome file to the user.
     unless ($request->{quiet}) {
         unless ($list->send_probe_to_user('welcome', $email)) {
             $log->syslog('notice', 'Unable to send "welcome" probe to %s',

--- a/t/Request_Handler_add+del.t
+++ b/t/Request_Handler_add+del.t
@@ -130,6 +130,7 @@ do_test(
         action => 'add',
         email  => $member1->[0],
         gecos  => $member1->[1],
+        quiet  => 1,
     },
     data => [$member1],
     name => 'add subscriber'
@@ -150,6 +151,7 @@ do_test(
         action => 'add',
         email  => $member2->[0],
         gecos  => $member2->[1],
+        quiet  => 1,
     },
     data => [$member1, $member2],
     name => 'add subscriber: Not exceeding max_list_members'
@@ -171,6 +173,7 @@ do_test(
         role   => 'owner',
         email  => $owner1->[1],
         gecos  => $owner1->[2],
+        quiet  => 1,
     },
     data => [$owner1],
     name => 'add owner'
@@ -181,6 +184,7 @@ do_test(
         role   => 'editor',
         email  => $editor1->[1],
         gecos  => $editor1->[2],
+        quiet  => 1,
     },
     data => [$editor1, $owner1],
     name => 'add moderator'
@@ -201,6 +205,7 @@ do_test(
         role   => 'editor',
         email  => [map { $_->[1] } ($editor1, $editor2, $editor3)],
         gecos  => [map { $_->[2] } ($editor1, $editor2, $editor3)],
+        quiet  => 1,
     },
     result => [[qw(user already_user)], [qw(notice add_performed)]],
     data   => [$editor1, $editor2, $editor3, $owner1],
@@ -220,6 +225,7 @@ do_test(
     request => {
         action => 'del',
         email  => $member1->[0],
+        quiet  => 1,
     },
     data => [$member2],
     name => 'del subscriber'
@@ -228,6 +234,7 @@ do_test(
     request => {
         action => 'del',
         email  => [$member1->[0], $member2->[0]],
+        quiet  => 1,
     },
     data   => [],
     result => [[qw(user user_not_subscriber)], [qw(notice removed)]],


### PR DESCRIPTION
  - `quiet_subscription` parameter overrided `quiet` option for `add` request (fix #1326)
  - WWSympa: Adding subscribers, sometimes `quiet` parameter was omitted, because template didn't support it.

