### PR TITLE
Remove user menu entries showing only information (#1393)

### DIFF
--- a/default/web_tt2/user_menu.tt2
+++ b/default/web_tt2/user_menu.tt2
@@ -1,10 +1,4 @@
 <!-- user_menu.tt2 -->
-[% IF user.gecos ~%]
-    <li>
-        <span>[% user.email %]</span>
-    </li>
-[%~ END %]
-
 [% IF restore_email ~%]
     <li>
         <form action="[% path_cgi %]" method="post">

--- a/default/web_tt2/user_menu.tt2
+++ b/default/web_tt2/user_menu.tt2
@@ -5,60 +5,6 @@
     </li>
 [%~ END %]
 
-[% IF top_menu ~%]
-    [%# Note: When is_listmaster is set, is_privileged_owner is also set. ~%]
-    [% SET owner_item = owner.item(user.email) ~%]
-    [% SET editor_item = editor.item(user.email) ~%]
-    [% IF is_listmaster || owner_item || is_editor || is_subscriber ~%]
-        <li class="nolink role">
-            <span>
-                [%# Show picture and higher privilege of user on this list. ~%]
-                [%~ IF is_subscriber && pictures_display && pictures_url ~%]
-                    <img class="Pictures" src="[% pictures_url %]" alt="[%|loc%]Your picture[%END%]" />
-                [%~ ELSIF owner_item || is_editor || is_subscriber ~%]
-                    <i class="fa fa-user"></i>
-                [%~ END %]
-                [%~ IF is_listmaster ~%]
-                    <i class="fa fa-star" style="color: #669900;" title="[%|loc%]You are listmaster.[%END%]"></i>
-                [%~ ELSIF owner_item ~%]
-                    <i class="fa fa-star" title="[%|loc%]You are owner.[%END%]"></i>
-                [%~ ELSIF is_editor ~%]
-                    <i class="fa fa-star-o" title="[%|loc%]You are moderator.[%END%]"></i>
-                [%~ END %]
-
-                [%# Show roles on this list. ~%]
-                [%~ IF is_listmaster ~%]
-                    [%|loc%]Listmaster[%END%]
-                    [%~ IF owner_item || is_editor || is_subscriber %]
-                        [%|loc%], [%END%]
-                    [% END %]
-                [%~ END %]
-                [%~ IF owner_item || is_editor ~%]
-                    [%~ IF is_privileged_owner ~%]
-                        [%|loc%]Privileged owner[%END%]
-                        [%~ IF is_subscriber %]
-                            [%|loc%], [%END%]
-                        [% END %]
-                    [%~ ELSIF is_owner ~%]
-                        [%|loc%]Owner[%END%]
-                        [%~ IF is_subscriber %]
-                            [%|loc%], [%END%]
-                        [% END %]
-                    [%~ ELSIF is_editor ~%]
-                        [%|loc%]Moderator[%END%]
-                        [%~ IF is_subscriber %]
-                            [%|loc%], [%END%]
-                        [% END %]
-                    [%~ END %]
-                [%~ END %]
-                [%~ IF is_subscriber ~%]
-                    [%|loc%]Subscriber[%END%]
-                [%~ END %]
-            </span>
-        </li>
-    [%~ END %]
-[%~ END %]
-
 [% IF restore_email ~%]
     <li>
         <form action="[% path_cgi %]" method="post">


### PR DESCRIPTION
As discussed in #1393, this PR removes the menu entries showing only information. These provide no target and cause layout problems.