### PR TITLE
Following typo fix in Mail::DKIM::ARC::Signer

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -258,7 +258,7 @@ feature 'Mail::DKIM::Verifier', 'Required in order to use DKIM features (both fo
 };
 
 feature 'Mail::DKIM::ARC::Signer', 'Required in order to use ARC features to add ARC seals.' => sub {
-    requires 'Mail::DKIM::ARC::Signer', '>= 0.55';
+    requires 'Mail::DKIM::ARC::Signer', '>= 0.57';
 };
 
 feature 'Net::DNS', 'This is required if you set a value for "dmarc_protection_mode" which requires DNS verification.' => sub {

--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -615,8 +615,8 @@ sub arc_seal {
         $log->syslog('err', 'Cannot ARC seal message');
         return undef;
     }
-    $log->syslog('debug2', 'ARC %s: %s', $arc->{result},
-        $arc->{result_reason});
+    $log->syslog('info', 'ARC %s: %s', $arc->{result}, $arc->{details})
+        unless $arc->{result} eq 'sealed';
 
     # don't need this since DKIM just did it
     #    my ($dummy, $new_body) = split /\r\n\r\n/, $msg_as_string, 2;


### PR DESCRIPTION
This PR follows fix of a non-fatal typo in Mail::DKIM::ARC::Signer: marcbradshaw/mail-dkim#3 .

