### PR TITLE
Update de.po

### DIFF
--- a/po/sympa/de.po
+++ b/po/sympa/de.po
@@ -5605,14 +5605,14 @@ msgstr "Listen anzeigen, die %1 einbinden"
 
 #: default/web_tt2/admin.tt2:68 default/web_tt2/confirm_action.tt2:106
 msgid "Remove List"
-msgstr "Liste löschen"
+msgstr "Liste entfernen"
 
 #: default/web_tt2/admin.tt2:69
 msgid ""
 "Completely removes the current list. Listmaster privileges are required to "
 "restore a list once it has been removed."
 msgstr ""
-"Entfernt die aktuelle Liste vollständig. Es sind Listenadministrator-Rechte "
+"Entfernt die aktuelle Liste. Es sind Listenadministrator-Rechte "
 "erforderlich, um eine Liste wiederherzustellen."
 
 #: default/web_tt2/admin.tt2:77 default/web_tt2/confirm_action.tt2:238


### PR DESCRIPTION
"remove" was wrongly translated as "löschen", but that's "delete" - use correct translation "entfernen" instead