### PR TITLE
Broken output with SOAP API due to mixture of byte- and utf8-strings (#1541)

### DIFF
--- a/src/cgi/sympa_soap_server.fcgi.in
+++ b/src/cgi/sympa_soap_server.fcgi.in
@@ -39,7 +39,7 @@ use Sympa::List;
 use Sympa::Log;
 use Sympa::Spool::Listmaster;
 use Sympa::WWW::SOAP;
-use Sympa::WWW::SOAP::Transport;
+use Sympa::WWW::SOAP::FastCGI;
 
 ## Load sympa config
 unless (Conf::load()) {
@@ -81,8 +81,7 @@ my $all_lists = Sympa::List::get_lists('*');
 #    Soap part
 ##############################################################################
 
-Sympa::WWW::SOAP::Transport->new(
-    cookie_expire => $Conf::Conf{'cookie_expire'})
+Sympa::WWW::SOAP::FastCGI->new(cookie_expire => $Conf::Conf{'cookie_expire'})
     ->dispatch_with({'urn:sympasoap' => 'Sympa::WWW::SOAP'})->handle;
 
 __END__

--- a/src/cgi/sympa_soap_server.fcgi.in
+++ b/src/cgi/sympa_soap_server.fcgi.in
@@ -9,7 +9,7 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018, 2019, 2022 The Sympa Community. See the
+# Copyright 2017, 2018, 2019, 2022, 2023 The Sympa Community. See the
 # AUTHORS.md file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -4,7 +4,7 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018, 2019, 2021, 2022 The Sympa Community. See the
+# Copyright 2017, 2018, 2019, 2021, 2022, 2023 The Sympa Community. See the
 # AUTHORS.md file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -242,7 +242,7 @@ nonCLI_modules = \
 	Sympa/WWW/SharedDocument.pm \
 	Sympa/WWW/Session.pm \
 	Sympa/WWW/SOAP.pm \
-	Sympa/WWW/SOAP/Transport.pm \
+	Sympa/WWW/SOAP/FastCGI.pm \
 	Sympa/WWW/Tools.pm
 nobase_modules_DATA = $(CLI_modules) $(nonCLI_modules)
 

--- a/src/lib/Sympa/CLI/test/soap.pm
+++ b/src/lib/Sympa/CLI/test/soap.pm
@@ -3,7 +3,7 @@
 
 # Sympa - SYsteme de Multi-Postage Automatique
 #
-# Copyright 2022 The Sympa Community. See the
+# Copyright 2022, 2023 The Sympa Community. See the
 # AUTHORS.md file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #

--- a/src/lib/Sympa/CLI/test/soap.pm
+++ b/src/lib/Sympa/CLI/test/soap.pm
@@ -24,6 +24,7 @@ package Sympa::CLI::test::soap;
 
 use strict;
 use warnings;
+use Encode qw();
 use Getopt::Long;
 use HTTP::Cookies;
 use SOAP::Lite;
@@ -72,8 +73,8 @@ sub _run {
         }
 
         play_soap_as_trusted($soap_url, $trusted_application,
-            $trusted_application_password, $service, $proxy_vars,
-            $service_parameters);
+            $trusted_application_password, $proxy_vars,
+            $service, $service_parameters);
     } elsif ($service eq 'getUserEmailByCookie') {
         play_soap(
             $soap_url,
@@ -110,8 +111,8 @@ sub play_soap_as_trusted {
     my $soap_url                     = shift;
     my $trusted_application          = shift;
     my $trusted_application_password = shift;
-    my $service                      = shift;
     my $proxy_vars                   = shift;
+    my $service                      = shift;
     my $service_parameters           = shift;
 
     my $soap = SOAP::Lite->new();
@@ -124,9 +125,8 @@ sub play_soap_as_trusted {
     } else {
         @parameters = ();
     }
-    my $p = join(',', @parameters);
-    printf
-        "calling authenticateRemoteAppAndRun( $trusted_application, $trusted_application_password, $proxy_vars,$service,$p)\n";
+    printf "calling authenticateRemoteAppAndRun( %s, ?, %s, %s, %s )\n",
+        $trusted_application, $proxy_vars, $service, join ',', @parameters;
 
     my $reponse =
         $soap->authenticateRemoteAppAndRun($trusted_application,
@@ -290,7 +290,8 @@ sub _dump_var {
     } elsif (ref $var) {
         printf "%s'%s'\n", "\t" x $level, ref $var;
     } elsif (defined $var) {
-        printf "%s'%s'\n", "\t" x $level, $var;
+        printf "%s'%s'\n", "\t" x $level,
+            Encode::is_utf8($var) ? Encode::encode_utf8($var) : $var;
     } else {
         printf "%sUNDEF\n", "\t" x $level;
     }

--- a/src/lib/Sympa/WWW/SOAP.pm
+++ b/src/lib/Sympa/WWW/SOAP.pm
@@ -7,9 +7,9 @@
 # Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
 # 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
 # Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017, 2018, 2019, 2020, 2021, 2022 The Sympa Community. See the
-# AUTHORS.md file at the top-level directory of this distribution and at
-# <https://github.com/sympa-community/sympa.git>.
+# Copyright 2017, 2018, 2019, 2020, 2021, 2022, 2023 The Sympa Community.
+# See the AUTHORS.md file at the top-level directory of this distribution
+# and at <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/lib/Sympa/WWW/SOAP.pm
+++ b/src/lib/Sympa/WWW/SOAP.pm
@@ -60,6 +60,14 @@ my %types = (
 
 my $log = Sympa::Log->instance;
 
+sub _map_encode_utf8 {
+    return map {
+              ref $_ eq 'ARRAY'   ? [_map_encode_utf8(@$_)]
+            : Encode::is_utf8($_) ? Encode::encode_utf8($_)
+            : $_
+    } @_;
+}
+
 sub checkCookie {
     my $class = shift;
 
@@ -73,19 +81,20 @@ sub checkCookie {
 
     $log->syslog('debug', 'SOAP checkCookie');
 
-    return SOAP::Data->name('result')->type('string')->value($sender);
+    return Sympa::WWW::SOAP::Data->name('result')->type('string')
+        ->value($sender);
 }
 
 sub lists {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('notice', '(%s, %s, %s, %s)', @_);
     my $self     = shift;         #$self is a service object
     my $topic    = shift;
     my $subtopic = shift;
     my $mode     = shift // '';
 
     my $sender = $ENV{'USER_EMAIL'};
-    my $robot  = $ENV{'SYMPA_ROBOT'};
-
-    $log->syslog('notice', '(%s, %s, %s)', $topic, $subtopic, $sender);
+    my $robot  = $ENV{SYMPA_DOMAIN};
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -121,9 +130,9 @@ sub lists {
 
         my $listInfo;
         if ($mode eq 'complex') {
-            $listInfo = struct_to_soap($result_item);
+            $listInfo = _struct_to_soap($result_item);
         } else {
-            $listInfo = struct_to_soap($result_item, 'as_string');
+            $listInfo = _struct_to_soap($result_item, 'as_string');
         }
 
         ## no topic ; List all lists
@@ -144,17 +153,18 @@ sub lists {
         }
     }
 
-    return SOAP::Data->name('listInfo')->value(\@result);
+    return Sympa::WWW::SOAP::Data->name('listInfo')->value(\@result);
 }
 
 sub login {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('notice', '(%s, %s, ?)', @_);
     my $class  = shift;
     my $email  = shift;
     my $passwd = shift;
 
     my $http_host = $ENV{'SERVER_NAME'};
-    my $robot     = $ENV{'SYMPA_ROBOT'};
-    $log->syslog('notice', '(%s)', $email);
+    my $robot     = $ENV{SYMPA_DOMAIN};
 
     #foreach my  $k (keys %ENV) {
     #$log->syslog('notice', 'ENV %s = %s', $k, $ENV{$k});
@@ -192,26 +202,27 @@ sub login {
     ## Create Sympa::WWW::Session object
     my $session =
         Sympa::WWW::Session->new($robot, {cookie => $ENV{SESSION_ID}});
-    $ENV{'USER_EMAIL'} = $email;
-    $session->{'email'} = $email;
-    $session->store();
+    $session->{'email'} = $ENV{USER_EMAIL} =
+        Sympa::Tools::Text::canonic_email($email);
+    $session->store;
 
     ## Note that id_session changes each time it is saved in the DB
     $ENV{'SESSION_ID'} = $session->{'id_session'};
 
     ## Also return the cookie value
-    return SOAP::Data->name('result')->type('string')
+    return Sympa::WWW::SOAP::Data->name('result')->type('string')
         ->value($ENV{SESSION_ID});
 }
 
 sub casLogin {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('notice', '(%s, %s)', @_);
     my $class       = shift;
     my $proxyTicket = shift;
 
     my $http_host = $ENV{'SERVER_NAME'};
     my $sender    = $ENV{'USER_EMAIL'};
-    my $robot     = $ENV{'SYMPA_ROBOT'};
-    $log->syslog('notice', '(%s)', $proxyTicket);
+    my $robot     = $ENV{SYMPA_DOMAIN};
 
     unless ($http_host and $proxyTicket) {
         $log->syslog('err', 'Incorrect number of parameters');
@@ -278,30 +289,30 @@ sub casLogin {
     ## Create Sympa::WWW::Session object
     my $session =
         Sympa::WWW::Session->new($robot, {cookie => $ENV{SESSION_ID}});
-    $ENV{'USER_EMAIL'} = $email;
-    $session->{'email'} = $email;
-    $session->store();
+    $session->{'email'} = $ENV{USER_EMAIL} =
+        Sympa::Tools::Text::canonic_email($email);
+    $session->store;
 
     ## Note that id_session changes each time it is saved in the DB
     $ENV{'SESSION_ID'} = $session->{'id_session'};
 
     ## Also return the cookie value
-    return SOAP::Data->name('result')->type('string')
+    return Sympa::WWW::SOAP::Data->name('result')->type('string')
         ->value($ENV{SESSION_ID});
 }
 
 ## Used to call a service as an authenticated user without using HTTP cookies
 ## First parameter is the secret contained in the cookie
 sub authenticateAndRun {
-    my ($self, $email, $cookie, $service, $parameters) = @_;
-    my $session_id;
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('notice', '(%s, %s, %.0s, %s, %s)', @_);
+    my $self       = shift;
+    my $email      = shift;
+    my $cookie     = shift;
+    my $service    = shift;
+    my $parameters = shift;
 
-    if ($parameters) {
-        $log->syslog('notice', '(%s, %s, %s, %s)',
-            $email, $cookie, $service, join(',', @$parameters));
-    } else {
-        $log->syslog('notice', '(%s, %s, %s)', $email, $cookie, $service);
-    }
+    my $session_id;
 
     unless ($cookie and $service) {
         $log->syslog('err', "Missing parameter");
@@ -313,7 +324,7 @@ sub authenticateAndRun {
     ## Provided email is not trusted, we fetch the user email from the
     ## session_table instead
     my $session =
-        Sympa::WWW::Session->new($ENV{'SYMPA_ROBOT'}, {cookie => $cookie});
+        Sympa::WWW::Session->new($ENV{SYMPA_DOMAIN}, {cookie => $cookie});
 
     unless (defined $session
         && !$session->{'new_session'}
@@ -325,7 +336,7 @@ sub authenticateAndRun {
             ->faultstring('Could not get email from cookie')->faultdetail('');
     }
 
-    $ENV{'USER_EMAIL'} = $email;
+    $ENV{'USER_EMAIL'} = Sympa::Tools::Text::canonic_email($email);
     $ENV{'SESSION_ID'} = $session->{'id_session'};
 
     no strict 'refs';
@@ -334,9 +345,10 @@ sub authenticateAndRun {
 ## request user email from http cookie
 ##
 sub getUserEmailByCookie {
-    my ($self, $cookie) = @_;
-
-    $log->syslog('debug3', '(%s)', $cookie);
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('debug3', '(%s,%s)', @_);
+    my $self   = shift;
+    my $cookie = shift;
 
     unless ($cookie) {
         $log->syslog('err', "Missing parameter cookie");
@@ -345,7 +357,7 @@ sub getUserEmailByCookie {
     }
 
     my $session =
-        Sympa::WWW::Session->new($ENV{'SYMPA_ROBOT'}, {'cookie' => $cookie});
+        Sympa::WWW::Session->new($ENV{SYMPA_DOMAIN}, {'cookie' => $cookie});
 
     unless (defined $session && ($session->{'email'} ne 'unkown')) {
         $log->syslog('err', 'Failed to load session for %s', $cookie);
@@ -353,7 +365,7 @@ sub getUserEmailByCookie {
             ->faultstring('Could not get email from cookie')->faultdetail('');
     }
 
-    return SOAP::Data->name('result')->type('string')
+    return Sympa::WWW::SOAP::Data->name('result')->type('string')
         ->value($session->{'email'});
 
 }
@@ -366,15 +378,16 @@ sub getUserEmailByCookie {
 ##   4nd is service name requested
 ##   5nd service parameters
 sub authenticateRemoteAppAndRun {
-    my ($self, $appname, $apppassword, $vars, $service, $parameters) = @_;
-    my $robot = $ENV{'SYMPA_ROBOT'};
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('notice', '(%s, %s, %.0s, %s, %s, %s)', @_);
+    my $self        = shift;
+    my $appname     = shift;
+    my $apppassword = shift;
+    my $vars        = shift;
+    my $service     = shift;
+    my $parameters  = shift;
 
-    if ($parameters) {
-        $log->syslog('notice', '(%s, %s, %s, %s)',
-            $appname, $vars, $service, join(',', @$parameters));
-    } else {
-        $log->syslog('notice', '(%s, %s, %s)', $appname, $vars, $service);
-    }
+    my $robot = $ENV{SYMPA_DOMAIN};
 
     unless ($appname and $apppassword and $service) {
         die SOAP::Fault->faultcode('Client')
@@ -423,11 +436,14 @@ sub authenticateRemoteAppAndRun {
 }
 
 sub amI {
-    my ($class, $listname, $function, $user) = @_;
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('notice', '(%s, %s, %s, %s)', @_);
+    my $class    = shift;
+    my $listname = shift;
+    my $function = shift;
+    my $user     = shift;
 
-    my $robot = $ENV{'SYMPA_ROBOT'};
-
-    $log->syslog('notice', '(%s, %s, %s)', $listname, $function, $user);
+    my $robot = $ENV{SYMPA_DOMAIN};
 
     unless ($listname and $user and $function) {
         die SOAP::Fault->faultcode('Client')
@@ -435,20 +451,16 @@ sub amI {
             ->faultdetail('Use : <list> <function> <user email>');
     }
 
-    $listname = lc($listname);
     my $list = Sympa::List->new($listname, $robot);
-
-    $log->syslog('debug', '(%s)', $listname);
-
     if ($list) {
         if ($function eq 'subscriber') {
-            return SOAP::Data->name('result')->type('boolean')
+            return Sympa::WWW::SOAP::Data->name('result')->type('boolean')
                 ->value($list->is_list_member($user));
         } elsif ($function eq 'editor') {
-            return SOAP::Data->name('result')->type('boolean')
+            return Sympa::WWW::SOAP::Data->name('result')->type('boolean')
                 ->value($list->is_admin('actual_editor', $user));
         } elsif ($function eq 'owner') {
-            return SOAP::Data->name('result')->type('boolean')
+            return Sympa::WWW::SOAP::Data->name('result')->type('boolean')
                 ->value($list->is_admin('owner', $user)
                     || Sympa::is_listmaster($list, $user));
         } else {
@@ -464,11 +476,13 @@ sub amI {
 }
 
 sub info {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('notice', '(%s, %s)', @_);
     my $class    = shift;
     my $listname = shift;
 
     my $sender = $ENV{'USER_EMAIL'};
-    my $robot  = $ENV{'SYMPA_ROBOT'};
+    my $robot  = $ENV{SYMPA_DOMAIN};
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -481,8 +495,6 @@ sub info {
             ->faultstring('Incorrect number of parameters')
             ->faultdetail('Use : <list>');
     }
-
-    $log->syslog('notice', '(%s)', $listname);
 
     my $list = Sympa::List->new($listname, $robot);
     unless ($list) {
@@ -505,7 +517,7 @@ sub info {
         unless (defined $action);
 
     if ($action =~ /reject/i) {
-        my $reason_string = get_reason_string(
+        my $reason_string = _get_reason_string(
             [{action => 'info'}, 'auth', $result->{'reason'}], $robot);
         $log->syslog('info', 'Info %s from %s refused (not allowed)',
             $listname, $sender);
@@ -516,34 +528,38 @@ sub info {
         my $result_item;
 
         $result_item->{'listAddress'} =
-            SOAP::Data->name('listAddress')->type('string')
+            Sympa::WWW::SOAP::Data->name('listAddress')->type('string')
             ->value(Sympa::get_address($list));
         $result_item->{'subject'} =
-            SOAP::Data->name('subject')->type('string')
+            Sympa::WWW::SOAP::Data->name('subject')->type('string')
             ->value($list->{'admin'}{'subject'});
         $result_item->{'info'} =
-            SOAP::Data->name('info')->type('string')->value($list->get_info);
+            Sympa::WWW::SOAP::Data->name('info')->type('string')
+            ->value($list->get_info);
         $result_item->{'homepage'} =
-            SOAP::Data->name('homepage')->type('string')
+            Sympa::WWW::SOAP::Data->name('homepage')->type('string')
             ->value(Sympa::get_url($list, 'info'));
 
         ## determine status of user
         if ($list->is_admin('owner', $sender)
             or Sympa::is_listmaster($list, $sender)) {
             $result_item->{'isOwner'} =
-                SOAP::Data->name('isOwner')->type('boolean')->value(1);
+                Sympa::WWW::SOAP::Data->name('isOwner')->type('boolean')
+                ->value(1);
         }
         if ($list->is_admin('actual_editor', $sender)) {
             $result_item->{'isEditor'} =
-                SOAP::Data->name('isEditor')->type('boolean')->value(1);
+                Sympa::WWW::SOAP::Data->name('isEditor')->type('boolean')
+                ->value(1);
         }
         if ($list->is_list_member($sender)) {
             $result_item->{'isSubscriber'} =
-                SOAP::Data->name('isSubscriber')->type('boolean')->value(1);
+                Sympa::WWW::SOAP::Data->name('isSubscriber')->type('boolean')
+                ->value(1);
         }
 
-        #push @result, SOAP::Data->type('listType')->value($result_item);
-        return SOAP::Data->value([$result_item]);
+        #push @result, Sympa::WWW::SOAP::Data->type('listType')->value($result_item);
+        return Sympa::WWW::SOAP::Data->value([$result_item]);
     }
     $log->syslog('info',
         'Info %s from %s aborted, unknown requested action in scenario',
@@ -556,11 +572,8 @@ sub info {
 }
 
 sub createList {
-    $log->syslog(
-        'info',
-        '(%s, listname=%s, subject=%s, template=%s, description=%s, topics=%s)',
-        @_
-    );
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('info', '(%s, %s, %s, %s, %s, %s)', @_);
     my $class       = shift;
     my $listname    = shift;
     my $subject     = shift;
@@ -569,7 +582,7 @@ sub createList {
     my $topics      = shift;
 
     my $sender                  = $ENV{'USER_EMAIL'};
-    my $robot                   = $ENV{'SYMPA_ROBOT'};
+    my $robot                   = $ENV{SYMPA_DOMAIN};
     my $remote_application_name = $ENV{'remote_application_name'};
 
     unless ($sender) {
@@ -645,7 +658,7 @@ sub createList {
     }
 
     foreach my $report (@{$spindle->{stash} || []}) {
-        my $reason_string = get_reason_string($report, $robot);
+        my $reason_string = _get_reason_string($report, $robot);
         if ($report->[1] eq 'auth') {
             die SOAP::Fault->faultcode('Server')->faultstring('Not allowed.')
                 ->faultdetail($reason_string);
@@ -653,25 +666,25 @@ sub createList {
             die SOAP::Fault->faultcode('Server')
                 ->faultstring('Internal error');
         } elsif ($report->[1] eq 'notice') {
-            return SOAP::Data->name('result')->type('boolean')->value(1);
+            return Sympa::WWW::SOAP::Data->name('result')->type('boolean')
+                ->value(1);
         } elsif ($report->[1] eq 'user') {
             die SOAP::Fault->faultcode('Server')->faultstring('Undef')
                 ->faultdetail($reason_string);
         }
     }
-    return SOAP::Data->name('result')->type('boolean')->value(1);
+    return Sympa::WWW::SOAP::Data->name('result')->type('boolean')->value(1);
 }
 
 sub closeList {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('info', '(%s, %s)', @_);
     my $class    = shift;
     my $listname = shift;
 
     my $sender                  = $ENV{'USER_EMAIL'};
-    my $robot                   = $ENV{'SYMPA_ROBOT'};
+    my $robot                   = $ENV{SYMPA_DOMAIN};
     my $remote_application_name = $ENV{'remote_application_name'};
-
-    $log->syslog('info', '(list = %s\@%s) From %s via proxy application %s',
-        $listname, $robot, $sender, $remote_application_name);
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -724,7 +737,7 @@ sub closeList {
     }
 
     foreach my $report (@{$spindle->{stash} || []}) {
-        my $reason_string = get_reason_string($report, $robot);
+        my $reason_string = _get_reason_string($report, $robot);
         if ($report->[1] eq 'auth') {
             die SOAP::Fault->faultcode('Server')->faultstring('Not allowed.')
                 ->faultdetail($reason_string);
@@ -732,16 +745,19 @@ sub closeList {
             die SOAP::Fault->faultcode('Server')
                 ->faultstring('Internal error');
         } elsif ($report->[1] eq 'notice') {
-            return SOAP::Data->name('result')->type('boolean')->value(1);
+            return Sympa::WWW::SOAP::Data->name('result')->type('boolean')
+                ->value(1);
         } elsif ($report->[1] eq 'user') {
             die SOAP::Fault->faultcode('Server')->faultstring('Undef')
                 ->faultdetail($reason_string);
         }
     }
-    return SOAP::Data->name('result')->type('boolean')->value(1);
+    return Sympa::WWW::SOAP::Data->name('result')->type('boolean')->value(1);
 }
 
 sub add {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('info', '(%s, %s, %s, %s, %s)', @_);
     my $class    = shift;
     my $listname = shift;
     my $email    = shift;
@@ -749,19 +765,8 @@ sub add {
     my $quiet    = shift;
 
     my $sender                  = $ENV{'USER_EMAIL'};
-    my $robot                   = $ENV{'SYMPA_ROBOT'};
+    my $robot                   = $ENV{SYMPA_DOMAIN};
     my $remote_application_name = $ENV{'remote_application_name'};
-
-    $log->syslog(
-        'info',
-        '(list = %s@%s, email = %s, quiet = %s) From %s via proxy application %s',
-        $listname,
-        $robot,
-        $email,
-        $quiet,
-        $sender,
-        $remote_application_name
-    );
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -813,7 +818,7 @@ sub add {
     }
 
     foreach my $report (@{$spindle->{stash} || []}) {
-        my $reason_string = get_reason_string($report, $robot);
+        my $reason_string = _get_reason_string($report, $robot);
         if ($report->[1] eq 'auth') {
             die SOAP::Fault->faultcode('Server')->faultstring('Not allowed.')
                 ->faultdetail($reason_string);
@@ -821,35 +826,27 @@ sub add {
             die SOAP::Fault->faultcode('Server')
                 ->faultstring('Internal error');
         } elsif ($report->[1] eq 'notice') {
-            return SOAP::Data->name('result')->type('boolean')->value(1);
+            return Sympa::WWW::SOAP::Data->name('result')->type('boolean')
+                ->value(1);
         } elsif ($report->[1] eq 'user') {
             die SOAP::Fault->faultcode('Server')->faultstring('Undef')
                 ->faultdetail($reason_string);
         }
     }
-    return SOAP::Data->name('result')->type('boolean')->value(1);
+    return Sympa::WWW::SOAP::Data->name('result')->type('boolean')->value(1);
 }
 
 sub del {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('info', '(%s, %s, %s, %s)', @_);
     my $class    = shift;
     my $listname = shift;
     my $email    = shift;
     my $quiet    = shift;
 
     my $sender                  = $ENV{'USER_EMAIL'};
-    my $robot                   = $ENV{'SYMPA_ROBOT'};
+    my $robot                   = $ENV{SYMPA_DOMAIN};
     my $remote_application_name = $ENV{'remote_application_name'};
-
-    $log->syslog(
-        'info',
-        '(list = %s@%s, email = %s, quiet = %s) From %s via proxy application %s',
-        $listname,
-        $robot,
-        $email,
-        $quiet,
-        $sender,
-        $remote_application_name
-    );
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -895,7 +892,7 @@ sub del {
     }
 
     foreach my $report (@{$spindle->{stash} || []}) {
-        my $reason_string = get_reason_string($report, $robot);
+        my $reason_string = _get_reason_string($report, $robot);
         if ($report->[1] eq 'auth') {
             die SOAP::Fault->faultcode('Server')->faultstring('Not allowed.')
                 ->faultdetail($reason_string);
@@ -903,21 +900,24 @@ sub del {
             die SOAP::Fault->faultcode('Server')
                 ->faultstring('Internal error');
         } elsif ($report->[1] eq 'notice') {
-            return SOAP::Data->name('result')->type('boolean')->value(1);
+            return Sympa::WWW::SOAP::Data->name('result')->type('boolean')
+                ->value(1);
         } elsif ($report->[1] eq 'user') {
             die SOAP::Fault->faultcode('Server')->faultstring('Undef')
                 ->faultdetail($reason_string);
         }
     }
-    return SOAP::Data->name('result')->type('boolean')->value(1);
+    return Sympa::WWW::SOAP::Data->name('result')->type('boolean')->value(1);
 }
 
 sub review {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('debug', '(%s, %s)', @_);
     my $class    = shift;
     my $listname = shift;
 
     my $sender = $ENV{'USER_EMAIL'};
-    my $robot  = $ENV{'SYMPA_ROBOT'};
+    my $robot  = $ENV{SYMPA_DOMAIN};
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -932,8 +932,6 @@ sub review {
             ->faultstring('Incorrect number of parameters')
             ->faultdetail('Use : <list>');
     }
-
-    $log->syslog('debug', '(%s, %s)', $listname, $robot);
 
     my $list = Sympa::List->new($listname, $robot);
     unless ($list) {
@@ -962,7 +960,7 @@ sub review {
         unless (defined $action);
 
     if ($action =~ /reject/i) {
-        my $reason_string = get_reason_string(
+        my $reason_string = _get_reason_string(
             [{action => 'review'}, 'auth', $result->{'reason'}], $robot);
         $log->syslog('info', 'Review %s from %s refused (not allowed)',
             $listname, $sender);
@@ -977,9 +975,10 @@ sub review {
             $log->syslog('err', 'No subscribers in list "%s"',
                 $list->{'name'});
             push @resultSoap,
-                SOAP::Data->name('result')->type('string')
+                Sympa::WWW::SOAP::Data->name('result')->type('string')
                 ->value('no_subscribers');
-            return SOAP::Data->name('return')->value(\@resultSoap);
+            return Sympa::WWW::SOAP::Data->name('return')
+                ->value(\@resultSoap);
         }
         do {
             ## Owners bypass the visibility option
@@ -989,13 +988,13 @@ sub review {
                 ## Lower case email address
                 $user->{'email'} =~ y/A-Z/a-z/;
                 push @resultSoap,
-                    SOAP::Data->name('item')->type('string')
+                    Sympa::WWW::SOAP::Data->name('item')->type('string')
                     ->value($user->{'email'});
             }
         } while ($user = $list->get_next_list_member());
         $log->syslog('info', 'Review %s from %s accepted', $listname,
             $sender);
-        return SOAP::Data->name('return')->value(\@resultSoap);
+        return Sympa::WWW::SOAP::Data->name('return')->value(\@resultSoap);
     }
     $log->syslog('info',
         'Review %s from %s aborted, unknown requested action in scenario',
@@ -1008,11 +1007,13 @@ sub review {
 }
 
 sub fullReview {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('debug', '(%s, %s)', @_);
     my $class    = shift;
     my $listname = shift;
 
     my $sender = $ENV{'USER_EMAIL'};
-    my $robot  = $ENV{'SYMPA_ROBOT'};
+    my $robot  = $ENV{SYMPA_DOMAIN};
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -1025,8 +1026,6 @@ sub fullReview {
             ->faultstring('Incorrect number of parameters')
             ->faultdetail('Use : <list>');
     }
-
-    $log->syslog('debug', '(%s, %s)', $listname, $robot);
 
     my $list = Sympa::List->new($listname, $robot);
     unless ($list) {
@@ -1084,20 +1083,21 @@ sub fullReview {
 
     my @result;
     foreach my $email (keys %$members) {
-        push @result, struct_to_soap($members->{$email});
+        push @result, _struct_to_soap($members->{$email});
     }
 
     $log->syslog('info', 'FullReview %s from %s accepted', $listname,
         $sender);
-    return SOAP::Data->name('return')->value(\@result);
+    return Sympa::WWW::SOAP::Data->name('return')->value(\@result);
 }
 
 sub signoff {
+    @_ = _map_encode_utf8(@_);
     $log->syslog('notice', '(%s, %s)', @_);
     my ($class, $listname) = @_;
 
     my $sender = $ENV{'USER_EMAIL'};
-    my $robot  = $ENV{'SYMPA_ROBOT'};
+    my $robot  = $ENV{SYMPA_DOMAIN};
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -1133,7 +1133,7 @@ sub signoff {
     }
 
     foreach my $report (@{$spindle->{stash} || []}) {
-        my $reason_string = get_reason_string($report, $robot);
+        my $reason_string = _get_reason_string($report, $robot);
         if ($report->[1] eq 'auth') {
             die SOAP::Fault->faultcode('Server')->faultstring('Not allowed.')
                 ->faultdetail($reason_string);
@@ -1141,21 +1141,25 @@ sub signoff {
             die SOAP::Fault->faultcode('Server')
                 ->faultstring('Internal error');
         } elsif ($report->[1] eq 'notice') {
-            return SOAP::Data->name('result')->type('boolean')->value(1);
+            return Sympa::WWW::SOAP::Data->name('result')->type('boolean')
+                ->value(1);
         } elsif ($report->[1] eq 'user') {
             die SOAP::Fault->faultcode('Server')->faultstring('Undef')
                 ->faultdetail($reason_string);
         }
     }
-    return SOAP::Data->name('result')->type('boolean')->value(1);
+    return Sympa::WWW::SOAP::Data->name('result')->type('boolean')->value(1);
 }
 
 sub subscribe {
+    @_ = _map_encode_utf8(@_);
     $log->syslog('notice', '(%s, %s, %s)', @_);
-    my ($class, $listname, $gecos) = @_;
+    my $class    = shift;
+    my $listname = shift;
+    my $gecos    = shift;
 
     my $sender = $ENV{'USER_EMAIL'};
-    my $robot  = $ENV{'SYMPA_ROBOT'};
+    my $robot  = $ENV{SYMPA_DOMAIN};
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -1193,7 +1197,7 @@ sub subscribe {
     }
 
     foreach my $report (@{$spindle->{stash} || []}) {
-        my $reason_string = get_reason_string($report, $robot);
+        my $reason_string = _get_reason_string($report, $robot);
         if ($report->[1] eq 'auth') {
             die SOAP::Fault->faultcode('Server')->faultstring('Not allowed.')
                 ->faultdetail($reason_string);
@@ -1201,31 +1205,33 @@ sub subscribe {
             die SOAP::Fault->faultcode('Server')
                 ->faultstring('Internal error');
         } elsif ($report->[1] eq 'notice') {
-            return SOAP::Data->name('result')->type('boolean')->value(1);
+            return Sympa::WWW::SOAP::Data->name('result')->type('boolean')
+                ->value(1);
         } elsif ($report->[1] eq 'user') {
             die SOAP::Fault->faultcode('Server')->faultstring('Undef')
                 ->faultdetail($reason_string);
         }
     }
-    return SOAP::Data->name('result')->type('boolean')->value(1);
+    return Sympa::WWW::SOAP::Data->name('result')->type('boolean')->value(1);
 }
 
 ## Which list the user is subscribed to
 ## TODO (pour listmaster, toutes les listes)
 sub complexWhich {
+    $log->syslog('notice', '(%s)', @_);
     my $self   = shift;
     my $sender = $ENV{'USER_EMAIL'};
-    $log->syslog('notice', 'Xx complexWhich(%s)', $sender);
 
     $self->which('complex');
 }
 
 sub complexLists {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('notice', '(%s, %s, %s)', @_);
     my $self     = shift;
     my $topic    = shift || '';
     my $subtopic = shift || '';
     my $sender   = $ENV{'USER_EMAIL'};
-    $log->syslog('notice', '(%s)', $sender);
 
     $self->lists($topic, $subtopic, 'complex');
 }
@@ -1234,14 +1240,14 @@ sub complexLists {
 ## TODO (pour listmaster, toutes les listes)
 ## Simplified return structure
 sub which {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('notice', '(%s, %s)', @_);
     my $self = shift;
     my $mode = shift // '';
     my @result;
 
     my $sender = $ENV{'USER_EMAIL'};
-    my $robot  = $ENV{'SYMPA_ROBOT'};
-
-    $log->syslog('notice', '(%s, %s)', $sender, $mode);
+    my $robot  = $ENV{SYMPA_DOMAIN};
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -1312,27 +1318,30 @@ sub which {
 
         my $listInfo;
         if ($mode eq 'complex') {
-            $listInfo = struct_to_soap($result_item);
+            $listInfo = _struct_to_soap($result_item);
         } else {
-            $listInfo = struct_to_soap($result_item, 'as_string');
+            $listInfo = _struct_to_soap($result_item, 'as_string');
         }
         push @result, $listInfo;
     }
 
-#    return SOAP::Data->name('return')->type->('ArrayOfString')
+#    return Sympa::WWW::SOAP::Data->name('return')->type->('ArrayOfString')
 #    ->value(\@result);
-    return SOAP::Data->name('return')->value(\@result);
+    return Sympa::WWW::SOAP::Data->name('return')->value(\@result);
 }
 
 sub getDetails {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('debug', '(%s, %s)', @_);
     my $class    = shift;
     my $listname = shift;
+
+    my $sender = $ENV{'USER_EMAIL'};
+    my $robot  = $ENV{SYMPA_DOMAIN};
+
     my $subscriber;
     my $list;
     my %result = ();
-
-    my $sender = $ENV{'USER_EMAIL'};
-    my $robot  = $ENV{'SYMPA_ROBOT'};
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -1345,9 +1354,6 @@ sub getDetails {
             ->faultstring('Incorrect number of parameters')
             ->faultdetail('Use : <list>');
     }
-
-    $log->syslog('debug', 'SOAP getDetails(%s,%s,%s)',
-        $listname, $robot, $sender);
 
     $list = Sympa::List->new($listname, $robot);
     if (!$list) {
@@ -1376,17 +1382,19 @@ sub getDetails {
             ->faultdetail('Use : <list>');
     }
 
-    return SOAP::Data->name('return')->value(\%result);
+    return Sympa::WWW::SOAP::Data->name('return')->value(\%result);
 }
 
 sub setDetails {
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('debug', '(%s, %s, %s, %s)', @_);
     my $class     = shift;
     my $listname  = shift;
     my $gecos     = shift;
     my $reception = shift;
 
     my $sender = $ENV{'USER_EMAIL'};
-    my $robot  = $ENV{'SYMPA_ROBOT'};
+    my $robot  = $ENV{SYMPA_DOMAIN};
 
     my $subscriber;
     my $list;
@@ -1406,8 +1414,6 @@ sub setDetails {
             'Use : <list> <gecos> <reception> [ <key> <value> ] ...');
     }
 
-    $log->syslog('debug', 'SOAP setDetails(%s,%s,%s)',
-        $listname, $robot, $sender);
     $list = Sympa::List->new($listname, $robot);
     if (!$list) {
         die SOAP::Fault->faultcode('Client')
@@ -1450,18 +1456,24 @@ sub setDetails {
         ->faultdetail("SOAP setDetails : update user failed")
         unless $list->update_list_member($sender, %user);
 
-    return SOAP::Data->name('result')->type('boolean')->value(1);
+    return Sympa::WWW::SOAP::Data->name('result')->type('boolean')->value(1);
 }
 
 sub setCustom {
-    my ($class, $listname, $key, $value) = @_;
+    @_ = _map_encode_utf8(@_);
+    $log->syslog('debug', '(%s, %s, %s, %s)', @_);
+    my $class    = shift;
+    my $listname = shift;
+    my $key      = shift;
+    my $value    = shift;
+
+    my $sender = $ENV{'USER_EMAIL'};
+    my $robot  = $ENV{SYMPA_DOMAIN};
+
     my $subscriber;
     my $list;
     my $rv;
     my %newcustom;
-
-    my $sender = $ENV{'USER_EMAIL'};
-    my $robot  = $ENV{'SYMPA_ROBOT'};
 
     unless ($sender) {
         die SOAP::Fault->faultcode('Client')
@@ -1474,9 +1486,6 @@ sub setCustom {
             ->faultstring('Incorrect number of parameters')
             ->faultdetail('Use : <list> <key> <value>');
     }
-
-    $log->syslog('debug', 'SOAP setCustom(%s,%s,%s,%s)',
-        $listname, $robot, $sender, $key);
 
     $list = Sympa::List->new($listname, $robot);
     if (!$list) {
@@ -1492,10 +1501,6 @@ sub setCustom {
     }
     %newcustom = %{$subscriber->{attrib} // {}};
 
-    # Workaround for possible bug in SOAP::Lite.
-    Encode::_utf8_off($key);
-    Encode::_utf8_off($value);
-
     unless (length($value // '')) {
         delete $newcustom{$key};
     } else {
@@ -1506,12 +1511,12 @@ sub setCustom {
         ->faultdetail("SOAP setCustom : update user failed")
         unless $list->update_list_member($sender, attrib => \%newcustom);
 
-    return SOAP::Data->name('result')->type('boolean')->value(1);
+    return Sympa::WWW::SOAP::Data->name('result')->type('boolean')->value(1);
 }
 
 ## Return a structure in SOAP data format
 ## either flat (string) or structured (complexType)
-sub struct_to_soap {
+sub _struct_to_soap {
     my $data   = shift;
     my $format = shift // '';
 
@@ -1522,29 +1527,21 @@ sub struct_to_soap {
     }
 
     if ($format eq 'as_string') {
-        my @all;
-        my $formated_data;
-        foreach my $k (keys %$data) {
-            push @all, Encode::decode_utf8($k . '=' . $data->{$k});
-        }
-
-        $formated_data = join ';', @all;
-        $soap_data = SOAP::Data->type('string')->value($formated_data);
+        return Sympa::WWW::SOAP::Data->type('string')
+            ->value(join ';',
+            map { sprintf '%s=%s', $_, $data->{$_} } sort keys %$data);
     } else {
-        my $formated_data;
-        foreach my $k (keys %$data) {
-            $formated_data->{$k} =
-                SOAP::Data->name($k)->type($types{'listType'}{$k})
-                ->value($data->{$k});
-        }
-
-        $soap_data = SOAP::Data->value($formated_data);
+        return Sympa::WWW::SOAP::Data->value(
+            {   map {
+                    ($_ => Sympa::WWW::SOAP::Data->name($_)
+                            ->type($types{listType}{$_})->value($data->{$_}))
+                } keys %$data
+            }
+        );
     }
-
-    return $soap_data;
 }
 
-sub get_reason_string {
+sub _get_reason_string {
     my $report = shift;
     my $robot  = shift;
 
@@ -1572,3 +1569,5 @@ sub get_reason_string {
 }
 
 1;
+__END__
+

--- a/src/lib/Sympa/WWW/SOAP/FastCGI.pm
+++ b/src/lib/Sympa/WWW/SOAP/FastCGI.pm
@@ -25,7 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package Sympa::WWW::SOAP::Transport;
+package Sympa::WWW::SOAP::FastCGI;
 
 use strict;
 use warnings;
@@ -58,21 +58,21 @@ sub request {
 
     if (my $request = $_[0]) {
         # Select appropriate robot.
-        $ENV{'SYMPA_ROBOT'} =
+        $ENV{SYMPA_DOMAIN} =
             Sympa::WWW::Tools::get_robot('soap_url_local', 'soap_url');
 
         my $session;
         ## Existing session or new one
         if (Sympa::WWW::Session::get_session_cookie($ENV{'HTTP_COOKIE'})) {
             $session = Sympa::WWW::Session->new(
-                $ENV{'SYMPA_ROBOT'},
+                $ENV{SYMPA_DOMAIN},
                 {   'cookie' => Sympa::WWW::Session::get_session_cookie(
                         $ENV{'HTTP_COOKIE'}
                     )
                 }
             );
         } else {
-            $session = Sympa::WWW::Session->new($ENV{'SYMPA_ROBOT'}, {});
+            $session = Sympa::WWW::Session->new($ENV{SYMPA_DOMAIN}, {});
             $session->store() if (defined $session);
             ## Note that id_session changes each time it is saved in the DB
             $session->renew()
@@ -135,3 +135,41 @@ sub handle {
 }
 
 1;
+
+package Sympa::WWW::SOAP::Data;
+
+use Encode qw();
+use SOAP::Lite;
+
+# 'base' pragma doesn't work here
+our @ISA = qw(SOAP::Data);
+
+sub type {
+    my $self = shift;
+    if (@_) {
+        my ($type, @value) = @_;
+
+        if ($type eq 'string') {
+            return $self->SUPER::type($type,
+                map { Encode::is_utf8($_) ? $_ : Encode::decode_utf8($_) }
+                    @value);
+        }
+    }
+
+    return $self->SUPER::type(@_);
+}
+
+sub value {
+    my $self = shift;
+
+    if (($self->type // '') eq 'string') {
+        return $self->SUPER::value(
+            map { Encode::is_utf8($_) ? $_ : Encode::decode_utf8($_) } @_);
+    }
+
+    return $self->SUPER::value(@_);
+}
+
+1;
+__END__
+

--- a/src/lib/Sympa/WWW/SOAP/FastCGI.pm
+++ b/src/lib/Sympa/WWW/SOAP/FastCGI.pm
@@ -4,12 +4,8 @@
 #
 # Sympa - SYsteme de Multi-Postage Automatique
 #
-# Copyright (c) 1997, 1998, 1999 Institut Pasteur & Christophe Wolfhugel
-# Copyright (c) 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
-# 2006, 2007, 2008, 2009, 2010, 2011 Comite Reseau des Universites
-# Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017 GIP RENATER
-# Copyright 2017 The Sympa Community. See the AUTHORS.md file at the top-level
-# directory of this distribution and at
+# Copyright 2017, 2023 The Sympa Community. See the
+# AUTHORS.md file at the top-level directory of this distribution and at
 # <https://github.com/sympa-community/sympa.git>.
 #
 # This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Broken output with SOAP API due to mixture of byte- and utf8-strings.

This may fix #1541.
This also reverts a redundant fix which has been done at 39ddf25 (#1407).
