### PR TITLE
Issue 1573 Archived crash with html sanitizer on regex recursion

### DIFF
--- a/src/lib/Sympa/Spindle/ProcessArchive.pm
+++ b/src/lib/Sympa/Spindle/ProcessArchive.pm
@@ -460,10 +460,11 @@ sub _mail2arc {
             }
         }
     }
-
-    unless ($archive->store($message) and $archive->html_store($message)) {
-        return undef;
-    }
+    eval { 
+        unless ($archive->store($message) and $archive->html_store($message)) {
+            return undef;
+        }
+    } or return undef;
     return 1;
 }
 


### PR DESCRIPTION
Just catching the exception to avoid looping (400 crashed mails received just for one bad email)
It's a very basic solution to consider that problem as a simple archive problem.
Should be better to just put it in spool bad without annoying the listmaster. But  it's a little bit too difficult for me.