### PR TITLE
Conform some fields in HTTP responses to current standards

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -2275,10 +2275,11 @@ sub check_action_parameters {
 sub send_html {
     my $tt2_file = shift;
 
-    ## Send HTML headers
+    # Send HTTP header
+
     printf "Date: %s\n", DateTime->now->strftime("%a, %d %b %Y %H:%M:%S GMT");
-    ## If we set the header indicating the last time the file to send was
-    ## modified, add an HTTP header (limitate web harvesting).
+    # If we indicate the last time the file to send was modified, add it
+    # as an HTTP header field to limitate web harvesting.
     if ($param->{'header_date'}) {
         printf "Last-Modified: %s\n",
             DateTime->from_epoch(epoch => $param->{'header_date'})

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -2289,8 +2289,8 @@ sub send_html {
     print "Cache-Control: no-store, max-age=0\n"
         unless $param->{'action'} eq 'arc';
     print "Content-Type: text/html; charset=utf-8\n";
-    ## Workaround for Internet Explorer 8 or later.
-    print "X-UA-Compatible: IE=100\n";
+    # No longer needed: Workaround for Internet Explorer 8 or later.
+    #print "X-UA-Compatible: IE=100\n";
 
     ## Notify crash to client.
     if ($param->{'action'} eq 'crash') {

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -2287,7 +2287,10 @@ sub send_html {
             DateTime->from_epoch(epoch => $param->{'header_date'})
             ->strftime("%a, %{day} %b %Y %H:%M:%S GMT");
     }
-    print "Cache-control: max-age=0\n" unless $param->{'action'} eq 'arc';
+    # Prevent caching responses except archives.
+    # "max-age=0" is a workaround for very old HTTP/1.0 proxies.
+    print "Cache-Control: no-store, max-age=0\n"
+        unless $param->{'action'} eq 'arc';
     print "Content-Type: text/html; charset=utf-8\n";
     ## Workaround for Internet Explorer 8 or later.
     print "X-UA-Compatible: IE=100\n";

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -2276,16 +2276,13 @@ sub send_html {
     my $tt2_file = shift;
 
     ## Send HTML headers
-    if ($param->{'date'}) {
-        printf "Date: %s\n",
-            DateTime->now->strftime("%a, %{day} %b %Y %H:%M:%S GMT");
-    }
+    printf "Date: %s\n", DateTime->now->strftime("%a, %d %b %Y %H:%M:%S GMT");
     ## If we set the header indicating the last time the file to send was
     ## modified, add an HTTP header (limitate web harvesting).
     if ($param->{'header_date'}) {
         printf "Last-Modified: %s\n",
             DateTime->from_epoch(epoch => $param->{'header_date'})
-            ->strftime("%a, %{day} %b %Y %H:%M:%S GMT");
+            ->strftime("%a, %d %b %Y %H:%M:%S GMT");
     }
     # Prevent caching responses except archives.
     # "max-age=0" is a workaround for very old HTTP/1.0 proxies.


### PR DESCRIPTION
* `no-store` is recommended for `Cache-Control` response field
* Use HTTP-date recommended by RFC 7231 in HTTP header
* Obsolete `X-UA-Compatible` field, workaround for Internet Explorer 8 or later
