### PR TITLE
Lower the list of months in the calendar and allow it scrolling

### DIFF
--- a/default/web_tt2/css.tt2
+++ b/default/web_tt2/css.tt2
@@ -1431,6 +1431,11 @@ span.divider{
 }
 
 /* Calendar in mhonarc_rc.tt2 */
+#ArcCalendar {
+    overflow-y: auto;
+    max-height: 9em;
+}
+
 ul.calendar {
     margin-left:0!important;
     padding-left:0!important;

--- a/www/js/sympa.js
+++ b/www/js/sympa.js
@@ -359,3 +359,15 @@ $(function(){
     });
 });
 
+/* Align the scrollable calendar. */
+$(function() {
+    $('.calendarLinksCurrentPage').each(function(){
+        var curmonth = $(this);
+        var container = $('#ArcCalendar');
+
+        container.scrollTop(
+            curmonth.position().top - container.position().top -
+            (container.height() - curmonth.height()) / 2);
+    });
+});
+


### PR DESCRIPTION
Lists that have been in operation for many years hide posts in archives with the list of months. This PR solves this problem.
![image](https://github.com/sympa-community/sympa/assets/5743546/80eca367-d259-4d67-b34c-7a6949ae5b6f)
