### PR TITLE
Fix UTF-8 handling for strftime format strings

### DIFF
--- a/src/lib/Sympa/Language.pm
+++ b/src/lib/Sympa/Language.pm
@@ -660,7 +660,8 @@ sub gettext_strftime {
         POSIX::setlocale(POSIX::LC_TIME(), 'C');
     } else {
         $format = $self->gettext($format);
-
+        $format = Encode::decode('UTF-8', $format);
+		
         ## If POSIX locale was not set, emulate format strings.
         unless ($self->{locale_time}
             and $self->{locale_time} ne 'C'


### PR DESCRIPTION
## Summary

On AlmaLinux 10, Japanese characters in format strings passed to `POSIX::strftime()` are handled differently from AlmaLinux 9.

When a Japanese character is included in the format string, `strftime()` can return a string with the UTF-8 flag enabled while the underlying data is still UTF-8 encoded bytes.

This can cause Japanese characters to become garbled when `Encode::_utf8_off()` is subsequently called.

## Change

Decode the format string as UTF-8 before passing it to `POSIX::strftime()`.

```perl
$format = $self->gettext($format);
$format = Encode::decode('UTF-8', $format);
```

## Verification

The behavior was reproduced on AlmaLinux 10 using a format string containing Japanese characters.

Before this change, the following behavior was observed:

```text
format:
UTF8 flag = OFF
bytes = 30.E5.B9.B4.30

after strftime():
UTF8 flag = ON
bytes = 30.E5.B9.B4.30

after Encode::_utf8_off():
0å¹´0
```

After decoding the format string before calling `strftime()`:

```text
format:
UTF8 flag = ON
Unicode character U+5E74

after strftime():
UTF8 flag = ON
Unicode character U+5E74

after Encode::_utf8_off():
0年0
```

The same test on AlmaLinux 9 produces the expected Unicode string from `strftime()` without this additional conversion.

This change makes the format string explicitly a Unicode string before it is passed to `strftime()`, and prevents the character encoding mismatch observed on AlmaLinux 10.

## Scope

This change only adds UTF-8 decoding of the localized format string before the existing `strftime()` processing.