### PR TITLE
Prevent custom_header with non-ASCII characters (#1840)

### DIFF
--- a/src/lib/Sympa/Config/Schema.pm
+++ b/src/lib/Sympa/Config/Schema.pm
@@ -1201,7 +1201,7 @@ our %pinfo = (
         gettext_id => "Custom header field",
         gettext_comment =>
             'This parameter is optional. The headers specified will be added to the headers of messages distributed via the list. As of release 1.2.2 of Sympa, it is possible to put several custom header lines in the configuration file at the same time.',
-        format     => '\S+:\s+.*',
+        format_s   => '$header_field_name:.+',
         occurrence => '0-n',
         length     => 30
     },
@@ -1353,7 +1353,7 @@ our %pinfo = (
             'Header fields to be removed before message distribution',
         gettext_comment =>
             "The removal happens after Sympa's own header fields are added; therefore, it is a convenient way to remove Sympa's own header fields (like \"X-Loop:\" or \"X-no-archive:\") if you wish.",
-        format     => '\S+',
+        format_s   => '$header_field_name(:.+)?',
         default    => 'none',
         sample     => 'X-no-archive',
         occurrence => '0-n',

--- a/src/lib/Sympa/Regexps.pm
+++ b/src/lib/Sympa/Regexps.pm
@@ -47,6 +47,8 @@ use constant email =>
 use constant family_name => qr'[a-z0-9][a-z0-9\-\.\+_]*';
 ## Allow \s for template names
 use constant template_name => qr'[a-zA-Z0-9][a-zA-Z0-9\-\.\+_\s]*';
+# cf. RFC5322, 2.2.
+use constant header_field_name => qr'[!-9;-~]+';
 #FIXME: Not matching with IPv6 address.
 use constant host     => qr'[\w\.\-]+';
 use constant hostport => qr{(?:

--- a/src/lib/Sympa/Spindle/TransformOutgoing.pm
+++ b/src/lib/Sympa/Spindle/TransformOutgoing.pm
@@ -102,7 +102,7 @@ sub _twist {
 
     # Add custom header fields
     foreach my $i (@{$list->{'admin'}{'custom_header'}}) {
-        $message->add_header($1, $2) if $i =~ /^([\S\-\:]*)\s(.*)$/;
+        $message->add_header(split /\s*:\s*/, $i, 2) if 0 < index $i, ':';
     }
 
     ## Add RFC 2919 header field
@@ -143,7 +143,7 @@ sub _twist {
     ## Useful to remove some header fields that Sympa has set
     if ($list->{'admin'}{'remove_outgoing_headers'}) {
         foreach my $field (@{$list->{'admin'}{'remove_outgoing_headers'}}) {
-            my ($f, $v) = split /\s*:\s*/, $field;
+            my ($f, $v) = split /\s*:\s*/, $field, 2;
             if (defined $v) {
                 my @values = $message->get_header($f);
                 my $i;


### PR DESCRIPTION
The `custom_header` should not contain non-ASCII characters.
Additionally, some minor bugs are fixed.

This may fix #1840.

