### PR TITLE
Adding GH workflow to submit the PR for translation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+# Configuration for Automated release notes.
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: What's Changed
+      labels:
+        - "*"
+

--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -5,8 +5,8 @@ on:
     tags-ignore:
       - '*'
   pull_request:
-    branches:
-      - '*'
+    branches-ignore:
+      - 'translation'
 
 jobs:
   make-check:
@@ -18,6 +18,7 @@ jobs:
           - 'macos-latest'
           - 'ubuntu-latest'
         perl:
+          - '5'
           - '5.34'
           - '5.32'
           - '5.30'
@@ -30,7 +31,7 @@ jobs:
           - '5.16'
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies for Linux
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/submit-pr-for-translation.yml
+++ b/.github/workflows/submit-pr-for-translation.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches:
+      - translation
+    paths:
+      - 'po/**'
+
+env:
+  GH_PR_TITLE: Update translation
+  GH_PR_BODY: This pull request was automatically submitted.
+  GH_PR_LABEL: translation,on going,ignore-for-release
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  submit-pr-for-translation:
+    if: github.repository_owner == 'sympa-community'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Submit PR to update translation
+        run: >
+          gh pr create -H $GITHUB_REPOSITORY_OWNER:$GITHUB_REF_NAME
+          -t "$GH_PR_TITLE" -b "$GH_PR_BODY" -l "$GH_PR_LABEL"
+          || true


### PR DESCRIPTION
I wrote a script that is regularly running on the translation server to push the update of translations.

This PR adds a new GitHub Actions workflow to submit the PR necessary to merge pushed changes above.

It also adds a new label "ignore-for-release" to exclude PRs from the automated release notes (check [the doc](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)).
