### PR TITLE
Deprecate scripts under bin/ (#1386), fixed

### DIFF
--- a/po/sympa/POTFILES.in
+++ b/po/sympa/POTFILES.in
@@ -1,5 +1,4 @@
 # List of source files which contain translatable strings.
-src/bin/*.pl.in
 src/libexec/*.pl.in
 src/sbin/*.pl.in
 src/lib/*.pm

--- a/t/compile_executables.t
+++ b/t/compile_executables.t
@@ -15,9 +15,7 @@ unless ($Test::Compile::Internal::VERSION) {
 } else {
     my $test  = Test::Compile::Internal->new;
     my @files = (
-        ##<po/*.pl>,
         <src/sbin/*.pl>,
-        <src/bin/*.pl>,
         <src/libexec/*.pl>,
         'src/cgi/wwsympa.fcgi',
         'src/cgi/sympa_soap_server.fcgi',


### PR DESCRIPTION
By #1405 , updating *.pot crashes.

This is a part of #1386 .