### PR TITLE
Allow listmaster to modify recipient on resend

### DIFF
--- a/default/mhonarc_rc.tt2
+++ b/default/mhonarc_rc.tt2
@@ -610,7 +610,12 @@ $POWERED_BY$
                         </label>
                 <% END %>
                 <input class="MainMenuLinks" type="submit" name="action_compose_mail" value="<%|loc%>Reply<%END%>" /><br />
+                <% IF is_listmaster %>
+                <input class="MainMenuLinks" type="submit" name="action_send_me" value="Re-deliver to:" />
+                <input name="send_msg_to" value="<%|loc(user.email)%>%1<%END%>" /><br />
+                <% ELSE %>
                 <input class="MainMenuLinks" type="submit" name="action_send_me" value="<%|loc(user.email)%>Re-deliver to %1<%END%>" /><br />
+                <% END %>
                 <input type="hidden" name="yyyy" value="$yyyy$" />
                 <input type="hidden" name="month" value="$mois$" />
                 <input type="hidden" name="msgid" value="$MSGID$" />

--- a/src/cgi/wwsympa.fcgi.in
+++ b/src/cgi/wwsympa.fcgi.in
@@ -869,6 +869,7 @@ our %in_regexp = (
     'new_email'     => Sympa::Regexps::email(),
     'sender'        => Sympa::Regexps::email(),
     'fromaddr'      => Sympa::Regexps::email(),
+    'send_msg_to'   => Sympa::Regexps::email(),
     'del_emails'    => '.*',
     'to' => '(([\w\-\_\.\/\+\=\']+|\".*\")\s[\w\-]+(\.[\w\-]+)+(,?))*',
     'automatic_list_part_*' => '[\w\-\.\+]*',
@@ -8610,14 +8611,20 @@ sub do_remove_arc {
 #  Sends a web archive message to a
 #  requesting user
 #
-# IN : -
+# IN : user to deliver to
 #
 # OUT : 'arc' | 1 | undef
 #
 ####################################################
 sub do_send_me {
-    wwslog('info', '(%s, %s, %s, %s)',
-        $in{'list'}, $in{'yyyy'}, $in{'month'}, $in{'msgid'});
+    wwslog('info', '(%s, %s, %s, %s, %s)',
+        $in{'list'}, $in{'yyyy'}, $in{'month'}, $in{'msgid'}, $in{'send_msg_to'});
+
+    if ($param->{'is_listmaster'}) {
+        $param->{'send_msg_to'} = $in{'send_msg_to'} || $param->{'user'}{'email'};
+    } else {
+        $param->{'send_msg_to'} = $param->{'user'}{'email'};
+    }
 
     my $message_id = Sympa::Tools::Text::canonic_message_id($in{'msgid'});
     unless ($message_id
@@ -8629,7 +8636,7 @@ sub do_send_me {
     }
 
     my $spindle = Sympa::Spindle::ResendArchive->new(
-        resent_by  => $param->{'user'}{'email'},
+        resent_by  => $param->{'send_msg_to'},
         context    => $list,
         arc        => "$in{'yyyy'}-$in{'month'}",
         message_id => $message_id,
@@ -8642,8 +8649,8 @@ sub do_send_me {
         return undef;
     } elsif ($spindle->{finish} and $spindle->{finish} eq 'success') {
         wwslog(
-            'info',      'Message %s spooled for %s',
-            $message_id, $param->{'user'}{'email'}
+            'info',      'Message %s spooled for %s by %s',
+            $message_id, $param->{'send_msg_to'}, $param->{'user'}{'email'}
         );
         add_stash('notice', 'performed');
         $in{'month'} = $in{'yyyy'} . "-" . $in{'month'};
@@ -8653,7 +8660,7 @@ sub do_send_me {
         wwslog(
             'err',
             'Impossible to send archive file to %s',
-            $param->{'user'}{'email'}
+            $param->{'send_msg_to'}
         );
         return undef;
     }


### PR DESCRIPTION
This commit is a change in the archive management, allowing the listmaster to chose a different e-mail as recipient when resending an e-mail.
The recipient is flexible (it doesn’t restrain to existing subscribers) on purpose: the use case that provoked this change was to submit a spam false positive to a remote mailer, which required sending the e-mail "exactly as is was sent initially"