### PR TITLE
"Use of uninitialized value" warning (#1941)

### DIFF
--- a/src/lib/Sympa/DatabaseDriver/PostgreSQL.pm
+++ b/src/lib/Sympa/DatabaseDriver/PostgreSQL.pm
@@ -159,7 +159,7 @@ sub is_autoinc {
         return undef;
     }
     my $field = $sth->fetchrow();
-    return ($field eq $seqname);
+    return ($field // '') eq $seqname;
 }
 
 sub set_autoinc {


### PR DESCRIPTION
This may fix #1941 .
