### PR TITLE
Templates couldn't access to the fields defined by db_additional_subscriber_fields parameter

### DIFF
--- a/src/lib/Sympa/Message/Template.pm
+++ b/src/lib/Sympa/Message/Template.pm
@@ -99,9 +99,9 @@ sub new {
         if ($list) {
             # FIXME: Don't overwrite date & update_date.  Format datetime on
             # the template.
-            my $subscriber =
-                Sympa::Tools::Data::dup_var($list->get_list_member($who));
-            if ($subscriber) {
+            if (my $subscriber = $list->get_list_member($who)) {
+                $data->{'subscriber'} =
+                    Sympa::Tools::Data::dup_var($subscriber);
                 $data->{'subscriber'}{'date'} =
                     $language->gettext_strftime("%d %b %Y",
                     localtime($subscriber->{'date'}));


### PR DESCRIPTION
This may fix #1494.

This bug was injected on 6.2a.41: cf. sympa-community/historic-sympa@178f0a8