### PR TITLE
LDAP: Parameters interpolated in the LDAP filter should be escaped

### DIFF
--- a/doc/auth.conf.pod
+++ b/doc/auth.conf.pod
@@ -205,6 +205,36 @@ Search the whole tree below the base object. This is the default.
 
 =back
 
+=item C<deref>
+
+Default value: C<find>
+
+Specifies how to dereference aliases.
+
+Introduced on Sympa 6.2.74.
+
+=over
+
+=item C<never>
+
+Aliases are never dereferenced.
+
+=item C<search>
+
+Aliases are dereferenced in searching subordinates of the base object.
+
+=item C<find>
+
+Aliases are derefernced in locating the base object, but
+not in searching subordinates of the base object.
+This is the default.
+
+=item C<always>
+
+Aliases are always dereferenced.
+
+=back
+
 =item C<authentication_info_url>
 
 Defines the URL of a document describing LDAP password management. When 
@@ -385,31 +415,50 @@ not defined>:
 
 =over
 
-=item C<ldap_host>
+=item C<host>
 
-The LDAP host Sympa will connect to fetch user email. The C<ldap_host> 
+(formerly C<ldap_host>)
+
+The LDAP host Sympa will connect to fetch user email. The C<host> 
 include the port number and it may be a comma separated list of redundant
 hosts.
 
-=item C<ldap_bind_dn>
+=item C<bind_dn>
+
+(formerly C<ldap_bind_dn>)
 
 The DN used to bind to this server. Anonymous bind is used if this parameter 
 is not defined.
 
-=item C<ldap_bind_password>
+=item C<bind_password>
+
+(formerly C<ldap_bind_password>)
 
 The password used unless anonymous bind is used.
 
-=item C<ldap_suffix>
+=item C<suffix>
+
+(formerly C<ldap_suffix>)
 
 The LDAP suffix used when searching user email.
 
-=item C<ldap_scope>
+=item C<scope>
+
+(formerly C<ldap_scope>)
 
 The scope used when searching user email. Possible values are C<sub>, C<base> 
 and C<one>.
 
-=item C<ldap_get_email_by_uid_filter>
+=item C<deref>
+
+(introduced on 6.2.74)
+
+How to dereference the aliases on searching LDAP.
+Possible values are C<never>, C<search>, C<find> and C<always>.
+
+=item C<get_email_by_uid_filter>
+
+(formerly C<ldap_get_email_by_uid_filter>)
 
 The filter used to perform the email search. It can refer to any environment 
 variables inherited from the SSO module, as shown below.
@@ -418,12 +467,16 @@ Example:
 
   ldap_get_email_by_uid_filter (mail=[SSL_CLIENT_S_DN_Email])
 
-=item C<ldap_email_attribute>
+=item C<email_attribute>
+
+(formerly C<ldap_email_attribute>)
 
 The attribute name to be used as user canonical email. In the current version 
 of Sympa, only the first value returned by the LDAP server is used.
 
-=item C<ldap_timeout>
+=item C<timeout>
+
+(formerly C<ldap_timeout>)
 
 The time out for the search.
 
@@ -519,40 +572,62 @@ The proxy validate service path, only used by the Sympa SOAP server.
 
 =over
 
-=item C<ldap_host>
+=item C<host>
+
+(formerly C<ldap_host>)
 
 The LDAP host Sympa will connect to fetch user email when user uid is return 
 by CAS service. The C<ldap_host> includes the port number and it may be a 
 comma separated list of redundant hosts.
 
-=item C<ldap_bind_dn>
+=item C<bind_dn>
+
+(formerly C<ldap_bind_dn>)
 
 The DN used to bind to this server. Anonymous bind is used if this parameter 
 is not defined.
 
-=item C<ldap_bind_password>
+=item C<bind_password>
+
+(formerly C<ldap_bind_password>)
 
 The password used unless anonymous bind is used.
 
-=item C<ldap_suffix>
+=item C<suffix>
+
+(formerly C<ldap_suffix>)
 
 The LDAP suffix used when searching user email.
 
-=item C<ldap_scope>
+=item C<scope>
+
+(formerly C<ldap_scope>)
 
 The scope used when searching user email. Possible values are C<sub>, C<base> 
 and C<one>.
 
