### PR TITLE
Inclusion from LDAP data sources supports RFC 2696 Paged Results control (#57)

### DIFF
--- a/src/lib/Sympa/Config/Schema.pm
+++ b/src/lib/Sympa/Config/Schema.pm
@@ -3466,6 +3466,15 @@ our %pinfo = (
                 format_s   => '$time_ranges',
                 occurrence => '0-1',
                 not_before => '6.2a.16',
+            },
+            pagesize => {
+                context      => [qw(list)],
+                order        => 12,
+                gettext_comment =>
+                    'Number of records to fetch per page, for a LDAP server that supports paging. If not set or set to zero, do not use paging. Typically 1000 for an Active Directory server, to avoid "SizeLimit" errors if there are more than 1000 records',
+                gettext_id   => "Page size",
+                format       => '\d*',
+                length       => 6,
             }
         },
         occurrence => '0-n'

--- a/src/lib/Sympa/Config/Schema.pm
+++ b/src/lib/Sympa/Config/Schema.pm
@@ -3471,11 +3471,11 @@ our %pinfo = (
                 context      => [qw(list)],
                 order        => 12,
                 gettext_comment =>
-                    'Number of records to fetch per page, for a LDAP server that supports paging. If not set or set to zero, do not use paging. Typically 1000 for an Active Directory server, to avoid "SizeLimit" errors if there are more than 1000 records',
+                    'Number of records to fetch per batch (paging), for a LDAP server that supports paging. If not set or set to zero, do not use paging. Typically 1000 for an Active Directory server, to avoid "SizeLimit" errors',
                 gettext_id   => "Page size",
                 format       => '\d*',
                 length       => 6,
-            }
+            },
         },
         occurrence => '0-n'
     },
@@ -3700,7 +3700,16 @@ our %pinfo = (
                 format_s   => '$time_ranges',
                 occurrence => '0-1',
                 not_before => '6.2a.16',
-            }
+            },
+            pagesize => {
+                context      => [qw(list)],
+                order        => 12,
+                gettext_comment =>
+                    'Number of records to fetch per batch (paging), for a LDAP server that supports paging. If not set or set to zero, do not use paging. Typically 1000 for an Active Directory server, to avoid "SizeLimit" errors',
+                gettext_id   => "Page size",
+                format       => '\d*',
+                length       => 6,
+            },
         },
         occurrence => '0-n'
     },

