### PR TITLE
Stop "do_distribute" actions from Web interface from generating backscatter emails to sympa-request alias (#1737)

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -7732,6 +7732,10 @@ sub do_distribute {
         $spool_mod->remove($handle, action => 'distribute');
     }
 
+    # Don't need to do anything if all messages were filtered out
+    # by the "already_moderated" clause above.
+    return 'modindex' if (@mail_command == 0);
+    
     # Commands are injected into incoming spool directly with "md5"
     # authentication level.
     my $cmd_message = Sympa::Message->new(


### PR DESCRIPTION
One line patch to stop "No command found in message" emails to sympa-request  when multiple list moderators try to approve the same message.