### PR TITLE
Sympa::Tools::Text: Noncharacters are no longer treated as ill-formed

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -153,7 +153,8 @@ requires 'Time::Local', '>= 1.23';
 requires 'Unicode::Normalize', '>= 1.03';
 
 # Sanitizes inputs with Unicode text.
-requires 'Unicode::UTF8', '>= 0.58';
+# Note: 0.64 conforms to Unicode Corrigendum #9.
+requires 'Unicode::UTF8', '>= 0.64';
 
 # Used to create URI containing non URI-canonical characters.
 # Note: '3.28' is the version included in URI-1.35.

--- a/t/Tools_Text.t
+++ b/t/Tools_Text.t
@@ -46,12 +46,14 @@ is $dec, $unicode_email, 'decode_filesystem_safe, Unicode';
 # ToDo: foldcase()
 # ToDo: wrap_text()
 
-# Noncharacters: U+D800, U+10FFE, U+110000, U+200000
+# Ill-formed sequences: U+D800, U+110000, U+200000
+# Note: Noncharacters (U+nFFFE, U+nFFFF and U+FDD0..U+FDEF) are no longer
+#   ill-formed according to Unicode Corrigendum #9.
 is Sympa::Tools::Text::canonic_text(
-    "\xED\xA0\x80\n\xF4\x8F\xBF\xBE\n\xF4\x90\x80\x80\n\xF8\x88\x80\x80\x80\n"
+    "\xED\xA0\x80\n\n\xF4\x90\x80\x80\n\xF8\x88\x80\x80\x80\n"
     ),
     Encode::encode_utf8(
-    "\x{FFFD}\x{FFFD}\x{FFFD}\n\x{FFFD}\n\x{FFFD}\x{FFFD}\x{FFFD}\x{FFFD}\n\x{FFFD}\x{FFFD}\x{FFFD}\x{FFFD}\x{FFFD}\n"
+    "\x{FFFD}\x{FFFD}\x{FFFD}\n\n\x{FFFD}\x{FFFD}\x{FFFD}\x{FFFD}\n\x{FFFD}\x{FFFD}\x{FFFD}\x{FFFD}\x{FFFD}\n"
     ),
     'canonic_text';
 


### PR DESCRIPTION
Noncharacters are no longer treated as ill-formed according to [Unicode Corrigendum #9](https://www.unicode.org/versions/corrigendum9.html).