### PR TITLE
Personalization: Use the content of original originator field in the template (#1962)

### DIFF
--- a/src/lib/Sympa/Message.pm
+++ b/src/lib/Sympa/Message.pm
@@ -1536,6 +1536,8 @@ sub _personalize_attrs {
         $value =~ s/(?:\r\n|\r|\n)(?=[ \t])//g;    # unfold
         $data->{headers}{$key} = $value;
     }
+    $data->{sender}  = $self->{sender};
+    $data->{gecos}   = $self->{gecos};
     $data->{subject} = $self->{decoded_subject};
 
     return $data;


### PR DESCRIPTION
This may fix #1962 .