### PR TITLE
Add text of the error on parsing failure

### DIFF
--- a/src/lib/Sympa/List.pm
+++ b/src/lib/Sympa/List.pm
@@ -3869,7 +3869,7 @@ sub _load_include_admin_user_file {
         if defined $entry->{'source_parameters'};
     my $template = Sympa::Template->new($self, subdir => 'data_sources');
     unless ($template->parse({param => [@data]}, $filename, \$output)) {
-        $log->syslog('err', 'Failed to parse %s', $filename);
+        $log->syslog('err', 'Failed to parse %s : %s', $filename, $template->{last_error});
         return undef;
     }
     1 while $output =~ s/(\A|\n)\s+\n/$1\n/g;    # Clean empty lines


### PR DESCRIPTION
This helped me nailed an issue with owner inclusion from an Oracle DB.

Side note, I stomped on this while working on a sympa 6.1.24 to 6.2.70 server move and it is very impressive to see such an old setup being updated quite smoothly, congrats !