--- a/src/lib/Sympa/DataSource/LDAP.pm
+++ b/src/lib/Sympa/DataSource/LDAP.pm
@@ -45,10 +45,11 @@ sub _open {
     return undef unless $db and $db->connect;
     $self->{_db} = $db;
 
-    if ($db->__dbh->root_dse->supported_control(
+    my $pagesize = $options{pagesize} || $self->{pagesize};
+    if ($pagesize and $db->__dbh->root_dse->supported_control(
             Net::LDAP::Constant::LDAP_CONTROL_PAGED()
         )) {
-        $self->{_page} = Net::LDAP::Control::Paged->new( size => 1000 );
+        $self->{_page} = Net::LDAP::Control::Paged->new( size => $pagesize );
     }
 
     my $mesg = $self->_open_operation(%options);

--- a/src/lib/Sympa/DataSource/LDAP.pm
+++ b/src/lib/Sympa/DataSource/LDAP.pm
@@ -78,6 +78,11 @@ sub _open_operation {
 
     my $mesg = $self->{_db}->do_operation('search', @args);
 
+    if ($self->{_page} and $mesg) {
+        my $cookie = $mesg->control( LDAP_CONTROL_PAGED )->cookie;
+        $self->{_page}->cookie( $cookie );
+    }
+
     unless ($mesg) {
         $log->syslog(
             'err',
@@ -172,11 +177,6 @@ sub _load_next {
 
             last if $ldap_select eq 'first';
         }
-    }
-
-    if ($self->{_page}) {
-        my $cookie = $mesg->control( LDAP_CONTROL_PAGED )->cookie;
-        $self->{_page}->cookie( $cookie );
     }
 
     return [@retrieved];

--- a/src/lib/Sympa/DataSource/LDAP.pm
+++ b/src/lib/Sympa/DataSource/LDAP.pm
@@ -90,7 +90,7 @@ sub _open_operation {
         if ($self->{_page}) {
             # We had an abnormal exit, so let the server know we do not want any more
             $self->{_page}->size(0);
-            $self->do_operation('search', @args);
+            $self->{_db}->do_operation('search', @args);
         }
 
         return undef;

--- a/src/lib/Sympa/DataSource/LDAP.pm
+++ b/src/lib/Sympa/DataSource/LDAP.pm
@@ -80,13 +80,6 @@ sub _open_operation {
 
     my $mesg = $self->{_db}->do_operation('search', @args);
 
-    if ($self->{_page} and $mesg) {
-        my $cookie = $mesg->control(
-            Net::LDAP::Constant::LDAP_CONTROL_PAGED
-        )->cookie;
-        $self->{_page}->cookie( $cookie );
-    }
-
     unless ($mesg) {
         $log->syslog(
             'err',
@@ -184,6 +177,13 @@ sub _load_next {
 
             last if $ldap_select eq 'first';
         }
+    }
+
+    if ($self->{_page} and $mesg) {
+        my $cookie = $mesg->control(
+            Net::LDAP::Constant::LDAP_CONTROL_PAGED
+        )->cookie;
+        $self->{_page}->cookie( $cookie );
     }
 
     return [@retrieved];

--- a/src/lib/Sympa/DataSource/LDAP.pm
+++ b/src/lib/Sympa/DataSource/LDAP.pm
@@ -46,7 +46,9 @@ sub _open {
     return undef unless $db and $db->connect;
     $self->{_db} = $db;
 
-    $self->{_page} = Net::LDAP::Control::Paged->new( size => 1000 );
+    if ($db->__dbh->root_dse->supported_control(LDAP_CONTROL_PAGED)) {
+        $self->{_page} = Net::LDAP::Control::Paged->new( size => 1000 );
+    }
 
     my $mesg = $self->_open_operation(%options);
     return undef unless $mesg;
@@ -164,8 +166,8 @@ sub _load_next {
     }
 
     if ($self->{_page}) {
-        my( $response ) = $mesg->control( LDAP_CONTROL_PAGED ) or undef;
-        my $cookie = $response->cookie or undef;
+        my( $response ) = $mesg->control( LDAP_CONTROL_PAGED );
+        my $cookie = $response->cookie;
 
         $self->{_page}->cookie( $cookie );
     }

--- a/src/lib/Sympa/DataSource/LDAP2.pm
+++ b/src/lib/Sympa/DataSource/LDAP2.pm
@@ -49,15 +49,22 @@ sub _open {
     my @values;
     while (
         my $entry = $self->SUPER::_next(
-            attrs  => $self->{attrs1},
-            select => $self->{select1},
-            regex  => $self->{regex1},
-            turn   => 'first'
+            filter  => $self->{filter1},
+            attrs   => $self->{attrs1},
+            select  => $self->{select1},
+            regex   => $self->{regex1},
+            timeout => $self->{timeout1},
+            suffix  => $self->{suffix1},
+            scope   => $self->{scope1},
+            turn    => 'first'
         )
     ) {
         push @values, $entry->[0] if defined $entry->[0];
     }
     $self->{_attr1values} = [@values];
+
+    # Don't paginate subsequent children searches, they return only one record
+    $self->{_page} = undef;
 
     return 1;
 }


### PR DESCRIPTION
Fix for #57

It includes a new configuration setting "page size" that's used both to enable paging, and to define the page size. I tried to integrate a description in the setting, as I think it's good to keep the documentation in/next to the functionality, but I'd suppose that the description/documentation can be improved, feedback really welcome on this.

Now, The code for the LDAP data sources is quite convoluted, difficult to read, etc... It took me a looong time to understand that "two-level" was practically working out of the box once I had implemented "one-level", LOL). I've the feeling that it could be simplified. I've entered a different ticket on this: #1738 , as this is clearly not part of #57 . 