### PR TITLE
Fix various typos in source comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -459,7 +459,7 @@ No changes.
 
 **Changes** (since 6.2.54) **:**
 
-- `http_host` parameter has been deprecated by the new `wwsympa_url_local` parameter [\#916](https://github.com/sympa-community/sympa/pull/916) ([ikedas](https://github.com/ikedas)). If you used `http_host` parameter, you possiblly need removing it (See [note](https://sympa-community.github.io/manual/upgrade/notes.html#from-version-prior-to-6256)).
+- `http_host` parameter has been deprecated by the new `wwsympa_url_local` parameter [\#916](https://github.com/sympa-community/sympa/pull/916) ([ikedas](https://github.com/ikedas)). If you used `http_host` parameter, you possibly need removing it (See [note](https://sympa-community.github.io/manual/upgrade/notes.html#from-version-prior-to-6256)).
 
 **Implemented enhancements:**
 

--- a/doc/sympa_config.podpl
+++ b/doc/sympa_config.podpl
@@ -249,7 +249,7 @@ sub _format {
             status     => 'Status of list.',
             listtopic  => 'List topic.',
             unixtime   => 'The time in second from Unix epoch.',
-            visibility => 'Visibility mode of list memeber.',
+            visibility => 'Visibility mode of list member.',
         }->{$pinfo->{field_type}}
             || $pinfo->{field_type};
         $parameters .= sprintf "%s\n\n", $desc;

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -2325,7 +2325,7 @@ sub send_html {
         }
     }
 
-    # Main CSS, possiblly customized.
+    # Main CSS, possibly customized.
     my $main_css;
     if ($session->{'custom_css'}) {
         $main_css = Sympa::WWW::Tools::get_css_url(

--- a/src/lib/Sympa.pm
+++ b/src/lib/Sympa.pm
@@ -673,7 +673,7 @@ sub get_listmasters_email {
         map  { Sympa::Tools::Text::canonic_email($_) }
         grep { Sympa::Tools::Text::valid_email($_) } split /\s*,\s*/,
         $listmaster;
-    # If no valid adresses found, use listmaster of site config.
+    # If no valid addresses found, use listmaster of site config.
     unless (@listmasters or (not ref $that and $that eq '*')) {
         $log->syslog('notice', 'Warning: No listmasters found for %s', $that);
         @listmasters = Sympa::get_listmasters_email('*');

--- a/src/lib/Sympa/CLI/show_pending_lists.pm
+++ b/src/lib/Sympa/CLI/show_pending_lists.pm
@@ -70,6 +70,6 @@ C<sympa show_pending_lists> I<domain>
 
 =head1 DESCRIPTION
 
-Print all pending lists for the robot, with informations.
+Print all pending lists for the robot, with information.
 
 =cut

--- a/src/lib/Sympa/DataSource.pm
+++ b/src/lib/Sympa/DataSource.pm
@@ -317,7 +317,7 @@ Parameters:
 =item $type
 
 Type of data source.
-This corresponds to impemented subclasses.
+This corresponds to implemented subclasses.
 
 =item $role
 

--- a/src/lib/Sympa/Family.pm
+++ b/src/lib/Sympa/Family.pm
@@ -643,7 +643,7 @@ Arguments
 
 =item $list
 
-A List object corresponding to the list to chek.
+A List object corresponding to the list to check.
 
 =back
 

--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -5881,7 +5881,7 @@ sub add_list_header {
         }
     } elsif ($field eq 'archived_at') {
         if ($wwsympa_url and $self->is_web_archived()) {
-            # Use possiblly anonymized Message-Id: field instead of
+            # Use possibly anonymized Message-Id: field instead of
             # {message_id} attribute.
             my $message_id = Sympa::Tools::Text::canonic_message_id(
                 $message->get_header('Message-Id'));
@@ -6299,7 +6299,7 @@ Limit result to the user with their e-mail $email.
 
 Returns:
 
-In array context, returns (possiblly empty or single-item) array of users.
+In array context, returns (possibly empty or single-item) array of users.
 In scalar context, returns reference to it.
 In case of database error, returns empty array or undefined value.
 
@@ -6424,7 +6424,7 @@ TBD.
 
 Returns:
 
-In array context, returns (possiblly empty or single-item) array of users.
+In array context, returns (possibly empty or single-item) array of users.
 In scalar context, returns reference to it.
 In case of database error, returns empty array or undefined value.
 

--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -4349,7 +4349,7 @@ DMARC protection.  See also L</dmarc_protect>().
 
 Personalizing.
 
-On Sympa 6.2.58 or earlier, there was no distiction between C<footer> and C<all>.
+On Sympa 6.2.58 or earlier, there was no distinction between C<footer> and C<all>.
 The C<merge> item in the messages stored into outgoing spool by earlier version
 of Sympa will be treated as C<all>.
 

--- a/src/lib/Sympa/Message/Plugin.pm
+++ b/src/lib/Sympa/Message/Plugin.pm
@@ -156,7 +156,7 @@ First, write your hook module:
       my $message = shift;    # Message object
       my %options = @_;
   
-      # Processing, possiblly changing $message...
+      # Processing, possibly changing $message...
   
       # Return suitable result.
       # If unrecoverable error occurred, you may return undef or simply die.

--- a/src/lib/Sympa/Tools/Data.pm
+++ b/src/lib/Sympa/Tools/Data.pm
@@ -507,7 +507,7 @@ XML formed data as stored in database
 
 Returns:
 
-A hashref storing custome attributes.
+A hashref storing custom attributes.
 
 =item diff_on_arrays ( $setA, $setB )
 
@@ -563,7 +563,7 @@ Options:
 
 =item $hasref
 
-Hashref storing custome attributes.
+Hashref storing custom attributes.
 
 =back
 
@@ -643,7 +643,7 @@ An arrayref.
 
 =item hash_2_string (...)
 
-Converts a hash into a string formated as var1="value1";var2="value2"; into
+Converts a hash into a string formatted as var1="value1";var2="value2"; into
 a hash.
 TBD.
 
@@ -699,7 +699,7 @@ If arguments matched, true value.  Otherwise false value.
 
 =item smart_lessthan (...)
 
-Compares two scalars, string/numeric independant.
+Compares two scalars, string/numeric independent.
 TBD.
 
 =item sort_uniq ( [ \&comp ], @items )
@@ -725,7 +725,7 @@ This function was added on Sympa 6.2.16.
 
 =item string_2_hash (...)
 
-Converts a string formated as var1="value1";var2="value2"; into a hash.
+Converts a string formatted as var1="value1";var2="value2"; into a hash.
 Used when extracting from session table some session properties or when
 extracting users preference from user table.
 Current encoding is NOT compatible with encoding of values with '"'.

--- a/src/sbin/sympa.pl.in
+++ b/src/sbin/sympa.pl.in
@@ -752,7 +752,7 @@ New command line format:
 
 =item C<--show_pending_lists>=I<robot>
 
-Print all pending lists for the robot, with informations.
+Print all pending lists for the robot, with information.
 
 New command line format:
 

--- a/support/xgettext.pl
+++ b/support/xgettext.pl
@@ -22,9 +22,9 @@ use constant QUOM2 => 9;
 use constant COMM  => 10;
 
 ## A hash that will contain the strings to translate and their meta
-## informations.
+## information.
 my %file;
-## conatins informations if a string is a date string.
+## contains information if a string is a date string.
 my %type_of_entries;
 ## Contains unique occurrences of each string
 my %Lexicon;


### PR DESCRIPTION
Some of theses typos are present in man pages.