### PR TITLE
WWSympa: `msg` (ex. `arcsearch_id`) crashes

### DIFF
--- a/src/lib/Marc/Search.pm
+++ b/src/lib/Marc/Search.pm
@@ -244,6 +244,7 @@ sub search {
     my $body        = $self->body || 0;
 
     @MSGFILES = '';
+    $self->{res} = [];
 
     my @directories = split /\0/, $directories;
     foreach my $dir (@directories) {


### PR DESCRIPTION
WWSympa: `msg` (ex. `arcsearch_id`) crashes with the list without archives.

This bug was reported by @mpkut .
