### PR TITLE
Add document encoding to the XML generated by instantiation

### DIFF
--- a/src/lib/Sympa/CLI/instantiate.pm
+++ b/src/lib/Sympa/CLI/instantiate.pm
@@ -577,7 +577,7 @@ sub _split_xml_file {
         ## creating list XML document
         my $list_doc =
             XML::LibXML::Document->createDocument($doc->version(),
-            $doc->encoding());
+            $doc->encoding() // 'UTF-8');
         $list_doc->setDocumentElement($list_elt);
 
         ## creating the list xml file


### PR DESCRIPTION
When using a xml file lacking encoding instantiate was throwing lots of "Use of uninitialized value in subroutine entry at /usr/local/sympa/bin/Sympa/CLI/instantiate.pm line 578" around. This uses "UTF-8" as default encoding.