### PR TITLE
Documentation says `regexp` and `negative_regexp` keywords is valid for `cas` and `generic_sso` paragraph in `auth.conf` (#2016)

### DIFF
--- a/doc/auth.conf.pod
+++ b/doc/auth.conf.pod
@@ -300,12 +300,6 @@ Introduced on Sympa 6.2.
 
 =over
 
-=item C<regexp>
-
-=item C<negative_regexp>
-
-See L<C<user_table> paragraph|/user_table paragraph>.
-
 =item C<service_name>
 
 This is the SSO service name that will be offered to the user in the login 
@@ -446,12 +440,6 @@ Sympa ; this should be configured through the L<cafile|sympa.conf(5)/cafile>
 or L<capath|sympa.conf(5)/capath> F<sympa.conf> configuration parameters.
 
 =over
-
-=item C<regexp>
-
-=item C<negative_regexp>
-
-See L<C<user_table> paragraph|/user_table paragraph>.
 
 =item C<auth_service_name>
 


### PR DESCRIPTION
This may fix #2016 .