### PR TITLE
Properly authorize copy_list action

### DIFF
--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -1496,12 +1496,13 @@ while ($query = Sympa::WWW::FastCGI->new) {
             my $old_subaction = $in{'subaction'};
 
             ## Check required action parameters
-            my $check_output = check_action_parameters($action);
+            my $check_action = $action eq 'move_list' && $in{'mode'} eq 'copy' ? 'copy_list' : $action;
+            my $check_output = check_action_parameters($check_action);
 
             unless (defined $check_output) {
                 delete $param->{'list'};
                 wwslog('err', 'Missing required parameters for action "%s"',
-                    $action);
+                    $check_action);
                 delete $param->{'action'};
                 last;
             } elsif ($check_output != 1) {


### PR DESCRIPTION
When creating a list from an existing list, the required privileges for the *copy_list* action are not properly tested. Since *copy_list* is remapped to the *move_list* action, it incorrectly inherits its required privileges.

*copy_list* is supposed to be permitted to [listmasters and list owners](https://github.com/sympa-community/sympa/blob/71bdf648bcc6fd8b22ba350db16a625bee318078/src/cgi/wwsympa.fcgi.in#L589) while *move_list* is limited to [privileged owners](https://github.com/sympa-community/sympa/blob/71bdf648bcc6fd8b22ba350db16a625bee318078/src/cgi/wwsympa.fcgi.in#L636). Without the proposed patch, both actions required the user to be a privileged owner of the existing list.