### PR TITLE
Crash with the broken message with "multipart/signed" MIME type (#1454)

### DIFF
--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -2543,9 +2543,11 @@ sub _as_singlepart {
             }
         }
     } elsif ($eff_type eq 'multipart/signed') {
-        my @parts = $entity->parts();
-        ## Only keep the first part
-        $entity->parts([$parts[0]]);
+        # Only keep the first part.
+        if ($entity->parts) {
+            my @parts = $entity->parts;
+            $entity->parts([$parts[0]]);
+        }
         $entity->make_singlepart();
 
         $done ||= _as_singlepart($entity, $preferred_type, $loops);


### PR DESCRIPTION
This may fix #1454.

This bug looks injected on Sympa 4.2b.3: cf. sympa-community/historic-sympa@7674013