### PR TITLE
🐛 — [moderation] Show message content when clicking on its object

### DIFF
--- a/default/web_tt2/modindex.tt2
+++ b/default/web_tt2/modindex.tt2
@@ -67,11 +67,15 @@
                         [%~ END %]
                     </div>
                     <div class="small-6 medium-3 columns" role="cell">
+                        <a href="[% 'ajax/viewmod' | url_rel([list,msg.key]) %]"
+                           data-reveal-id="mainviewmod" data-reveal-ajax="true"
+                           data-tooltip aria-haspopup="true"
                         [% UNLESS msg.value.subject.length ~%]
                             <i>[%|loc%]No subject[%END%]</i>
                         [%~ ELSE ~%]
                             [% msg.value.subject %]
                         [%~ END %]
+                        </a>
                     </div>
                     <div class="small-11 medium-2 columns" role="cell">
                         [% UNLESS msg.value.date ~%]


### PR DESCRIPTION
The moderation help said "To read a message, click on its subject", but it wasn’t true, you needed to click on the eye icon. The eye icon it quite counter-intuitive, people has the reflex to click on the subject of the mail to see it, like on mail clients.

It sounded better to me to make the interface like the documentation instead of modifying the documentation.