### PR TITLE
WWSympa: Invalid input on sso_login form floods listmaster notification (#1654)

### DIFF
--- a/default/mail_tt2/report.tt2
+++ b/default/mail_tt2/report.tt2
@@ -266,9 +266,6 @@
 [%~ ELSIF report_entry == 'auth_msg_failed' ~%]
   [%|loc(report_param.key)%]Unable to access the message authenticated with key %1[%END%]
 
-[%~ ELSIF report_entry == 'no_identified_user' ~%]
-  [%|loc%]Failed to get your email address from the authentication service.[%END%]
-
 [%~ ELSIF report_entry == 'db_error' ~%]
   [%|loc%]Database error.[%END%]
 
@@ -931,6 +928,9 @@ Warning: this message may already have been sent by one of the list's moderators
 
 [%~ ELSIF report_entry == 'cannot_get_privilege' ~%]
   [%|loc()%]You are not allowed to get the privilege of this user.[%END%]
+
+[%~ ELSIF report_entry == 'no_identified_user' ~%]
+  [%|loc%]Failed to get your email address from the authentication service.[%END%]
 
 [%~ END ~%]
 

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -3593,7 +3593,7 @@ sub do_sso_login {
         }
 
         unless ($email) {
-            add_stash('intern', 'no_identified_user');
+            add_stash('user', 'no_identified_user');
             wwslog(
                 'err',
                 'User could not be identified, no %s HTTP header set',


### PR DESCRIPTION
This may fix #1654 