### PR TITLE
🩹 — Fix missing chevron in modindex template

### DIFF
--- a/default/web_tt2/modindex.tt2
+++ b/default/web_tt2/modindex.tt2
@@ -69,7 +69,7 @@
                     <div class="small-6 medium-3 columns" role="cell">
                         <a href="[% 'ajax/viewmod' | url_rel([list,msg.key]) %]"
                            data-reveal-id="mainviewmod" data-reveal-ajax="true"
-                           data-tooltip aria-haspopup="true"
+                           data-tooltip aria-haspopup="true">
                         [% UNLESS msg.value.subject.length ~%]
                             <i>[%|loc%]No subject[%END%]</i>
                         [%~ ELSE ~%]


### PR DESCRIPTION
Thanks to @msokolo to [notice it](https://github.com/sympa-community/sympa/commit/7681fad8edb94232260558a1352988491c1c72bb#commitcomment-151809143)!