### PR TITLE
Import SOAP encoding schema in WSDL

### DIFF
--- a/default/sympa.wsdl
+++ b/default/sympa.wsdl
@@ -16,7 +16,11 @@
 	xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" 
 	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
 	xmlns="http://www.w3.org/2001/XMLSchema">
-	
+
+
+	<import namespace="http://schemas.xmlsoap.org/soap/encoding/"
+		schemaLocation="http://schemas.xmlsoap.org/soap/encoding/"/>
+
 	<complexType name="ArrayOfLists">
 		<complexContent>
 			<restriction base="SOAP-ENC:Array">


### PR DESCRIPTION
This fix adds the required import of the SOAP encoding schema in WSDL so clients don't have to [deal with a broken schema](https://github.com/suds-community/suds#fixing-broken-schemas).