-=item C<ldap_get_email_by_uid_filter>
+=item C<deref>
+
+(introduced on 6.2.74)
+
+How to dereference the aliases on searching LDAP.
+
+=item C<get_email_by_uid_filter>
+
+(formerly C<ldap_get_email_by_uid_filter>)
 
 The filter used to perform the email search.
 
-=item C<ldap_email_attribute>
+=item C<email_attribute>
+
+(formerly C<ldap_email_attribute>)
 
 The attribute name to be used as user canonical email. In the current version 
 of Sympa, only the first value returned by the LDAP server is used.
 
-=item C<ldap_timeout>
+=item C<timeout>
+
+(formerly C<ldap_timeout>)
 
 The time out for the search.
 

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -3643,7 +3643,7 @@ sub is_ldap_user {
             Sympa::Tools::Text::valid_email($userid)
             ? $ldap->{get_dn_by_email_filter}
             : $ldap->{get_dn_by_uid_filter};
-        $filter =~ s/\[sender\]/$userid/ig;
+        $filter =~ s/\[sender\]/$db->quote($userid)/egi;
 
         my $mesg = $db->do_operation('search', filter => $filter);
 

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -3627,8 +3627,6 @@ sub is_ldap_user {
         return undef;
     }
 
-    my $filter;
-
     foreach my $ldap (@ldap_servers) {
         # skip ldap auth service if the user id or email do not match regexp
         # auth service parameter
@@ -3641,33 +3639,24 @@ sub is_ldap_user {
             next;
         }
 
-        if (Sympa::Tools::Text::valid_email($userid)) {
-            $filter = $ldap->{'get_dn_by_email_filter'};
-        } else {
-            $filter = $ldap->{'get_dn_by_uid_filter'};
-        }
+        my $filter =
+            Sympa::Tools::Text::valid_email($userid)
+            ? $ldap->{get_dn_by_email_filter}
+            : $ldap->{get_dn_by_uid_filter};
         $filter =~ s/\[sender\]/$userid/ig;
 
-        ## !! une fonction get_dn_by_email/uid
+        my $mesg = $db->do_operation('search', filter => $filter);
 
-        my $mesg = $db->do_operation(
-            'search',
-            base    => $ldap->{'suffix'},
-            filter  => "$filter",
-            scope   => $ldap->{'scope'},
-            deref   => $ldap->{'deref'},
-        );
-
-        unless ($mesg and $mesg->count()) {
+        unless ($mesg and $mesg->count) {
             wwslog('notice',
                 'No entry in the LDAP Directory Tree of %s for %s',
                 $ldap->{'host'}, $userid);
-            $db->disconnect();
-            last;
+            $db->disconnect;
+            return undef;
+        } else {
+            $db->disconnect;
+            return $ldap->{'authentication_info_url'} || 'none';
         }
-
-        $db->disconnect();
-        return $ldap->{'authentication_info_url'} || 'none';
     }
 
     return undef;

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -3657,6 +3657,7 @@ sub is_ldap_user {
             base    => $ldap->{'suffix'},
             filter  => "$filter",
             scope   => $ldap->{'scope'},
+            deref   => $ldap->{'deref'},
             timeout => $ldap->{'timeout'}
         );
 

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -3641,8 +3641,6 @@ sub is_ldap_user {
             next;
         }
 
-        my $attrs = $ldap->{'email_attribute'};
-
         if (Sympa::Tools::Text::valid_email($userid)) {
             $filter = $ldap->{'get_dn_by_email_filter'};
         } else {
@@ -3658,7 +3656,6 @@ sub is_ldap_user {
             filter  => "$filter",
             scope   => $ldap->{'scope'},
             deref   => $ldap->{'deref'},
-            timeout => $ldap->{'timeout'}
         );
 
         unless ($mesg and $mesg->count()) {

--- a/src/lib/Conf.pm
+++ b/src/lib/Conf.pm
@@ -685,12 +685,13 @@ sub _load_auth {
             'get_dn_by_uid_filter'   => '.+',
             'get_dn_by_email_filter' => '.+',
             'email_attribute'        => Sympa::Regexps::ldap_attrdesc(),
-            'alternative_email_attribute' => '.*',                 # Obsoleted
+            'alternative_email_attribute' => '.*',             # Obsoleted
             'scope'                       => 'base|one|sub',
-            'authentication_info_url'     => 'http(s)?:/.*',
-            'use_tls'                     => 'starttls|ldaps|none',
-            'use_ssl'                     => '1',                  # Obsoleted
-            'use_start_tls'               => '1',                  # Obsoleted
+            'deref'                   => 'never|search|find|always',
+            'authentication_info_url' => 'http(s)?:/.*',
+            'use_tls'                 => 'starttls|ldaps|none',
+            'use_ssl'       => '1',                            # Obsoleted
+            'use_start_tls' => '1',                            # Obsoleted
             'ssl_version' => 'sslv2/3|sslv2|sslv3|tlsv1|tlsv1_[123]',
             'ssl_ciphers' => '[\w:]+',
             'ssl_cert'    => '.+',
@@ -722,6 +723,7 @@ sub _load_auth {
             'timeout'       => '\d+',
             'suffix'        => '.+',
             'scope'         => 'base|one|sub',
+            'deref'         => 'never|search|find|always',
             'get_email_by_uid_filter' => '.+',
             'email_attribute'         => Sympa::Regexps::ldap_attrdesc(),
             'use_tls'                 => 'starttls|ldaps|none',
@@ -749,6 +751,7 @@ sub _load_auth {
             'timeout'       => '\d+',
             'suffix'        => '.+',
             'scope'         => 'base|one|sub',
+            'deref'         => 'never|search|find|always',
             'get_email_by_uid_filter' => '.+',
             'email_attribute'         => Sympa::Regexps::ldap_attrdesc(),
             'use_tls'                 => 'starttls|ldaps|none',
@@ -883,10 +886,12 @@ sub _load_auth {
                     ## Force the default scope because '' is interpreted as
                     ## 'base'
                     $current_paragraph->{'scope'} ||= 'sub';
+                    $current_paragraph->{'deref'} ||= 'find';
                 } elsif ($current_paragraph->{'auth_type'} eq 'generic_sso') {
                     ## Force the default scope because '' is interpreted as
                     ## 'base'
                     $current_paragraph->{'scope'} ||= 'sub';
+                    $current_paragraph->{'deref'} ||= 'find';
                     ## default value for http_header_value_separator is ';'
                     $current_paragraph->{'http_header_value_separator'} ||=
                         ';';
@@ -903,6 +908,7 @@ sub _load_auth {
                     ## Force the default scope because '' is interpreted as
                     ## 'base'
                     $current_paragraph->{'scope'} ||= 'sub';
+                    $current_paragraph->{'deref'} ||= 'find';
                 } elsif ($current_paragraph->{'auth_type'} eq 'user_table') {
                     ;
                 } elsif ($current_paragraph->{'auth_type'} eq 'cgi') {

--- a/src/lib/Sympa/CLI/test/ldap.pm
+++ b/src/lib/Sympa/CLI/test/ldap.pm
@@ -86,10 +86,7 @@ sub _run {
         or die sprintf "Connect impossible: %s\n", ($db->error || '');
     $mesg = $db->do_operation(
         'search',
-        base   => ($options->{suffix} // ''),
         filter => $filter,
-        scope  => ($options->{scope} || 'sub'),
-        deref  => ($options->{deref} || 'find'),
         attrs =>
             ($options->{attrs} ? [split /\s*,\s*/, $options->{attrs}] : ['']),
     ) or die sprintf "Search  impossible: %s\n", $db->error;

--- a/src/lib/Sympa/CLI/test/ldap.pm
+++ b/src/lib/Sympa/CLI/test/ldap.pm
@@ -89,6 +89,7 @@ sub _run {
         base   => ($options->{suffix} // ''),
         filter => $filter,
         scope  => ($options->{scope} || 'sub'),
+        deref  => ($options->{deref} || 'find'),
         attrs =>
             ($options->{attrs} ? [split /\s*,\s*/, $options->{attrs}] : ['']),
     ) or die sprintf "Search  impossible: %s\n", $db->error;

--- a/src/lib/Sympa/Config/Schema.pm
+++ b/src/lib/Sympa/Config/Schema.pm
@@ -348,7 +348,7 @@ our %pinfo = (
         gettext_id => 'Name of the database',
         gettext_comment =>
             "With SQLite, this must be the full path to database file.\nWith Oracle Database, this must be SID, net service name or easy connection identifier (to use net service name, db_host should be set to \"none\" and HOST, PORT and SERVICE_NAME should be defined in tnsnames.ora file).",
-        format => '.+',
+        format     => '.+',
         occurrence => '1',
     },
     db_user => {
@@ -1717,8 +1717,8 @@ our %pinfo = (
                 default    => 'owner',
             },
             quota => {
-                context => [qw(list domain site)],
-                order   => 3,
+                context      => [qw(list domain site)],
+                order        => 3,
                 gettext_id   => "quota",
                 gettext_unit => 'Kbytes',
                 format       => '\d+',
@@ -3418,6 +3418,15 @@ our %pinfo = (
                 occurrence => '1',
                 default    => 'sub'
             },
+            deref => {
+                context    => [qw(list)],
+                order      => 5.5,
+                gettext_id => "dereferencing aliases",
+                format     => ['never', 'search', 'find', 'always'],
+                occurrence => '1',
+                default    => 'find',
+                not_before => '6.2.74',
+            },
             timeout => {
                 context      => [qw(list)],
                 order        => 6,
@@ -3599,6 +3608,15 @@ our %pinfo = (
                 format     => ['base', 'one', 'sub'],
                 default    => 'sub'
             },
+            deref1 => {
+                context    => [qw(list)],
+                order      => 5.5,
+                gettext_id => "dereferencing aliases",
+                format     => ['never', 'search', 'find', 'always'],
+                occurrence => '1',
+                default    => 'find',
+                not_before => '6.2.74',
+            },
             timeout1 => {
                 context      => [qw(list)],
                 order        => 6,
@@ -3652,6 +3670,15 @@ our %pinfo = (
                 format     => ['base', 'one', 'sub'],
                 occurrence => '1',
                 default    => 'sub'
+            },
+            deref2 => {
+                context    => [qw(list)],
+                order      => 12.5,
+                gettext_id => "dereferencing aliases",
+                format     => ['never', 'search', 'find', 'always'],
+                occurrence => '1',
+                default    => 'find',
+                not_before => '6.2.74',
             },
             timeout2 => {
                 context      => [qw(list)],
@@ -3821,8 +3848,8 @@ our %pinfo = (
                 order   => 9,
                 gettext_id =>
                     "Directory where the database is stored (used for DBD::CSV only)",
-                format => '.+',
-                obsolete => 'db_name',
+                format    => '.+',
+                obsolete  => 'db_name',
                 not_after => '6.2.70',
             },
             nosync_time_ranges => {
@@ -3986,6 +4013,15 @@ our %pinfo = (
                 format     => ['base', 'one', 'sub'],
                 occurrence => '1',
                 default    => 'sub'
+            },
+            deref => {
+                context    => [qw(list)],
+                order      => 5.5,
+                gettext_id => "dereferencing aliases",
+                format     => ['never', 'search', 'find', 'always'],
+                occurrence => '1',
+                default    => 'find',
+                not_before => '6.2.74',
             },
             timeout => {
                 context      => [qw(list)],
@@ -4164,6 +4200,15 @@ our %pinfo = (
                 occurrence => '1',
                 default    => 'sub'
             },
+            deref1 => {
+                context    => [qw(list)],
+                order      => 5.5,
+                gettext_id => "dereferencing aliases",
+                format     => ['never', 'search', 'find', 'always'],
+                occurrence => '1',
+                default    => 'find',
+                not_before => '6.2.74',
+            },
             timeout1 => {
                 context      => [qw(list)],
                 order        => 6,
@@ -4217,6 +4262,15 @@ our %pinfo = (
                 format     => ['base', 'one', 'sub'],
                 occurrence => '1',
                 default    => 'sub'
+            },
+            deref2 => {
+                context    => [qw(list)],
+                order      => 12.5,
+                gettext_id => "dereferencing aliases",
+                format     => ['never', 'search', 'find', 'always'],
+                occurrence => '1',
+                default    => 'find',
+                not_before => '6.2.74',
             },
             timeout2 => {
                 context      => [qw(list)],
@@ -4381,8 +4435,8 @@ our %pinfo = (
                 order   => 9,
                 gettext_id =>
                     "Directory where the database is stored (used for DBD::CSV only)",
-                format => '.+',
-                obsolete => 'db_name',
+                format    => '.+',
+                obsolete  => 'db_name',
                 not_after => '6.2.70',
             },
             email_entry => {

--- a/src/lib/Sympa/DataSource/LDAP.pm
+++ b/src/lib/Sympa/DataSource/LDAP.pm
@@ -46,10 +46,12 @@ sub _open {
     $self->{_db} = $db;
 
     my $pagesize = $options{pagesize} || $self->{pagesize};
-    if ($pagesize and $db->__dbh->root_dse->supported_control(
+    if ($pagesize
+        and $db->__dbh->root_dse->supported_control(
             Net::LDAP::Constant::LDAP_CONTROL_PAGED()
-        )) {
-        $self->{_page} = Net::LDAP::Control::Paged->new( size => $pagesize );
+        )
+    ) {
+        $self->{_page} = Net::LDAP::Control::Paged->new(size => $pagesize);
     }
 
     my $mesg = $self->_open_operation(%options);
@@ -65,22 +67,8 @@ sub _open_operation {
     my $self    = shift;
     my %options = @_;
 
-    my $ldap_suffix = $options{suffix} || $self->{suffix};
-    my $ldap_filter = $options{filter} || $self->{filter};
-    my $ldap_attrs  = $options{attrs}  || $self->{attrs};
-    my $ldap_scope  = $options{scope}  || $self->{scope};
-    my $ldap_deref  = $options{deref}  || $self->{deref};
-
-    my @args = (
-        base    => $ldap_suffix,
-        filter  => $ldap_filter,
-        attrs   => [split /\s*,\s*/, $ldap_attrs],
-        scope   => $ldap_scope,
-        deref   => $ldap_deref,
-        control => $self->{_page} ? [$self->{_page}] : []
-    );
-
-    my $mesg = $self->{_db}->do_operation('search', @args);
+    my $mesg = $self->{_db}->do_operation('search', %options,
+        control => ($self->{_page} ? [$self->{_page}] : []));
 
     unless ($mesg) {
         $log->syslog(
@@ -92,7 +80,8 @@ sub _open_operation {
         if ($self->{_page}) {
             # We had an abnormal exit, so let the server know we do not want any more
             $self->{_page}->size(0);
-            $self->{_db}->do_operation('search', @args);
+            $self->{_db}->do_operation('search', %options,
+                control => [$self->{_page}]);
         }
 
         return undef;
@@ -135,8 +124,7 @@ sub _load_next {
         # second page, or later one (but not post-last) of a paged search:
         # load next page
         $mesg = $self->_open_operation(%options);
-    }
-    else {
+    } else {
         $mesg = $self->__dsh;
     }
     while (my $entry = $mesg->shift_entry) {
@@ -182,10 +170,9 @@ sub _load_next {
     }
 
     if ($self->{_page} and $mesg) {
-        my $cookie = $mesg->control(
-            Net::LDAP::Constant::LDAP_CONTROL_PAGED
-        )->cookie;
-        $self->{_page}->cookie( $cookie );
+        my $cookie =
+            $mesg->control(Net::LDAP::Constant::LDAP_CONTROL_PAGED)->cookie;
+        $self->{_page}->cookie($cookie);
     }
 
     return [@retrieved];

--- a/src/lib/Sympa/DataSource/LDAP.pm
+++ b/src/lib/Sympa/DataSource/LDAP.pm
@@ -69,13 +69,15 @@ sub _open_operation {
     my $ldap_filter = $options{filter} || $self->{filter};
     my $ldap_attrs  = $options{attrs}  || $self->{attrs};
     my $ldap_scope  = $options{scope}  || $self->{scope};
+    my $ldap_deref  = $options{deref}  || $self->{deref};
 
     my @args = (
-        base   => $ldap_suffix,
-        filter => $ldap_filter,
-        attrs  => [split /\s*,\s*/, $ldap_attrs],
-        scope  => $ldap_scope,
-        control=> $self->{_page} ? [$self->{_page}] : []
+        base    => $ldap_suffix,
+        filter  => $ldap_filter,
+        attrs   => [split /\s*,\s*/, $ldap_attrs],
+        scope   => $ldap_scope,
+        deref   => $ldap_deref,
+        control => $self->{_page} ? [$self->{_page}] : []
     );
 
     my $mesg = $self->{_db}->do_operation('search', @args);

--- a/src/lib/Sympa/DatabaseDriver/LDAP.pm
+++ b/src/lib/Sympa/DatabaseDriver/LDAP.pm
@@ -45,7 +45,7 @@ use constant optional_parameters => [
         ssl_cert ssl_key ca_verify ca_path ca_file
         timeout)
 ];
-use constant required_modules => [qw(Net::LDAP)];
+use constant required_modules => [qw(Net::LDAP Net::LDAP::Util)];
 use constant optional_modules => [qw(IO::Socket::SSL)];
 
 sub _new {
@@ -253,6 +253,14 @@ sub error {
 #sub escape_dn_value;
 #sub escape_filter_value;
 
+sub quote {
+    my $self   = shift;
+    my $string = shift;
+
+    return undef unless defined $string;
+    return Net::LDAP::Util::escape_filter_value($string);
+}
+
 1;
 
 =encoding utf-8
@@ -291,6 +299,8 @@ B<Obsoleted>.
 
 I<Instance method>.
 See L<Net::LDAP::Util/escape_filter_value>.
+
+As of 6.2.74, use quote() instead.
 
 =back
 

--- a/src/lib/Sympa/ListOpt.pm
+++ b/src/lib/Sympa/ListOpt.pm
@@ -106,6 +106,14 @@ our %list_option = (
     'one'  => {'gettext_id' => 'one level'},
     'sub'  => {'gettext_id' => 'subtree'},
 
+    # include_ldap_2level_query.deref2, include_ldap_2level_query.deref1,
+    # include_ldap_query.deref
+    'never' => {'gettext_id' => 'never'},
+    'search' =>
+        {'gettext_id' => 'in searching subordinates of the base object'},
+    'find'   => {'gettext_id' => 'in locating the base object'},
+    'always' => {'gettext_id' => 'always'},
+
     # include_ldap_query.use_tls, include_ldap_2level_query.use_tls,
     # include_ldap_ca.use_tls, include_ldap_2level_ca.use_tls
     'starttls' => {'gettext_id' => 'use STARTTLS'},

--- a/src/lib/Sympa/Scenario.pm
+++ b/src/lib/Sympa/Scenario.pm
@@ -1401,6 +1401,7 @@ sub do_search {
             base   => "$ldap_conf{'suffix'}",
             filter => "$filter",
             scope  => "$ldap_conf{'scope'}",
+            deref  => "$ldap_conf{'deref'}",
             attrs  => ['1.1']
         );
         unless ($mesg) {
@@ -1580,7 +1581,8 @@ sub _load_ldap_configuration {
         return;
     }
 
-    my @valid_options = qw(host suffix filter scope bind_dn bind_password
+    my @valid_options =
+        qw(host suffix filter scope deref bind_dn bind_password
         use_tls ssl_version ssl_ciphers ssl_cert ssl_key
         ca_verify ca_path ca_file);
     my @required_options = qw(host suffix filter);
@@ -1593,6 +1595,7 @@ sub _load_ldap_configuration {
         'suffix'        => undef,
         'filter'        => undef,
         'scope'         => 'sub',
+        'deref'         => 'find',
         'bind_dn'       => undef,
         'bind_password' => undef
     );

--- a/src/lib/Sympa/WWW/Auth.pm
+++ b/src/lib/Sympa/WWW/Auth.pm
@@ -260,7 +260,6 @@ sub ldap_authentication {
         filter  => $filter,
         scope   => $ldap->{'scope'},
         deref   => $ldap->{'deref'},
-        timeout => $ldap->{'timeout'}
     );
     unless ($mesg and $entry = $mesg->shift_entry) {
         $log->syslog(
@@ -341,7 +340,6 @@ sub get_email_by_net_id {
         filter  => $filter,
         scope   => $auth->{scope},
         deref   => $auth->{deref},
-        timeout => $auth->{timeout},
         attrs   => [$auth->{email_attribute}],
     );
 

--- a/src/lib/Sympa/WWW/Auth.pm
+++ b/src/lib/Sympa/WWW/Auth.pm
@@ -259,6 +259,7 @@ sub ldap_authentication {
         base    => $ldap->{'suffix'},
         filter  => $filter,
         scope   => $ldap->{'scope'},
+        deref   => $ldap->{'deref'},
         timeout => $ldap->{'timeout'}
     );
     unless ($mesg and $entry = $mesg->shift_entry) {
@@ -339,6 +340,7 @@ sub get_email_by_net_id {
         base    => $auth->{suffix},
         filter  => $filter,
         scope   => $auth->{scope},
+        deref   => $auth->{deref},
         timeout => $auth->{timeout},
         attrs   => [$auth->{email_attribute}],
     );

--- a/src/lib/Sympa/WWW/Auth.pm
+++ b/src/lib/Sympa/WWW/Auth.pm
@@ -29,7 +29,6 @@ package Sympa::WWW::Auth;
 use strict;
 use warnings;
 use Digest::MD5;
-BEGIN { eval 'use Net::LDAP::Util'; }
 
 use Sympa;
 use Conf;
@@ -224,10 +223,6 @@ sub ldap_authentication {
     my $whichfilter = shift;
 
     die 'bug in logic. Ask developer' unless $ldap->{auth_type} eq 'ldap';
-    unless ($Net::LDAP::Util::VERSION) {
-        $log->syslog('err', 'Net::LDAP::Util required. Install it');
-        return undef;
-    }
 
     # Skip ldap auth mechanism if an email address was provided and it does
     # not match the corresponding regexp.
@@ -236,21 +231,18 @@ sub ldap_authentication {
         and defined $ldap->{regexp}
         and $auth !~ /$ldap->{regexp}/i;
 
-    my $filter;
-    if ($whichfilter eq 'uid_filter') {
-        $filter = $ldap->{'get_dn_by_uid_filter'};
-    } elsif ($whichfilter eq 'email_filter') {
-        $filter = $ldap->{'get_dn_by_email_filter'};
-    }
-    my $escaped_auth = Net::LDAP::Util::escape_filter_value($auth);
-    $filter =~ s/\[sender\]/$escaped_auth/ig;
-
     my $db = Sympa::Database->new('LDAP', %$ldap);
     unless ($db and $db->connect) {
         $log->syslog('err', 'Unable to connect to the LDAP Server "%s": %s',
             $ldap->{host}, ($db and $db->error));
         return undef;
     }
+
+    my $filter =
+          ($whichfilter eq 'uid_filter')   ? $ldap->{get_dn_by_uid_filter}
+        : ($whichfilter eq 'email_filter') ? $ldap->{get_dn_by_email_filter}
+        :                                    undef;
+    $filter =~ s/\[sender\]/$db->quote($auth)/egi if defined $filter;
 
     my $entry;
     my $mesg = $db->do_operation('search', filter => $filter);
@@ -325,7 +317,13 @@ sub get_email_by_net_id {
     }
 
     my $filter = $auth->{get_email_by_uid_filter};
-    $filter =~ s/\[([\w-]+)\]/$attributes->{$1}/ig;
+    $filter =~ s{
+      \[
+      ( [-\w]+ )
+      \]
+    }{
+        $db->quote($attributes->{lc $1} // '')
+    }egix;
 
     my $mesg = $db->do_operation(
         'search',


### PR DESCRIPTION
* Insignificant fix: Removing `timeout` parameters not used by do_operation().
* Parameters interpolated in the LDAP filter should be escaped.
* Some refactoring to remove duplicate parameters.

This PR depends on the pR #1853 .
