### PR TITLE
Display name in `From:` header field should be quoted / unquoted appropriately

### DIFF
--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -266,7 +266,16 @@ sub _get_sender_email {
             if (@sender_hdr and $sender_hdr[0]->address) {
                 $sender = lc($sender_hdr[0]->address);
                 my $phrase = $sender_hdr[0]->phrase;
-                if (defined $phrase and length $phrase) {
+                if (length($phrase // '')) {
+                    # Unquote quoted strings in the phrase.
+                    # cf. RFC 5322, 3.2.4 and 3.2.5.
+                    $phrase =~ s{(?<!\S) " ((?:\\. | [^\\"])*) " (?!\S)}{
+                        my $qcontent = $1;
+                        $qcontent =~ s/\\(.)/$1/grs;
+                    }egsx;
+
+                    # Decode B- or Q-encoded words. Note that some (mistaken)
+                    # implementations may quote encoded words.
                     $gecos = MIME::EncWords::decode_mimewords($phrase,
                         Charset => 'UTF-8');
                     # Eliminate hostile characters.

--- a/src/lib/Sympa/Tools/Text.pm
+++ b/src/lib/Sympa/Tools/Text.pm
@@ -47,7 +47,12 @@ sub addrencode {
 
     return undef unless $addr =~ /\S/;
 
+    # Eliminate hostile characters.
+    $phrase =~ s/(\r\n|\r|\n)(?=[ \t])//g;
+    $phrase =~ s/[\0\r\n]+//g;
+
     if ($phrase =~ /[^\s\x21-\x7E]/) {
+        # String containing Non-ASCII should be encoded.
         $phrase = MIME::EncWords::encode_mimewords(
             Encode::decode('utf8', $phrase),
             'Encoding'    => 'A',
@@ -56,10 +61,13 @@ sub addrencode {
             'Field'       => 'Resent-Sender', # almost longest
             'Minimal'     => 'DISPNAME',      # needs MIME::EncWords >= 1.012.
         );
-    } elsif ($phrase =~ /\S/) {
+    } elsif ($phrase =~ /[()<>\[\]:;\@\\,\"]/) {
+        # Otherwise, the string has to be quoted when it is not a
+        # dot-atom-text (RFC 5322 3.2.3).
         $phrase =~ s/([\\\"])/\\$1/g;
         $phrase = '"' . $phrase . '"';
     }
+
     if ($comment =~ /[^\s\x21-\x27\x2A-\x5B\x5D-\x7E]/) {
         $comment = MIME::EncWords::encode_mimewords(
             Encode::decode('utf8', $comment),


### PR DESCRIPTION
  * Getting {gecos} field from incoming message, display name in `From:` field should be unquoted.
  * Setting display name in `From:` field of the message sent by system, the name should be quoted only if necessary.

This PR may fix #999, with the latter in above.
