### PR TITLE
The owner sees the pop-up stating a message is waiting for moderation even if moderators are defined separately (#1406)

### DIFF
--- a/default/web_tt2/info.tt2
+++ b/default/web_tt2/info.tt2
@@ -17,7 +17,7 @@
     [% IF is_owner || is_editor %]
         <hr />
         <h3>[%|loc%]Administrative Options[%END%]</h3>
-        [% IF is_owner || is_editor %]
+        [% IF is_editor %]
             [% IF mod_message && (mod_message > 0) %]
                 <p class="small-8 small-centered columns alert-box info text-center">
                     [%|loc(mod_message)%]There are %1 message(s) awaiting moderation.[%END%]


### PR DESCRIPTION
This may fix #1406.
