### PR TITLE
Excess header fields are shown in the web archives (#1447)

### DIFF
--- a/default/mhonarc_rc.tt2
+++ b/default/mhonarc_rc.tt2
@@ -639,38 +639,7 @@ $POWERED_BY$
 <!-- Message itself -->
 <!-- Do not display the following header -->
 <EXCS Override>
-content-
-errors-to
-forward
-lines
-mime-
-message-id
-nntp-
-originator
-path
-precedence
-received
-replied
-return-path
-status
-via
-x-
-sender
-list-help
-list-owner
-list-post
-list-subscribe
-list-unsubscribe
-in-reply-to
-delivered-to
-references
-reply-to
-thread-
-User-agent
-Mail-followup-to
-Dkim-signature
-autocrypt
-openpgp
+(?!(Subject|(Resent-)?(From|To|Cc|Date))\z)
 </EXCS>
 
 <!-- Field order in message header -->


### PR DESCRIPTION
This may fix #1447.
