### PR TITLE
Fix cross-robot list inclusion (#1797)

### DIFF
--- a/src/lib/Sympa/DataSource/List.pm
+++ b/src/lib/Sympa/DataSource/List.pm
@@ -45,7 +45,8 @@ sub _new {
 
     my $list = $self->{context};
     if (ref $list eq 'Sympa::List') {
-        my $inlist = Sympa::List->new($self->{listname}, $list->{'domain'},
+        my $inlist = Sympa::List->new($self->{listname},
+            ($self->{listname} =~ /\@/ ? undef : $list->{'domain'}),
             {just_try => 1});
         $self->{listname} = $inlist->get_id if $inlist;
     }


### PR DESCRIPTION
If the Sympa::List->new($name, $robot, $options) constructor is called with an optional $robot parameter specified, then that $robot overrides any domain that may be present in $name.  When constructing a DataSource for inclusion, the robot of the DataSource should be inferred only if no domain is present in the list name.