### PR TITLE
Options for welcome_return_path & remind_return_path do not describe their function (#1475)

### DIFF
--- a/default/edit_list.conf
+++ b/default/edit_list.conf
@@ -67,9 +67,9 @@ del 				owner,privileged_owner 		hidden
 
 remind 				owner,privileged_owner 		hidden
 
-remind_return_path 		owner,privileged_owner 		hidden
+verp_remind 			owner,privileged_owner 		hidden
 
-welcome_return_path 		owner,privileged_owner 		hidden
+verp_welcome	 		owner,privileged_owner 		hidden
 
 priority 			owner,privileged_owner 		hidden
 

--- a/src/lib/Sympa/Config/Schema.pm
+++ b/src/lib/Sympa/Config/Schema.pm
@@ -2123,28 +2123,42 @@ our %pinfo = (
         not_after  => '6.2a.40',
     },
 
-    welcome_return_path => {
+    verp_welcome => {
         context    => [qw(list site)],
         order      => 50.06,
         group      => 'bounces',
-        gettext_id => "Welcome return-path",
-        #gettext_id => 'Remove bouncing new subscribers',
+        gettext_id => 'Remove bouncing new subscribers',
         gettext_comment =>
-            'If set to unique, the welcome message is sent using a unique return path in order to remove the subscriber immediately in the case of a bounce.',
-        format  => ['unique', 'owner'],
-        default => 'owner',
+            'If enabled, the welcome message is sent using VERP in order to remove the subscriber immediately in the case of a bounce.',
+        format     => ['on', 'off'],
+        synonym    => {'unique' => 'on', 'owner' => 'off'},
+        default    => 'off',
+        not_before => '6.2.71b.1',
+    },
+    welcome_return_path => {
+        context    => [qw(list site)],
+        obsolete   => 'verp_welcome',
+        not_before => '2.5',
+        not_after  => '6.2.70',
     },
 
-    remind_return_path => {
+    verp_remind => {
         context    => [qw(list site)],
         order      => 50.07,
         group      => 'bounces',
-        gettext_id => "Return-path of the REMIND command",
-        #gettext_id => 'Remove subscribers bouncing remind message',
+        gettext_id => 'Remove subscribers bouncing remind message',
         gettext_comment =>
-            'Same as welcome_return_path, but applied to remind messages.',
-        format  => ['unique', 'owner'],
-        default => 'owner',
+            'If enabled, the remind message is sent using VERP in order to remove the subscriber immediately in the case of a bounce.',
+        format     => ['on', 'off'],
+        synonym    => {'unique' => 'on', 'owner' => 'off'},
+        default    => 'off',
+        not_before => '6.2.71b.1',
+    },
+    remind_return_path => {
+        context    => [qw(list site)],
+        obsolete   => 'verp_remind',
+        not_before => '2.5',
+        not_after  => '6.2.70',
     },
 
     expire_bounce_task => {

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -1494,17 +1494,12 @@ sub send_probe_to_user {
     my $who  = shift;
 
     # Shelve VERP for welcome or remind message if necessary
-    my $tracking;
-    if (    $self->{'admin'}{'welcome_return_path'} eq 'unique'
-        and $type eq 'welcome') {
-        $tracking = 'w';
-    } elsif ($self->{'admin'}{'remind_return_path'} eq 'unique'
-        and $type eq 'remind') {
-        $tracking = 'r';
-    } else {
-        #FIXME? Return-Path for '*_return_path' parameter with 'owner'
-        # value is LIST-owner address.  It might be LIST-request address.
-    }
+    my $tracking =
+        ($self->{'admin'}{'verp_welcome'} eq 'on' and $type eq 'welcome')
+        ? 'w'
+        : ($self->{'admin'}{'verp_remind'} eq 'on' and $type eq 'remind')
+        ? 'r'
+        : undef;
 
     my $spindle = Sympa::Spindle::ProcessTemplate->new(
         context  => $self,

--- a/src/lib/Sympa/ListOpt.pm
+++ b/src/lib/Sympa/ListOpt.pm
@@ -70,8 +70,7 @@ our %list_option = (
     'if_epmty' => {'gettext_id' => 'if no list members contained'},
 
     # bouncers_level2.notification, bouncers_level1.notification,
-    # welcome_return_path, remind_return_path, rfc2369_header_fields,
-    # archive.mail_access
+    # rfc2369_header_fields, archive.mail_access
     'owner' => {'gettext_id' => 'owner'},
 
     # bouncers_level2.notification, bouncers_level1.notification
@@ -135,9 +134,6 @@ our %list_option = (
     # editor_include.visibility
     'conceal'   => {'gettext_id' => 'concealed from list menu'},
     'noconceal' => {'gettext_id' => 'listed on the list menu'},
-
-    # welcome_return_path, remind_return_path
-    'unique' => {'gettext_id' => 'bounce management'},
 
     # antivirus_notify
     'delivery_status' => {'gettext_id' => 'send back DSN'},

--- a/t/data/sympa.conf
+++ b/t/data/sympa.conf
@@ -275,11 +275,11 @@ bounce_halt_rate	50
 ## S'il est positionné à "unique", le message de bienvenue comprend une
 ## adresse de retour unique, permettant de supprimer immédiatement un nouvel
 ## abonné en erreur.
-welcome_return_path	owner
+verp_welcome	off
 
 ## Remove subscribers bouncing remind message
-## Idem "welcome_return_path" mais appliqué au message de rappel
-remind_return_path	owner
+## Idem "verp_welcome" mais appliqué au message de rappel
+verp_remind	off
 
 ## Task for expiration of old bounces
 ## This task resets bouncing information for addresses not bouncing in the


### PR DESCRIPTION
  * Rename `welcome_return_path` & `remind_return_path` to `verp_*`.
  * Rename their options "owner" & "unique" to "off" and "on".

This may fix #1475.
