### PR TITLE
Upgrade command should fail if no previuos version number can be found.

### DIFF
--- a/src/lib/Sympa/CLI/upgrade.pm
+++ b/src/lib/Sympa/CLI/upgrade.pm
@@ -57,7 +57,10 @@ sub _upgrade {
     $options->{from} ||= Sympa::Upgrade::get_previous_version();
     $options->{to}   ||= Sympa::Constants::VERSION;
 
-    if ($options->{from} eq $options->{to}) {
+    if (!defined $options->{from}) {
+        $log->syslog('err', 'No previous version specified');
+        exit 1;
+    } elsif ($options->{from} eq $options->{to}) {
         $log->syslog('notice', 'Current version: %s; no upgrade is required',
             $options->{to});
         exit 0;


### PR DESCRIPTION
Currently the `sympa upgrade` cli command when not given an explicit previous version via the from parameter checks the file data_structure.version in the config directory. But instead of stopping if this also doesn't exist it assumes the previous version to be zero an consequently tries to apply all data upgrades. This patch just lets upgrade err on the safe side. If the previous behavior is needed passing along a `--from 0` should suffice.