### PR TITLE
🐛 — Fix error when rejecting message from direct URL

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -7578,6 +7578,9 @@ sub do_reject {
         if (($in{'quiet'} ne '1') || ($in{'blocklist'})) {
             my $rejected_sender = $message->{'sender'};
             if ($rejected_sender) {
+                unless ($in{'message_template'}) {
+                    $in{'message_template'} = 'reject';
+                }
                 unless ($in{'message_template'} eq 'reject_quiet') {
                     my %context;
                     $context{'subject'}       = $message->{'decoded_subject'};


### PR DESCRIPTION
When using the reject URL sent in the moderation notification mail, there is no message_template argument, creating an error. This commit adds a default value for the argument.

The reject URL is like `https://example.org/sympa/reject/the_list/token_created_by_sympa`.

The error was
```
DIED: Parameter $tpl is not defined at /var/sympa/share/sympa/lib/Sympa/Message/Template.pm line 64.
```

And a stacktrace, leading me to the FCGI script.