### PR TITLE
Fix #533 — Prevent the use of the list address as subscriber

### DIFF
--- a/default/mail_tt2/report.tt2
+++ b/default/mail_tt2/report.tt2
@@ -663,6 +663,9 @@ Warning: this message may already have been sent by one of the list's moderators
 [%~ ELSIF report_entry == 'blocklisted_domain' ~%]
   [%|loc(report_param.email || report_param.value)%]Address "%1" belongs to a blocklisted domain[%END%]
 
+[%~ ELSIF report_entry == 'email_is_the_list' ~%]
+  [%|loc(report_param.email || report_param.value)%]Address "%1" is the address of the list[%END%]
+
 [%~ ELSIF report_entry == 'incorrect_passwd' ~%]
   [%|loc%]Provided password is incorrect[%END%]
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -3126,6 +3126,11 @@ sub add_list_member {
                 $u->{email});
             next;
         }
+        if ($who eq $self->get_id) {
+            $log->syslog('err', 'Ignoring %s which is the address of the list',
+                $who);
+            next;
+        }
         unless (
             $current_list_members_count < $self->{'admin'}{'max_list_members'}
             || $self->{'admin'}{'max_list_members'} == 0) {

--- a/src/lib/Sympa/Request/Handler/add.pm
+++ b/src/lib/Sympa/Request/Handler/add.pm
@@ -91,6 +91,13 @@ sub _twist {
                 $email);
             return undef;
         }
+        if ($email eq $list->get_id) {
+            $self->add_stash($request, 'user', 'email_is_the_list',
+                {'email' => $email});
+            $log->syslog('err', 'Ignoring %s which is the address of the list',
+                $email);
+            return undef;
+        }
 
         $list->add_list_member(
             {email => $email, gecos => $comment, custom_attribute => $ca},

--- a/src/lib/Sympa/Request/Handler/subscribe.pm
+++ b/src/lib/Sympa/Request/Handler/subscribe.pm
@@ -82,6 +82,13 @@ sub _twist {
             $list, $email);
         return undef;
     }
+    if ($email eq $list->get_id) {
+        $self->add_stash($request, 'user', 'email_is_the_list',
+            {'email' => $email});
+        $log->syslog('err', 'SUBSCRIBE to %s command rejected; the address is the address of the list',
+            $email);
+        return undef;
+    }
 
     # If a list is not 'open' and allow_subscribe_if_pending has been set to
     # 'off' returns undef.


### PR DESCRIPTION
In #533, I originally wanted to prevent adding the list address as subscriber with a reception mode which sends mail to the subscriber but:
- it’s far more easy to just prevint adding the list address as subscriber
- it would need to prevent changing the reception mode after subscribing, so more work
- I can’t see a usecase where you want to subscribe with the address of the list. But I think it’s better to have a backend check to prevent it (to avoid typo and other user mistakes)

`po/sympa/sympa.pot` needs to be updated as I introduce a new localized string. Shoud I run `make -C po/sympa sympa.pot-update` and commit `po/sympa/sympa.pot` or is there another workflow for that?