### PR TITLE
When a CLI command defines both 'domain|site' arguments and 'domain*', '*' argument fails.

### DIFF
--- a/src/lib/Sympa/CLI.pm
+++ b/src/lib/Sympa/CLI.pm
@@ -178,7 +178,7 @@ sub run {
                             $domain || $Conf::Conf{'domain'});
                     }
                 } elsif ($def eq 'domain') {
-                    if (length $arg and Conf::valid_robot($arg)) {
+                    if (length $arg and $arg ne '*' and Conf::valid_robot($arg)) {
                         $val = $arg;
                     }
                 } elsif ($def eq 'site') {


### PR DESCRIPTION
See #1419 for discussion.