### PR TITLE
WWSympa: New "cgi" authentication simply using credentials provided by HTTP server

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1317,6 +1317,10 @@ while ($query = Sympa::WWW::FastCGI->new) {
                 $param->{'ssl_cipher_usekeysize'} =
                     $ENV{SSL_CIPHER_USEKEYSIZE};
             }
+        } elsif (my $email = _cgi_get_authenticated_user()) {
+            $param->{'user'}{'email'} = $email unless $email eq 'nobody';
+            $session->{'email'}       = $email;
+            $session->{'auth'}        = 'cgi';
         } elsif (($session->{'email'}) && ($session->{'email'} ne 'nobody')) {
             $param->{'user'}{'email'} = $session->{'email'};
         } elsif ($in{'ticket'} =~ /(S|P)T\-/) {
@@ -3071,6 +3075,30 @@ sub do_ticket {
     _split_params($param->{'ticket_context'}{'data'});
     return $in{'action'};
 
+}
+
+sub _cgi_get_authenticated_user {
+    foreach my $auth (grep { $_->{auth_type} eq 'cgi' }
+        @{$Conf::Conf{'auth_services'}{$robot} || []}) {
+        if (length($auth->{auth_scheme} // '')) {
+            next unless lc $auth->{auth_scheme} eq lc($ENV{AUTH_TYPE} // '');
+        }
+
+        my $email = $ENV{$auth->{remote_user_variable}};
+        next unless Sympa::Tools::Text::valid_email($email);
+        next unless $email =~ m{$auth->{regexp}}i;
+        if (length($auth->{negative_regexp} // '')) {
+            next if $email =~ m{$auth->{negative_regexp}}i;
+        }
+
+        return Sympa::Tools::Text::canonic_email($email);
+    }
+
+    # As soon as cgi authentication is deactivated, the user should logout.
+    return 'nobody' if $session->{'auth'} eq 'cgi';
+
+    # Otherwise no cgi mechanisms available.
+    return undef;
 }
 
 # Login WWSympa

--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -843,6 +843,13 @@ sub _load_auth {
     my $current_paragraph;
 
     my %valid_keywords = (
+        'cgi' => {
+            'auth_scheme'          => '.*',
+            'remote_user_variable' => '.+',
+            'regexp'               => '.*',
+            'negative_regexp'      => '.*',
+        },
+
         'ldap' => {
             'regexp'          => '.*',
             'negative_regexp' => '.*',
@@ -953,7 +960,7 @@ sub _load_auth {
         if (/^\s*authentication_info_url\s+(.*\S)\s*$/o) {
             $Conf{'authentication_info_url'}{$robot} = $1;
             next;
-        } elsif (/^\s*(ldap|cas|user_table|generic_sso)\s*$/io) {
+        } elsif (/^\s*(cgi|ldap|user_table|cas|generic_sso)\s*$/io) {
             $current_paragraph->{'auth_type'} = lc($1);
         } elsif (/^\s*(\S+)\s+(.*\S)\s*$/o) {
             my ($keyword, $value) = ($1, $2);
@@ -1074,6 +1081,9 @@ sub _load_auth {
                     $current_paragraph->{'scope'} ||= 'sub';
                 } elsif ($current_paragraph->{'auth_type'} eq 'user_table') {
                     ;
+                } elsif ($current_paragraph->{'auth_type'} eq 'cgi') {
+                    $current_paragraph->{'remote_user_variable'} ||=
+                        'REMOTE_USER';
                 }
                 # setting default
                 $current_paragraph->{'regexp'} = '.*'


### PR DESCRIPTION
By this PR. the new "cgi" paragraph(s) may be added in `auth.conf`:
```  code
cgi
    auth_scheme Basic
    remote_user_variable REMOTE_USER
    regexp @my[.]dom[.]ain
    negative_regexp evil@user[.]net
```
All parameters are optional.
- `remote_user_variable` (default value is `REMOTE_USER`) is the name of CGI variable providing e-mail of the authenticated user.
- If `auth_scheme` is specified, authentication is available only when the value of `AUTH_TYPE` CGI variable matches it.

This is a candidate of changes aim at fixing #1497.
