### PR TITLE
CLI: With `sympa config key=value`, key couldn't contain dot

### DIFF
--- a/src/lib/Sympa/CLI.pm
+++ b/src/lib/Sympa/CLI.pm
@@ -186,7 +186,7 @@ sub run {
                         $val = $arg;
                     }
                 } elsif ($def eq 'keyvalue') {
-                    if ($arg =~ /\A(\w+)=(.*)\z/) {
+                    if ($arg =~ /\A(\w+(?:[.]\w+)*)=(.*)\z/) {
                         $val = [$1 => $2];
                     }
                 } else {


### PR DESCRIPTION
For example,
```
sympa config dmarc_protection.mode="dmarc_reject" 
```
was rejected due to `Invalid argument 'dmarc_protection.mode=dmarc_reject' ("key=value" is expected)`.

This PR may fix it.
