### PR TITLE
WWSympa: "Synchronize ... with data sources" button is not shown (#1355)

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -2849,15 +2849,19 @@ sub check_param_out {
 
             $param->{'may_include'} = {
                 member => (
-                    $param->{'is_owner'} and $list->has_data_sources('member')
+                    $param->{'is_owner'}
+                        and ($list->has_data_sources('member')
+                        or $list->has_included_users('member'))
                 ),
                 owner => (
-                            $param->{'is_privileged_owner'}
-                        and $list->has_data_sources('owner')
+                    $param->{'is_privileged_owner'}
+                        and ($list->has_data_sources('owner')
+                        or $list->has_included_users('owner'))
                 ),
                 editor => (
-                            $param->{'is_privileged_owner'}
-                        and $list->has_data_sources('editor')
+                    $param->{'is_privileged_owner'}
+                        and ($list->has_data_sources('editor')
+                        or $list->has_included_users('editor'))
                 ),
             };
             # Compat.<=6.2.54


### PR DESCRIPTION
WWSympa: When the last data source has been removed and included user(s) remain, [Synchronize ... with data sources] button is no longer shown.

This may fix #1355.
