### PR TITLE
Can't locate object method "new" via package "Sympa::Aliases" (#1710)

### DIFF
--- a/src/lib/Sympa/Request/Handler/update_automatic_list.pm
+++ b/src/lib/Sympa/Request/Handler/update_automatic_list.pm
@@ -29,6 +29,7 @@ use English qw(-no_match_vars);
 use File::Copy qw();
 
 use Sympa;
+use Sympa::Aliases;
 use Conf;
 use Sympa::Config_XML;
 use Sympa::List;


### PR DESCRIPTION
This may fix #1710.