### PR TITLE
Fix 'sympa config' command return code to be 0 when there are no changes

### DIFF
--- a/src/lib/Sympa/CLI/config.pm
+++ b/src/lib/Sympa/CLI/config.pm
@@ -65,7 +65,7 @@ sub _run {
             only_changed => 1,
             filter => ([@{$options->{output} // []}, qw(explicit mandatory)])
         );
-        die "Not changed.\n" unless defined $out;
+        return 1 unless defined $out;
 
         my $sympa_conf = Sympa::Constants::CONFIG();
         my $date = POSIX::strftime('%Y%m%d%H%M%S', localtime time);


### PR DESCRIPTION
While trying to update a config value using `sympa config` command when there are no changes, it die() with a return code > 0.

It means that the command is not idempotent.

As an example, we started to use it in Debian Maintainer scripts with some config parameters instead of our custom routines to update configuration.