### PR TITLE
Database: Nested transaction crashes

### DIFF
--- a/src/lib/Sympa/DatabaseDriver/SQLite.pm
+++ b/src/lib/Sympa/DatabaseDriver/SQLite.pm
@@ -520,44 +520,6 @@ sub translate_type {
     return $type;
 }
 
-# As SQLite does not support nested transactions, these are not effective
-# during when {_sdbSQLiteTransactionLevel} attribute is positive, i.e. only
-# the outermost transaction will be available.
-sub begin {
-    my $self = shift;
-
-    $self->{_sdbSQLiteTransactionLevel} //= 0;
-
-    if ($self->{_sdbSQLiteTransactionLevel}++) {
-        return 1;
-    }
-    return $self->SUPER::begin;
-}
-
-sub commit {
-    my $self = shift;
-
-    unless ($self->{_sdbSQLiteTransactionLevel}) {
-        die 'bug in logic. Ask developer';
-    }
-    if (--$self->{_sdbSQLiteTransactionLevel}) {
-        return 1;
-    }
-    return $self->SUPER::commit;
-}
-
-sub rollback {
-    my $self = shift;
-
-    unless ($self->{_sdbSQLiteTransactionLevel}) {
-        die 'bug in logic. Ask developer';
-    }
-    if (--$self->{_sdbSQLiteTransactionLevel}) {
-        return 1;
-    }
-    return $self->SUPER::rollback;
-}
-
 # Note:
 # - To prevent "database is locked" error, acquire "immediate" lock
 #   by each query.  Most queries excluding "SELECT" need to lock in this
@@ -572,7 +534,7 @@ sub do_query {
     my $need_lock =
         ($_[0] =~
             /^\s*(ALTER|CREATE|DELETE|DROP|INSERT|REINDEX|REPLACE|UPDATE)\b/i)
-        unless $self->{_sdbSQLiteTransactionLevel};
+        unless $self->{_sdbTransactionLevel};
 
     ## acquire "immediate" lock
     unless (!$need_lock or $self->__dbh->begin_work) {
@@ -612,7 +574,7 @@ sub do_prepared_query {
     my $need_lock =
         ($_[0] =~
             /^\s*(ALTER|CREATE|DELETE|DROP|INSERT|REINDEX|REPLACE|UPDATE)\b/i)
-        unless $self->{_sdbSQLiteTransactionLevel};
+        unless $self->{_sdbTransactionLevel};
 
     ## acquire "immediate" lock
     unless (!$need_lock or $self->__dbh->begin_work) {


### PR DESCRIPTION
As most of RDBMS do not support nested transactions, only the outermost transaction should be available.

This may fix #1330 .
