### PR TITLE
Fixing SQL custom attributes synchronization.

### DIFF
--- a/src/lib/Sympa/DataSource/SQL.pm
+++ b/src/lib/Sympa/DataSource/SQL.pm
@@ -75,8 +75,11 @@ sub _open {
                     my $email = delete $row->{$self->{email_entry}};
                     next unless defined $email and length $email;
                     $email =~ s/[\t\r\n]+/ /g;
-
-                    print $tmpfh "%s\t%s\n", $email,
+                    foreach my $k (keys %$row) {
+                        $row->{$k} = { value => $row->{$k} }
+                            unless ref $row->{$k} eq 'HASH' and defined $row->{$k}{value};
+                    }
+                    printf $tmpfh "%s\t%s\n", $email,
                         Sympa::Tools::Data::encode_custom_attribute($row);
                 }
             } else {


### PR DESCRIPTION
Currently, SQL custom attributes fails because:

  - it calls Sympa::Tools::Data::encode_custom_attributes with the wrong data structures for the custom attributes,
  - print is called instead of printf.

All this is fixed here.