### PR TITLE
In edit_list_request page, sort scenario on titles

### DIFF
--- a/default/web_tt2/config_common.tt2
+++ b/default/web_tt2/config_common.tt2
@@ -154,20 +154,22 @@
     [% IF pitem.privilege == 'write' ~%]
         <select name="single_param.[% ppaths.join('.') %].name"
                 id="param.[% ppaths.join('.') %]">
-            [% FOREACH scenario = pitem.format ~%]
-                <option value="[% scenario.value.name %]"
-                        [%~ IF scenario.value.name == val.name %] selected="selected"[% END %]>
-                    [%~ scenario.value.title %]
-                    [%~ IF is_listmaster %] ([% scenario.value.name %])[% END ~%]
+			[% SET all = pitem.format.values %]
+            [% FOREACH scenario = all.sort('title') ~%]
+                <option value="[% scenario.name %]"
+                        [%~ IF scenario.name == val.name %] selected="selected"[% END %]>
+                    [%~ scenario.title %]
+                    [%~ IF is_listmaster %] ([% scenario.name %])[% END ~%]
                 </option>
             [% END %]
         </select>
     [%~ ELSE ~%]
-        [% FOREACH scenario = pitem.format ~%]
-            [% IF scenario.value.name == val.name ~%]
-                [% scenario.value.title %]
+		[% SET all = pitem.format.values %]
+        [% FOREACH scenario = all.sort('title') ~%]
+            [% IF scenario.name == val.name ~%]
+                [% scenario.title %]
                 [%~ IF is_listmaster %]
-                    ([% scenario.value.name %])
+                    ([% scenario.name %])
                 [% END %]
             [%~ END %]
         [%~ END %]


### PR DESCRIPTION
Currently scenario in edit_list_request pages are sorted on scenario filenames.
As reported in https://lists.sympa.community/msg/fr/2023-04/1TZ5Q-_qRxSqJkG0zscNjQ, it would make sense to sort them on scenario titles.

This PR does the sort in TT2 file