### PR TITLE
SympaSOAP: Result by setCustom with parameter including non-ASCII characters is broken (#1407)

### DIFF
--- a/src/lib/Sympa/WWW/SOAP.pm
+++ b/src/lib/Sympa/WWW/SOAP.pm
@@ -1501,6 +1501,11 @@ sub setCustom {
     #if(! defined $list->{'admin'}{'custom_attribute'}{$key} ) {
     #	return SOAP::Data->name('result')->type('boolean')->value(0);
     #}
+
+    # Workaround for possible bug in SOAP::Lite.
+    Encode::_utf8_off($key);
+    Encode::_utf8_off($value);
+
     if ($value eq '') {
         undef $newcustom{$key};
     } else {


### PR DESCRIPTION
This may fix #1407.
