### PR TITLE
Fix SQLite upgrade with lowercase types

### DIFF
--- a/src/lib/Sympa/DatabaseDriver/SQLite.pm
+++ b/src/lib/Sympa/DatabaseDriver/SQLite.pm
@@ -191,7 +191,7 @@ sub get_fields {
     }
     while (my $field = $sth->fetchrow_hashref('NAME_lc')) {
         # http://www.sqlite.org/datatype3.html
-        my $type = $field->{'type'};
+        my $type = lc $field->{'type'};
         if ($type =~ /int/) {
             $type = 'integer';
         } elsif ($type =~ /char|clob|text/) {


### PR DESCRIPTION
It seems that "occasionally" the SQL schema types in SQLite are not lower case so the upgrade in this case fail.

This patch was submitted in the following bug report: https://bugs.debian.org/1022943