### PR TITLE
✨ login right away when there is only sso configured

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1432,6 +1432,26 @@ while ($query = Sympa::WWW::FastCGI->new) {
                 $session->{'do_not_use_cas'} = 1
                     unless $param->{'redirect_to'} =~ /http(s)+\:\//i;
             }
+        } elsif (((!$session->{'email'}) || ($session->{'email'} == "nobody")) && scalar @{$auth_services || []} == 1 && ($param->{'sso_number'} == 1)) {
+            # only one auth method specified (sso). try to login right away
+            my $service_id = each %{$param->{'sso'}};
+            my $auth = Conf::get_auth_service(
+                    $robot, 'generic_sso', $service_id
+            );
+            if ((defined $auth->{email_http_header}) && (defined $ENV{$auth->{email_http_header}})) {
+                my @email_list = split(
+                    /$auth->{http_header_value_separator}/,
+                    Sympa::Tools::Text::canonic_email(
+                        $ENV{$auth->{email_http_header}}
+                    )
+                );
+                my $email = $email_list[0];
+                if ($email) {
+                    $param->{'user'}{'email'}    = $email;
+                    $session->{'email'}          = $email;
+                    $session->{'auth'}           = 'generic_sso';
+                }
+            }
         }
 
         if ($param->{'user'}{'email'}) {


### PR DESCRIPTION
we only use sso for sympa logins and it is really annoying to press the login button (we are deep linking into confidential archive URLs which currently triggers a not authenticated message which users don't understand).

this works for me but I have no idea what I am doing. I never did anything in perl.

would be great to have this (or some other mechanism that solves this) by default.