### PR TITLE
Use DSN for the message to notify moderation

### DIFF
--- a/default/mail_tt2/delivery_status_notification.tt2
+++ b/default/mail_tt2/delivery_status_notification.tt2
@@ -1,8 +1,8 @@
 [%# delivery_status_notification.tt2 ~%]
 Content-Type: multipart/report; report-type=delivery-status; 
 	boundary="[% boundary %]"
-[% IF action == "delivered" -%]
-Subject: [%"Message was successfully delivered"|loc|qencode%]
+[% IF status == '2.3.0' || status == '4.3.0' -%]
+Subject: [%"Message distribution: Forwarded"|loc|qencode%]
 [% ELSIF status == '4.2.1' -%]
 Subject: [%"List could not be created"|loc|qencode%]
 [% ELSIF status == '4.2.4' -%]
@@ -25,6 +25,8 @@ Subject: [%"Cannot personalize message"|loc|qencode%]
 Subject: [%"A virus in your mail"|loc|qencode%]
 [% ELSIF status == '5.7.1' -%]
 Subject: [%"Message distribution: Authorization denied"|loc|qencode%]
+[% ELSIF action == "delivered" -%]
+Subject: [%"Message was successfully delivered"|loc|qencode%]
 [% ELSE -%]
 Subject: [%"Delivery Status Notification: %1"|loc(action)|qencode%]
 [% END -%]
@@ -37,7 +39,10 @@ Content-Disposition: inline
 Content-Description: Notification
 
 [%|loc%]This is an automatic response sent by Sympa Mailing Lists Manager.[%END%]
-[% IF action == "delivered" -%]
+[% IF status == '2.3.0' || status == '4.3.0' -%]
+[%|loc(listname)%]Your message to the list '%1' has been forwarded to the moderator(s)[%END%]
+
+[% ELSIF action == "delivered" -%]
 [%|loc%]Message was successfully delivered to following address:[%END%]
 
 	[% recipient %]
@@ -143,8 +148,11 @@ Remote-MTA: dns; [% domain %]
 Diagnostic-Code: X-Sympa; [% diagnostic_code %]
 
 --[% boundary %]
-[%# Attach only header part of potentially unsafe contents. ~%]
-[% IF status == '5.1.1' || status == '5.1.2'
+[%# Attach only header part of potentially unsafe contents.
+  # And, 2.1.5, 2.3.0 and 4.3.0 are successful stata and don't need copy of
+  # message content. ~%]
+[% IF status == '2.1.5' || status == '2.3.0' || status == '4.3.0'
+   || status == '5.1.1' || status == '5.1.2'
    || status == '5.2.3' || status == '5.7.0' -%]
 Content-Type: text/rfc822-headers
 Content-Disposition: inline

--- a/default/mail_tt2/message_report.tt2
+++ b/default/mail_tt2/message_report.tt2
@@ -5,9 +5,7 @@
 ~%]
 Subject: [%"Message distribution"|loc|qencode%]
 
-[% IF entry == 'moderating_message' -%]
-[%|loc(list.name)%]Your message to the list '%1' has been forwarded to the moderator(s)[%END%]
-[% ELSIF entry == 'message_distributed' -%]
+[% IF entry == 'message_distributed' -%]
 [%|loc(key,list.name)%]Message %1 for list '%2' has been distributed.[%END%]
 [% ELSIF entry == 'message_rejected' -%]
 [%|loc(key,list.name)%]Message %1 for list '%2' has been rejected.[%END%]

--- a/src/lib/Sympa.pm
+++ b/src/lib/Sympa.pm
@@ -251,10 +251,14 @@ my %diag_messages = (
     'default' => 'Other undefined Status',
     # success
     '2.1.5' => 'Destination address valid',
+    # forwarded to moderators
+    '2.3.0' => 'Other or undefined mail system status',
     # no available family, dynamic list creation failed, etc.
     '4.2.1' => 'Mailbox disabled, not accepting messages',
     # no subscribers in dynamic list
     '4.2.4' => 'Mailing list expansion problem',
+    # held for moderation
+    '4.3.0' => 'Other or undefined mail system status',
     # unknown list address
     '5.1.1' => 'Bad destination mailbox address',
     # unknown robot
@@ -335,7 +339,10 @@ sub send_dsn {
     # Diagnostic message.
     $diag ||= $diag_messages{$status} || $diag_messages{'default'};
     # Delivery result, "failed" or "delivered".
-    my $action = (index($status, '2') == 0) ? 'delivered' : 'failed';
+    my $action =
+          ($status eq '4.3.0') ? 'delayed'
+        : (0 == index $status, '2') ? 'delivered'
+        :                             'failed';
 
     # Attach original (not decrypted) content.
     my $msg_string = $message->as_string(original => 1);

--- a/src/lib/Sympa/Spindle/ToEditor.pm
+++ b/src/lib/Sympa/Spindle/ToEditor.pm
@@ -89,19 +89,9 @@ sub _twist {
     );
 
     # Do not report to the sender if the message was tagged as a spam.
-    unless ($self->{quiet} or $message->{'spam_status'} eq 'spam') {
-        # Ensure 1 second elapsed since last message.
-        Sympa::send_file(
-            $list,
-            'message_report',
-            $sender,
-            {   type           => 'success',              # Compat. <=6.2.12.
-                entry          => 'moderating_message',
-                auto_submitted => 'auto-replied'
-            },
-            date => time + 1
-        );
-    }
+    Sympa::send_dsn($list, $message, {}, '2.3.0')
+        unless $self->{quiet}
+        or $message->{'spam_status'} eq 'spam';
     return 1;
 }
 

--- a/src/lib/Sympa/Spindle/ToModeration.pm
+++ b/src/lib/Sympa/Spindle/ToModeration.pm
@@ -95,20 +95,9 @@ sub _twist {
         Time::HiRes::time() - $self->{start_time}
     );
 
-    # Do not report to the sender if the message was tagged as a spam.
-    unless ($self->{quiet} or $message->{'spam_status'} eq 'spam') {
-        # Ensure 1 second elapsed since last message.
-        Sympa::send_file(
-            $list,
-            'message_report',
-            $sender,
-            {   type           => 'success',              # Comapt. <=6.2.12.
-                entry          => 'moderating_message',
-                auto_submitted => 'auto-replied'
-            },
-            date => time + 1
-        );
-    }
+    Sympa::send_dsn($list, $message, {}, '4.3.0')
+        unless $self->{quiet}
+        or $message->{'spam_status'} eq 'spam';
     return 1;
 }
 


### PR DESCRIPTION
The report "Your message ... has been forwarded to the moderator(s)" may be sent as DSN.  This is not a notification that must be received always.

This may be related to #1354.
