### PR TITLE
♿ — WWSympa: The items in the multiselect box are not readable fully (#1752)

### DIFF
--- a/default/web_tt2/css.tt2
+++ b/default/web_tt2/css.tt2
@@ -2113,4 +2113,11 @@ a, li {
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
+[%# Accessibility %]
+[%# See https://github.com/sympa-community/sympa/issues/1752 %]
+select[multiple] option {
+    overflow-x: scroll;
+}
+[%# End Accessibility %]
+
 [%# end css.tt2 %]


### PR DESCRIPTION
I asked a friend who worked in web accessibility about [my solution](https://github.com/sympa-community/sympa/issues/1752#issuecomment-1833384255) and he said it was quite the best you can do about this specific problem.