### PR TITLE
"warning: ignoring prerequisites on suffix rule definition" with GNU make 4.3

### DIFF
--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -67,7 +67,7 @@ sympa: sympa.in Makefile
 		< $(srcdir)/$@.in > $@
 	@chmod +x $@
 
-.servicein.service: Makefile
+.servicein.service:
 	@rm -f $@
 	$(AM_V_GEN)$(SED) \
 		-e 's|--USER--|$(USER)|' \
@@ -77,13 +77,13 @@ sympa: sympa.in Makefile
 		-e 's|--sbindir--|$(sbindir)|' \
 		< $(srcdir)/$@in > $@
 
-.socketin.socket: Makefile
+.socketin.socket:
 	@rm -f $@
 	$(AM_V_GEN)$(SED) \
 		-e 's|--piddir--|$(piddir)|' \
 		< $(srcdir)/$@in > $@
 
-.confin.conf: Makefile
+.confin.conf:
 	@rm -f $@
 	$(AM_V_GEN)$(SED) \
 		-e 's|--USER--|$(USER)|' \

--- a/src/libexec/Makefile.am
+++ b/src/libexec/Makefile.am
@@ -122,7 +122,7 @@ alias_manager.pl: $(srcdir)/alias_manager.pl.in
 ldap_alias_manager.pl: $(srcdir)/ldap_alias_manager.pl.in
 mysql_alias_manager.pl: $(srcdir)/mysql_alias_manager.pl.in
 
-.pl.8: Makefile
+.pl.8:
 	@rm -f $@
 	$(AM_V_GEN)$(POD2MAN) --section=8 --center="sympa $(VERSION)" \
 		--lax --release="$(VERSION)" $*.pl $@


### PR DESCRIPTION
<!--- ↑↑ Provide a general summary of the issue in the Title above ↑↑ -->

Version
-------
<!-- Versions of Sympa and related software -->
Maybe any, with GNU make 4.3

Installation method
-------------------
<!-- How you installed Sympa: deb, rpm, ports, ... or source package -->
Source.

Expected behavior
-----------------
<!--- Tell us what should happen -->
No warnings during `make` is running.

Actual behavior
---------------
<!--- Tell us what happens instead of the expected behavior -->
Warnings are shown:
``` code
...

Making all in libexec
make[2]: Entering directory '/.../.../src/libexec'
Makefile:961: warning: ignoring prerequisites on suffix rule definition

...

Making all in service
make[1]: Entering directory '/.../.../service'
Makefile:613: warning: ignoring prerequisites on suffix rule definition
Makefile:597: warning: ignoring prerequisites on suffix rule definition
Makefile:607: warning: ignoring prerequisites on suffix rule definition

...
```


Steps to reproduce
------------------
<!-- Actual steps that can reproduce the actual behavior -->
<!-- "I opened URL 'aaa', clicked 'bbb' button, ..." and so on -->
Extract the source, and then run:
``` bash
$ autoreconf -i
$ ./configure
$ make
```

Additional information
----------------------
<!-- You may also attach configuration files and/or logs -->
<!-- "selecting or pasting them" link below may be used -->
<!-- NOTE that you should not include sensitive information! -->
The [documentation of GNU make](https://www.gnu.org/software/make/manual/html_node/Error-Messages.html) says:
> ‘**warning: ignoring prerequisites on suffix rule definition**’
> 
> According to POSIX, a suffix rule cannot contain prerequisites. If a rule that could be a suffix rule has prerequisites it is interpreted as a simple explicit rule, with an odd target name. (...) In versions of GNU `make` prior to 4.3, no warning was emitted and a suffix rule was created, however all prerequisites were ignored and were not part of the suffix rule. Starting with GNU `make` 4.3 the behavior is the same, and in addition this warning is generated. In a future version the POSIX-conforming behavior will be the only behavior: no rule with a prerequisite can be suffix rule and this warning will be removed. 

